### PR TITLE
Make language configurable via settings.json

### DIFF
--- a/Sunrise/resources/default_settings.json
+++ b/Sunrise/resources/default_settings.json
@@ -14,6 +14,7 @@
     }
   },
   "steam": {
+    "language": "english",
     "user": {
       "persona_name": "Player"
     }

--- a/Sunrise/src/core/settings/steam/definition.h
+++ b/Sunrise/src/core/settings/steam/definition.h
@@ -9,6 +9,10 @@ namespace sunrise::core::settings::steam {
 inline constexpr std::size_t kMaximumPersonaNameBytes = 63;
 /** Fixed persona storage includes one trailing null byte. */
 inline constexpr std::size_t kPersonaNameCapacity = kMaximumPersonaNameBytes + 1;
+/** Comfortably longer than any published Steam API language token (e.g. "vietnamese"). */
+inline constexpr std::size_t kMaximumLanguageBytes = 15;
+/** Fixed language storage includes one trailing null byte. */
+inline constexpr std::size_t kLanguageCapacity = kMaximumLanguageBytes + 1;
 
 /** Read-only settings for the single local Steam user. */
 struct User {
@@ -20,6 +24,8 @@ struct User {
 struct Settings {
     /** Options for the single local user exposed through Steam interfaces. */
     User user;
+    /** Steam API language token answered for GetCurrentGameLanguage/GetAvailableGameLanguages. */
+    std::array<char, kLanguageCapacity> language{"english"};
 };
 
 } // namespace sunrise::core::settings::steam

--- a/Sunrise/src/core/settings/steam/steam_settings_parser.cpp
+++ b/Sunrise/src/core/settings/steam/steam_settings_parser.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+#include <array>
 #include <string_view>
 
 #include "../parser.h"
@@ -95,14 +97,18 @@ decode_escape(std::string_view encoded, std::size_t& position, char& output) noe
 }
 
 /**
- * Decodes a nonempty persona into process-owned fixed storage.
+ * Decodes a nonempty printable-ASCII JSON string into fixed storage. Shared by every settings
+ * field that stores a short bounded string, so each caller only names its own byte limit.
  * @param encoded Borrowed encoded JSON string bytes.
+ * @param maxBytes Largest accepted decoded length, excluding the trailing null.
  * @param output Receives the decoded bytes and a trailing null only on success.
- * @return True for 1 to 63 printable ASCII bytes.
+ * @return True for 1 to maxBytes printable ASCII bytes.
  */
-[[nodiscard]] bool decode_persona(std::string_view encoded,
-                                  std::array<char, steam::kPersonaNameCapacity>& output) noexcept {
-    std::array<char, steam::kPersonaNameCapacity> candidate{};
+template <std::size_t Capacity>
+[[nodiscard]] bool decode_bounded_string(std::string_view encoded,
+                                         std::size_t maxBytes,
+                                         std::array<char, Capacity>& output) noexcept {
+    std::array<char, Capacity> candidate{};
     std::size_t decodedCount = 0;
     for (std::size_t position = 0; position < encoded.size();) {
         char value = encoded[position++];
@@ -111,7 +117,7 @@ decode_escape(std::string_view encoded, std::size_t& position, char& output) noe
         }
         const auto byte = static_cast<unsigned char>(value);
         if (byte < kMinimumPrintableAscii || byte > kMaximumPrintableAscii
-            || decodedCount >= steam::kMaximumPersonaNameBytes) {
+            || decodedCount >= maxBytes) {
             return false;
         }
         candidate[decodedCount++] = value;
@@ -123,33 +129,45 @@ decode_escape(std::string_view encoded, std::size_t& position, char& output) noe
     return true;
 }
 
+/** Destiny 2 only supports these languages; anything else falls back to English. */
+constexpr std::array<std::string_view, 13> kSupportedLanguages{
+    "english",
+    "french",
+    "german",
+    "italian",
+    "japanese",
+    "brazilian",
+    "spanish",
+    "russian",
+    "polish",
+    "schinese",
+    "tchinese",
+    "latam",
+    "koreana",
+};
+
+/** @param token Candidate Steam API language code. @return True when this build ships it. */
+[[nodiscard]] bool is_supported_language(std::string_view token) noexcept {
+    return std::find(kSupportedLanguages.begin(), kSupportedLanguages.end(), token)
+           != kSupportedLanguages.end();
+}
+
 /**
- * Decodes a nonempty Steam API language token into process-owned fixed storage.
+ * Resolves an authored Steam API language token, falling back to English for anything that
+ * isn't exactly one language this build ships. This also catches a comma-separated list — a
+ * shape only GetAvailableGameLanguages should ever receive — which would otherwise leave
+ * GetCurrentGameLanguage answering with a value the Client cannot parse as one language.
  * @param encoded Borrowed encoded JSON string bytes.
- * @param output Receives the decoded bytes and a trailing null only on success.
- * @return True for 1 to 15 printable ASCII bytes.
+ * @return The matching supported code, or the English fallback.
  */
-[[nodiscard]] bool decode_language(std::string_view encoded,
-                                   std::array<char, steam::kLanguageCapacity>& output) noexcept {
-    std::array<char, steam::kLanguageCapacity> candidate{};
-    std::size_t decodedCount = 0;
-    for (std::size_t position = 0; position < encoded.size();) {
-        char value = encoded[position++];
-        if (value == '\\' && !decode_escape(encoded, position, value)) {
-            return false;
-        }
-        const auto byte = static_cast<unsigned char>(value);
-        if (byte < kMinimumPrintableAscii || byte > kMaximumPrintableAscii
-            || decodedCount >= steam::kMaximumLanguageBytes) {
-            return false;
-        }
-        candidate[decodedCount++] = value;
+[[nodiscard]] std::array<char, steam::kLanguageCapacity>
+resolve_language(std::string_view encoded) noexcept {
+    std::array<char, steam::kLanguageCapacity> decoded{};
+    if (decode_bounded_string(encoded, steam::kMaximumLanguageBytes, decoded)
+        && is_supported_language(std::string_view(decoded.data()))) {
+        return decoded;
     }
-    if (decodedCount == 0) {
-        return false;
-    }
-    output = candidate;
-    return true;
+    return {"english"};
 }
 
 } // namespace
@@ -177,9 +195,10 @@ bool Parser::steam_settings(steam::Settings& output) noexcept {
             hasUser = true;
         } else if (key == "language") {
             std::string_view value;
-            if (hasLanguage || !string(value) || !decode_language(value, candidate.language)) {
+            if (hasLanguage || !string(value)) {
                 return false;
             }
+            candidate.language = resolve_language(value);
             hasLanguage = true;
         } else if (!skip_value(0)) {
             return false;
@@ -211,7 +230,9 @@ bool Parser::steam_user_settings(steam::User& output) noexcept {
         }
         if (key == "persona_name") {
             std::string_view value;
-            if (hasPersonaName || !string(value) || !decode_persona(value, candidate.personaName)) {
+            if (hasPersonaName || !string(value)
+                || !decode_bounded_string(
+                    value, steam::kMaximumPersonaNameBytes, candidate.personaName)) {
                 return false;
             }
             hasPersonaName = true;

--- a/Sunrise/src/core/settings/steam/steam_settings_parser.cpp
+++ b/Sunrise/src/core/settings/steam/steam_settings_parser.cpp
@@ -123,6 +123,35 @@ decode_escape(std::string_view encoded, std::size_t& position, char& output) noe
     return true;
 }
 
+/**
+ * Decodes a nonempty Steam API language token into process-owned fixed storage.
+ * @param encoded Borrowed encoded JSON string bytes.
+ * @param output Receives the decoded bytes and a trailing null only on success.
+ * @return True for 1 to 15 printable ASCII bytes.
+ */
+[[nodiscard]] bool decode_language(std::string_view encoded,
+                                   std::array<char, steam::kLanguageCapacity>& output) noexcept {
+    std::array<char, steam::kLanguageCapacity> candidate{};
+    std::size_t decodedCount = 0;
+    for (std::size_t position = 0; position < encoded.size();) {
+        char value = encoded[position++];
+        if (value == '\\' && !decode_escape(encoded, position, value)) {
+            return false;
+        }
+        const auto byte = static_cast<unsigned char>(value);
+        if (byte < kMinimumPrintableAscii || byte > kMaximumPrintableAscii
+            || decodedCount >= steam::kMaximumLanguageBytes) {
+            return false;
+        }
+        candidate[decodedCount++] = value;
+    }
+    if (decodedCount == 0) {
+        return false;
+    }
+    output = candidate;
+    return true;
+}
+
 } // namespace
 
 /** Parses Steam settings on top of the fixed defaults. */
@@ -132,6 +161,7 @@ bool Parser::steam_settings(steam::Settings& output) noexcept {
     }
     steam::Settings candidate = output;
     bool hasUser = false;
+    bool hasLanguage = false;
     if (consume('}')) {
         return true;
     }
@@ -145,6 +175,12 @@ bool Parser::steam_settings(steam::Settings& output) noexcept {
                 return false;
             }
             hasUser = true;
+        } else if (key == "language") {
+            std::string_view value;
+            if (hasLanguage || !string(value) || !decode_language(value, candidate.language)) {
+                return false;
+            }
+            hasLanguage = true;
         } else if (!skip_value(0)) {
             return false;
         }

--- a/Sunrise/src/steam/interfaces/methods/common.cpp
+++ b/Sunrise/src/steam/interfaces/methods/common.cpp
@@ -1,13 +1,12 @@
 #include <cstdint>
 #include <cstring>
 
+#include "../../../core/settings/settings.h"
 #include "../internal.h"
 
 namespace sunrise::steam::interfaces::methods {
 namespace {
 
-/** Steam language token used when there is no localization service. */
-constexpr char kLanguage[] = "english";
 /** Steam callback id for receiving the current user stats. */
 constexpr int kUserStatsReceivedCallback = 1101;
 /** Steam result code for success. */
@@ -61,9 +60,9 @@ bool return_true([[maybe_unused]] void* self) noexcept {
     return true;
 }
 
-/** @return Language token. It lasts for the whole process. */
+/** @return Language token from settings. It lasts for the whole process. */
 const char* language([[maybe_unused]] void* self) noexcept {
-    return kLanguage;
+    return core::settings::get().steam.language.data();
 }
 
 /** @return The stable local user handle. */


### PR DESCRIPTION
Adds a `steam.language` field to `settings.json` to configure the language , replacing the hardcoded `"english"` constant in
`common.cpp`.