### PR TITLE
Implement persistent inventory replication

### DIFF
--- a/Sunrise/src/client/content/items/packages/package_item_rows.cpp
+++ b/Sunrise/src/client/content/items/packages/package_item_rows.cpp
@@ -6,6 +6,15 @@
 #include "internal.h"
 
 namespace sunrise::client::content::items::packages {
+namespace {
+
+/** Inventory buckets the installed client maps to an equippable character slot. */
+[[nodiscard]] bool equippable_bucket(std::uint8_t bucketId) noexcept {
+    constexpr std::uint8_t buckets[]{16, 3, 4, 5, 6, 7, 0, 1, 2, 10, 9, 8, 27, 41, 17, 47};
+    return std::find(std::begin(buckets), std::end(buckets), bucketId) != std::end(buckets);
+}
+
+} // namespace
 
 /** Walks the located item index table, then publishes every domain that depends on it. */
 bool build_item_rows(const reader::Source& source,
@@ -39,8 +48,16 @@ bool build_item_rows(const reader::Source& source,
         }
         storage.rows[rowCount++] = state::build_data::items::Definition{
             item.definitionHash, item.definitionIndex, item.bucketId};
-        if (haveAuthored && authored(storage.authoredHashes, item.definitionHash)) {
+        // Keep every equippable definition, not only startup equipment. Opcode 1820 names a
+        // collection item by native index and must be resolvable without a per-item patch.
+        const bool startupAuthored =
+            haveAuthored && authored(storage.authoredHashes, item.definitionHash);
+        if (startupAuthored || equippable_bucket(item.bucketId)) {
             (void)request(item.definitionIndex, storage.requested, detailCount);
+        }
+        // Full plug details are needed for authored appearance/stat aggregation. Runtime
+        // collection items can publish their native initial plug indices directly.
+        if (startupAuthored) {
             (void)append_initial_plugs(item, storage.requested, detailCount);
         }
     }

--- a/Sunrise/src/client/hooks/banner/banner_bind.cpp
+++ b/Sunrise/src/client/hooks/banner/banner_bind.cpp
@@ -106,9 +106,21 @@ __declspec(noinline) std::int64_t __fastcall tick(void* self, std::int64_t frame
     std::byte* const component = static_cast<std::byte*>(self);
     std::uint64_t account = 0;
     std::uint8_t family = 0;
+    std::int32_t currentLight = 0;
+    std::uint32_t emblemState = 0;
     std::memcpy(&account, component + BannerLayout::accountKey, sizeof account);
     std::memcpy(&family, component + BannerLayout::family, sizeof family);
-    if (account != 0 && family != kBannerFamilyNone) {
+    std::memcpy(&currentLight, component + BannerLayout::light, sizeof currentLight);
+    std::memcpy(&emblemState, component + BannerLayout::emblemState, sizeof emblemState);
+    // A component can bind before the Family-4 snapshot is usable. In that case the update body
+    // leaves power at zero or emblem state 2. Keep retrying that incomplete component; once both
+    // values resolve, the ordinary clean fast path resumes.
+    if (account != 0 && family != kBannerFamilyNone && currentLight > 0 && emblemState == 0) {
+        // The presentation widget is a second consumer behind this component. A one-shot dirty
+        // transition updates the component but can occur before that widget subscribes, leaving
+        // the visible card at its constructor defaults. Keep the resolved component publishable
+        // while it is ticking so late-created orbit/fireteam views receive the same values.
+        std::memcpy(component + BannerLayout::dirty, &kBannerDirty, sizeof kBannerDirty);
         return original(self, frame);
     }
     const Identity identity = selected_identity();

--- a/Sunrise/src/client/hooks/queuez/svc123_null_payload_guard.cpp
+++ b/Sunrise/src/client/hooks/queuez/svc123_null_payload_guard.cpp
@@ -7,6 +7,7 @@
 
 #include "../../../core/logging/log.h"
 #include "../../hooking/detour.h"
+#include "../network/investment/internal.h"
 #include "../../patterns/image_scan.h"
 #include "internal.h"
 
@@ -70,7 +71,19 @@ __declspec(noinline) char __fastcall handler(void* self,
         return kNotHandled;
     }
     const Handler original = g_original.load(std::memory_order_acquire);
-    return original != nullptr ? original(self, context, message) : kNotHandled;
+    // The native commit notifies live item-detail screens before returning. Arm the dependency
+    // cache first so that notification observes the new Family-4 objects instead of retaining the
+    // old socket view until the screen is closed.
+    network::investment::arm_derived_rebuild();
+    const char result = original != nullptr ? original(self, context, message) : kNotHandled;
+    if (result != kNotHandled) {
+        // Family updates replace authoritative investment objects, but this client build does not
+        // reliably expire the derived character/loadout cache after the first Family-4 arrival.
+        // Marking it stale here makes one subsequent read rebuild power, socket, equipment and
+        // bucket views from the objects the native handler has just committed.
+        network::investment::arm_derived_rebuild();
+    }
+    return result;
 }
 
 } // namespace

--- a/Sunrise/src/middleware/datagen/character_record/character_record_encoder.cpp
+++ b/Sunrise/src/middleware/datagen/character_record/character_record_encoder.cpp
@@ -62,6 +62,10 @@ constexpr std::size_t kPreviewFlagOffsets[]{8, 9};
 /** @param light Equipment light. @return The trailing summary block both records carry. */
 [[nodiscard]] layout::Summary build_summary(std::int32_t light) noexcept {
     layout::Summary summary{};
+    // Different presentation paths consume different mirrors of the same value. The
+    // character screen uses the signed field while the orbit fireteam card reads a float.
+    summary.lightFloatA = static_cast<float>(light);
+    summary.lightFloatB = static_cast<float>(light);
     summary.light = light;
     summary.hashA = layout::kNoHash;
     return summary;

--- a/Sunrise/src/middleware/datagen/family4/character/character_encoder.cpp
+++ b/Sunrise/src/middleware/datagen/family4/character/character_encoder.cpp
@@ -71,14 +71,15 @@ constexpr std::int32_t kOccupiedRowWatermark = 1;
             || itemInstance.bounds.itemDefinitionCount > instance::layout::kDefinitionIndexCapacity
             || itemInstance.baseDefinitionIndex == kEmptyDefinitionIndex
             || itemInstance.baseDefinitionIndex >= itemInstance.bounds.itemDefinitionCount
-            || occupiedRows[item.inventoryRow] || occupiedEquipmentSlots[item.equipmentSlot]
+            || occupiedRows[item.inventoryRow]
+            || (item.equipped && occupiedEquipmentSlots[item.equipmentSlot])
             || std::find(instanceSoids.cbegin(), priorSoidsEnd, itemInstance.instanceSoid)
                    != priorSoidsEnd
             || (index != 0 && resolvedLoadout.items[index - 1].inventoryRow >= item.inventoryRow)) {
             return false;
         }
         occupiedRows[item.inventoryRow] = true;
-        occupiedEquipmentSlots[item.equipmentSlot] = true;
+        if (item.equipped) occupiedEquipmentSlots[item.equipmentSlot] = true;
         instanceSoids[index] = itemInstance.instanceSoid;
     }
     return true;
@@ -97,11 +98,16 @@ summary_matches_loadout(const loadout::ResolvedLoadout& resolvedLoadout,
     for (const std::optional<state::equipment::light::ItemScore>& score : evaluation.character) {
         summaryItemCount += static_cast<std::size_t>(score.has_value());
     }
-    if (summaryItemCount != resolvedLoadout.itemCount) {
+    const std::size_t equippedCount = static_cast<std::size_t>(std::count_if(
+        resolvedLoadout.items.cbegin(),
+        resolvedLoadout.items.cbegin() + static_cast<std::ptrdiff_t>(resolvedLoadout.itemCount),
+        [](const loadout::ResolvedItem& item) { return item.equipped; }));
+    if (summaryItemCount != equippedCount) {
         return false;
     }
     for (std::size_t index = 0; index < resolvedLoadout.itemCount; ++index) {
         const loadout::ResolvedItem& item = resolvedLoadout.items[index];
+        if (!item.equipped) continue;
         const auto& score = evaluation.character[item.equipmentSlot];
         if (!score.has_value() || score->definitionIndex != item.instance.baseDefinitionIndex) {
             return false;
@@ -165,7 +171,7 @@ bool encode(const state::CharacterState& state,
         object.newItemFlags[item.inventoryRow / kBitsPerFlagByte] |=
             std::byte{1U} << (item.inventoryRow % kBitsPerFlagByte);
         object.instanceProgressWatermarks[item.inventoryRow] = kOccupiedRowWatermark;
-        object.equippedInstanceSoids[item.equipmentSlot] = item.instance.instanceSoid;
+        if (item.equipped) object.equippedInstanceSoids[item.equipmentSlot] = item.instance.instanceSoid;
     }
 
     // Commit only after validation so callers never receive a partially initialized object.

--- a/Sunrise/src/middleware/datagen/family4/loadout/definition.h
+++ b/Sunrise/src/middleware/datagen/family4/loadout/definition.h
@@ -10,13 +10,16 @@
 namespace sunrise::middleware::datagen::family4::loadout {
 
 /** One selected item can occupy each of the 16 authored semantic equipment slots. */
-inline constexpr std::size_t kItemCapacity = state::account::inventory::kEquipmentSlotCount;
+inline constexpr std::size_t kItemCapacity =
+    state::account::inventory::kEquipmentSlotCount
+    + state::account::inventory::kCharacterInventoryCapacity;
 
 /** One installed-build-resolved item ready for character and instance encoding. */
 struct ResolvedItem {
     std::uint16_t inventoryRow{};
     std::uint8_t equipmentSlot{};
     std::int32_t quantity{};
+    bool equipped{};
     instance::ResolvedInstance instance{};
 };
 

--- a/Sunrise/src/middleware/datagen/family4/loadout/loadout_item_resolver.cpp
+++ b/Sunrise/src/middleware/datagen/family4/loadout/loadout_item_resolver.cpp
@@ -19,6 +19,12 @@ namespace build_socket_lists = state::build_data::socket_entry_lists;
 
 /** Native instanced inventory rows always carry exactly one item. */
 constexpr std::int32_t kInstancedQuantity = 1;
+/** User-selected appearance overrides for the two native-default Warlock pieces. */
+constexpr std::uint32_t kShadowsMindHash = 0xC7A2025EU;
+constexpr std::uint32_t kEmperorsMinisterRobesHash = 0xD621F24BU;
+constexpr std::uint32_t kAmethystVeilHash = 0x51487F22U;
+/** Native socket type 26 is the armour shader lane. */
+constexpr std::uint16_t kArmourShaderSocketType = 26;
 
 /**
  * Finds the installed item index for one authored plug hash.
@@ -48,6 +54,7 @@ constexpr std::int32_t kInstancedQuantity = 1;
  * @return True when policy, lane count, and every present plug resolve.
  */
 [[nodiscard]] bool resolve_ordinary_sockets(const authored_inventory::Sockets& authored,
+                                            std::uint32_t baseDefinitionHash,
                                             const build_details::Definition& definition,
                                             std::size_t itemDefinitionCount,
                                             instance::OrdinarySockets& output) noexcept {
@@ -75,6 +82,24 @@ constexpr std::int32_t kInstancedQuantity = 1;
                 return false;
             }
             output.plugs[index] = plugIndex;
+        }
+        if (baseDefinitionHash == kShadowsMindHash
+            || baseDefinitionHash == kEmperorsMinisterRobesHash) {
+            std::uint16_t shaderIndex = 0;
+            if (!resolve_plug(kAmethystVeilHash, itemDefinitionCount, shaderIndex)) {
+                return false;
+            }
+            bool replaced = false;
+            for (std::size_t index = 0; index < definition.ordinarySocketCount; ++index) {
+                if (definition.socketTypes[index] == kArmourShaderSocketType) {
+                    output.plugs[index] = shaderIndex;
+                    replaced = true;
+                    break;
+                }
+            }
+            if (!replaced) {
+                return false;
+            }
         }
         return true;
     }
@@ -155,6 +180,7 @@ bool resolve_item(const authored_inventory::Item& authored,
     candidate.item.equipmentSlot = static_cast<std::uint8_t>(*itemDetail.equipmentSlot);
     if (!resolve_quantity(authored, itemDetail, candidate.item.quantity)
         || !resolve_ordinary_sockets(authored.sockets,
+                                     authored.definitionHash,
                                      itemDetail,
                                      itemDefinitionCount,
                                      candidate.item.instance.ordinarySockets)) {

--- a/Sunrise/src/middleware/datagen/family4/loadout/loadout_resolver.cpp
+++ b/Sunrise/src/middleware/datagen/family4/loadout/loadout_resolver.cpp
@@ -109,6 +109,16 @@ bool resolve_instances(const state::AccountState& account,
             || !place_item(candidate, occupied, resolved[itemCount])) {
             return false;
         }
+        resolved[itemCount].equipped = true;
+        ++itemCount;
+    }
+    for (std::size_t inventoryIndex = 0;
+         character.selected && inventoryIndex < character.inventory.itemCount; ++inventoryIndex) {
+        Candidate candidate{};
+        if (itemCount >= resolved.size()
+            || !resolve_item(character.inventory.items[inventoryIndex], character, itemDefinitionCount, socketEntryListCount, candidate)
+            || !place_item(candidate, occupied, resolved[itemCount])) return false;
+        resolved[itemCount].equipped = false;
         ++itemCount;
     }
     std::sort(resolved.begin(),
@@ -186,8 +196,16 @@ bool resolve(const state::AccountState& account,
             }
             if (characterIndex == selectedCharacterIndex) {
                 selectedCandidates[semanticIndex] = candidate;
+                selectedCandidates[semanticIndex].item.equipped = true;
                 selectedPresent[semanticIndex] = true;
             }
+        }
+        for (std::size_t inventoryIndex = 0; inventoryIndex < character.inventory.itemCount; ++inventoryIndex) {
+            const authored_inventory::Item& authored = character.inventory.items[inventoryIndex];
+            const auto instanceSoidEnd = instanceSoids.cbegin() + static_cast<std::ptrdiff_t>(instanceSoidCount);
+            if (instanceSoidCount >= instanceSoids.size()
+                || std::find(instanceSoids.cbegin(), instanceSoidEnd, authored.instanceSoid) != instanceSoidEnd) return false;
+            instanceSoids[instanceSoidCount++] = authored.instanceSoid;
         }
     }
 
@@ -203,6 +221,15 @@ bool resolve(const state::AccountState& account,
                 selectedCandidates[semanticIndex], occupied, staged.items[staged.itemCount])) {
             return false;
         }
+        ++staged.itemCount;
+    }
+    const state::CharacterState& selectedCharacter = account.characters[selectedCharacterIndex];
+    for (std::size_t inventoryIndex = 0; inventoryIndex < selectedCharacter.inventory.itemCount; ++inventoryIndex) {
+        Candidate candidate{};
+        if (staged.itemCount >= staged.items.size()
+            || !resolve_item(selectedCharacter.inventory.items[inventoryIndex], selectedCharacter, itemDefinitionCount, socketEntryListCount, candidate)
+            || !place_item(candidate, occupied, staged.items[staged.itemCount])) return false;
+        staged.items[staged.itemCount].equipped = false;
         ++staged.itemCount;
     }
     std::sort(staged.items.begin(),

--- a/Sunrise/src/server/bap/encrypted/activity_message/activity_message_route.cpp
+++ b/Sunrise/src/server/bap/encrypted/activity_message/activity_message_route.cpp
@@ -29,6 +29,8 @@ namespace epoch_message = service::patch_epoch;
 
 /** Activity message type 3 starts the client join transaction. */
 constexpr std::uint32_t kJoinRequestMessageType = 3;
+constexpr std::uint32_t kEntityStateMessageType = 33;
+constexpr std::size_t kEntityStatePayloadBytes = 1 + state::activity::entity_slots::kSlotCount / 8;
 
 /**
  * Reports one activity message the route did not stage, naming its type.
@@ -40,18 +42,182 @@ constexpr std::uint32_t kJoinRequestMessageType = 3;
  */
 void report_message(std::uint32_t messageType,
                     std::uint64_t accountHandle,
+                    std::span<const std::byte> payload,
                     const char* reason) noexcept {
     std::array<char, core::log::kLineCapacity> line{};
-    const int written = std::snprintf(line.data(),
-                                      line.size(),
-                                      "ev=activity stage=message result=skip type=%u "
-                                      "handle=0x%llX reason=%s",
-                                      messageType,
-                                      static_cast<unsigned long long>(accountHandle),
-                                      reason);
+    int written = std::snprintf(line.data(),
+                                line.size(),
+                                "ev=activity stage=message result=skip type=%u "
+                                "handle=0x%llX reason=%s bytes=%zu head=",
+                                messageType,
+                                static_cast<unsigned long long>(accountHandle),
+                                reason,
+                                payload.size());
+    constexpr std::size_t kPreviewBytes = 32;
+    const std::size_t preview = (std::min)(payload.size(), kPreviewBytes);
+    for (std::size_t index = 0;
+         written > 0 && index < preview
+         && static_cast<std::size_t>(written) + 2 < line.size();
+         ++index) {
+        const int appended = std::snprintf(line.data() + written,
+                                           line.size() - static_cast<std::size_t>(written),
+                                           "%02X",
+                                           std::to_integer<unsigned>(payload[index]));
+        if (appended <= 0) {
+            break;
+        }
+        written += appended;
+    }
     if (written > 0) {
         core::log::write(core::log::Channel::server,
                          core::log::Level::warn,
+                         {line.data(), static_cast<std::size_t>(written)});
+    }
+
+    // Type 39 is the only large unhandled message observed on activity setup and authority
+    // changes. Preserve it in bounded chunks so its schema can be reconstructed offline.
+    if (messageType != 39 || payload.size() > 4096) {
+        return;
+    }
+    constexpr std::size_t kChunkBytes = 64;
+    for (std::size_t offset = 0; offset < payload.size(); offset += kChunkBytes) {
+        std::array<char, core::log::kLineCapacity> chunk{};
+        int chunkWritten = std::snprintf(chunk.data(),
+                                         chunk.size(),
+                                         "ev=activity stage=message_dump type=39 handle=0x%llX "
+                                         "offset=%zu data=",
+                                         static_cast<unsigned long long>(accountHandle),
+                                         offset);
+        const std::size_t count = (std::min)(kChunkBytes, payload.size() - offset);
+        for (std::size_t index = 0;
+             chunkWritten > 0 && index < count
+             && static_cast<std::size_t>(chunkWritten) + 2 < chunk.size();
+             ++index) {
+            const int appended = std::snprintf(
+                chunk.data() + chunkWritten,
+                chunk.size() - static_cast<std::size_t>(chunkWritten),
+                "%02X",
+                std::to_integer<unsigned>(payload[offset + index]));
+            if (appended <= 0) {
+                break;
+            }
+            chunkWritten += appended;
+        }
+        if (chunkWritten > 0) {
+            core::log::write(core::log::Channel::server,
+                             core::log::Level::debug,
+                             {chunk.data(), static_cast<std::size_t>(chunkWritten)});
+        }
+    }
+}
+
+[[nodiscard]] unsigned count_bits(unsigned value) noexcept {
+    unsigned count = 0;
+    while (value != 0) {
+        value &= value - 1;
+        ++count;
+    }
+    return count;
+}
+
+/** Observes the 8192-slot entity bitmap without changing activity state. */
+void observe_entity_state(std::uint64_t accountHandle,
+                          std::span<const std::byte> payload) noexcept {
+    if (payload.size() != kEntityStatePayloadBytes) {
+        report_message(kEntityStateMessageType, accountHandle, payload, "entity_state_size");
+        return;
+    }
+    const auto mask = payload.subspan(1);
+    std::size_t setCount = 0;
+    std::size_t first = state::activity::entity_slots::kSlotCount;
+    std::size_t last = state::activity::entity_slots::kSlotCount;
+    std::array<std::size_t, 16> samples{};
+    std::size_t sampleCount = 0;
+    for (std::size_t byteIndex = 0; byteIndex < mask.size(); ++byteIndex) {
+        const unsigned value = std::to_integer<unsigned>(mask[byteIndex]);
+        setCount += count_bits(value);
+        for (unsigned bit = 0; bit < 8; ++bit) {
+            if ((value & (1u << bit)) == 0) {
+                continue;
+            }
+            const std::size_t slot = byteIndex * 8 + bit;
+            if (first == state::activity::entity_slots::kSlotCount) {
+                first = slot;
+            }
+            last = slot;
+            if (sampleCount < samples.size()) {
+                samples[sampleCount++] = slot;
+            }
+        }
+    }
+    std::array<char, core::log::kLineCapacity> line{};
+    int written = std::snprintf(line.data(),
+                                line.size(),
+                                "ev=activity stage=entity_state result=observe type=33 "
+                                "handle=0x%llX control=0x%02X set=%zu first=%zu last=%zu slots=",
+                                static_cast<unsigned long long>(accountHandle),
+                                std::to_integer<unsigned>(payload.front()),
+                                setCount,
+                                first == state::activity::entity_slots::kSlotCount ? 0 : first,
+                                last == state::activity::entity_slots::kSlotCount ? 0 : last);
+    for (std::size_t index = 0;
+         written > 0 && index < sampleCount
+         && static_cast<std::size_t>(written) + 24 < line.size();
+         ++index) {
+        const int appended = std::snprintf(line.data() + written,
+                                           line.size() - static_cast<std::size_t>(written),
+                                           "%s%zu",
+                                           index == 0 ? "" : ",",
+                                           samples[index]);
+        if (appended <= 0) {
+            break;
+        }
+        written += appended;
+    }
+    if (written > 0) {
+        core::log::write(core::log::Channel::server,
+                         core::log::Level::info,
+                         {line.data(), static_cast<std::size_t>(written)});
+    }
+}
+
+/** Reports one prepared entity-slot lease mutation without changing it. */
+void report_entity_lease(const char* operation,
+                         std::uint64_t accountHandle,
+                         std::size_t requested,
+                         const state::activity::entity_slots::LeaseMask& mask) noexcept {
+    std::size_t selected = 0;
+    std::size_t first = state::activity::entity_slots::kSlotCount;
+    std::size_t last = state::activity::entity_slots::kSlotCount;
+    for (std::size_t byteIndex = 0; byteIndex < mask.size(); ++byteIndex) {
+        const unsigned value = std::to_integer<unsigned>(mask[byteIndex]);
+        selected += count_bits(value);
+        for (unsigned bit = 0; bit < 8; ++bit) {
+            if ((value & (1u << bit)) == 0) {
+                continue;
+            }
+            const std::size_t slot = byteIndex * 8 + bit;
+            if (first == state::activity::entity_slots::kSlotCount) {
+                first = slot;
+            }
+            last = slot;
+        }
+    }
+    std::array<char, core::log::kLineCapacity> line{};
+    const int written = std::snprintf(
+        line.data(),
+        line.size(),
+        "ev=activity stage=entity_lease result=observe op=%s handle=0x%llX "
+        "requested=%zu selected=%zu first=%zu last=%zu",
+        operation,
+        static_cast<unsigned long long>(accountHandle),
+        requested,
+        selected,
+        first == state::activity::entity_slots::kSlotCount ? 0 : first,
+        last == state::activity::entity_slots::kSlotCount ? 0 : last);
+    if (written > 0) {
+        core::log::write(core::log::Channel::server,
+                         core::log::Level::info,
                          {line.data(), static_cast<std::size_t>(written)});
     }
 }
@@ -77,6 +243,10 @@ void report_message(std::uint32_t messageType,
     plan.joinCharacterSoid = parsed.characterSoid;
     plan.delivery = Delivery::joinNotifications;
     plan.mutationDomain = MutationDomain::entitySlots;
+    report_entity_lease("join",
+                        request.accountHandle,
+                        state::activity::entity_slots::kSlotCount,
+                        plan.entitySlotMutation.mask);
     return true;
 }
 
@@ -97,6 +267,10 @@ void report_message(std::uint32_t messageType,
     plan.sessionId = request.accountHandle;
     plan.delivery = Delivery::entitySlotNotification;
     plan.mutationDomain = MutationDomain::entitySlots;
+    report_entity_lease("grant",
+                        request.accountHandle,
+                        static_cast<std::size_t>(requested),
+                        plan.entitySlotMutation.mask);
     return true;
 }
 
@@ -120,6 +294,7 @@ void report_message(std::uint32_t messageType,
     plan.sessionId = request.accountHandle;
     plan.delivery = Delivery::none;
     plan.mutationDomain = MutationDomain::entitySlots;
+    report_entity_lease("release", request.accountHandle, 0, plan.entitySlotMutation.mask);
     return true;
 }
 
@@ -135,7 +310,7 @@ bool process(std::uint64_t boundSessionId,
 
     service::Request request;
     if (!service::parse_request(requestBody, request)) {
-        report_message(0, 0, "parse");
+        report_message(0, 0, requestBody, "parse");
         return false;
     }
     // Dispatch is on message type alone, and every handler keys off the envelope's own handle, so
@@ -163,15 +338,18 @@ bool process(std::uint64_t boundSessionId,
         prepared = membership::prepare_authoritative(request, plan);
     } else if (request.messageType == service::membership_acknowledgement::kMessageType) {
         prepared = membership::prepare_acknowledgement(request, plan);
+    } else if (request.messageType == kEntityStateMessageType) {
+        observe_entity_state(request.accountHandle, request.payload);
+        return true;
     } else {
         // Later message handlers are independent. An owned envelope is a safe no-op.
-        report_message(request.messageType, request.accountHandle, "unhandled");
+        report_message(request.messageType, request.accountHandle, request.payload, "unhandled");
         return true;
     }
     // A message that cannot be staged is reported and dropped. Failing the frame would leave the
     // Client's pending ring jammed.
     if (!prepared) {
-        report_message(request.messageType, request.accountHandle, "prepare");
+        report_message(request.messageType, request.accountHandle, request.payload, "prepare");
         plan = {};
         return true;
     }

--- a/Sunrise/src/server/bap/encrypted/body/bap_service_body.cpp
+++ b/Sunrise/src/server/bap/encrypted/body/bap_service_body.cpp
@@ -116,6 +116,8 @@ bool process(const ServiceRoute& route,
         }
         outcome.hasSubscription = webOutcome.hasSubscription;
         outcome.subscription = webOutcome.subscription;
+        outcome.hasInventoryMutation = webOutcome.hasInventoryMutation;
+        outcome.mutatedInstanceSoid = webOutcome.acquiredInstanceSoid;
         // A pick that names the resident character moves nothing, so staging refuses it and the
         // reply still stands on its own.
         if (webOutcome.hasSelectedCharacter

--- a/Sunrise/src/server/bap/encrypted/internal.h
+++ b/Sunrise/src/server/bap/encrypted/internal.h
@@ -43,6 +43,8 @@ struct ServiceOutcome {
     queuez::ChangeCharacter changeCharacter{};
     bool hasSelectCharacter{};
     queuez::SelectCharacter selectCharacter{};
+    bool hasInventoryMutation{};
+    std::uint64_t mutatedInstanceSoid{};
     bool hasActivitySessionAllocation{};
     state::activity::PendingAllocation activitySessionAllocation{};
     bool hasActivityTransaction{};
@@ -238,6 +240,17 @@ append_select_character_notification(Scratch& scratch,
                                      std::span<const std::byte, state::kBapNonceSize> nonce,
                                      std::span<std::byte> response,
                                      std::size_t& written) noexcept;
+
+/** Appends a next-version full Family-4 replacement after an inventory mutation. */
+[[nodiscard]] bool append_inventory_notification(
+    Scratch& scratch,
+    const queuez::SessionState& before,
+    std::uint64_t mutatedInstanceSoid,
+    std::span<const std::byte, state::kAesKeySize> key,
+    std::array<std::byte, state::kBapNonceSize>& nonce,
+    std::span<std::byte> response,
+    std::size_t& written,
+    queuez::SessionState& after) noexcept;
 
 } // namespace push
 

--- a/Sunrise/src/server/bap/encrypted/push/queuez/queuez_subscription.cpp
+++ b/Sunrise/src/server/bap/encrypted/push/queuez/queuez_subscription.cpp
@@ -2,9 +2,11 @@
 
 #include "../../../../../core/logging/log.h"
 #include "../../../../../middleware/secure_channel/runtime.h"
+#include "../../../../../middleware/datagen/definitions.h"
 #include "../../../../../state/runtime/runtime.h"
 #include "../../queuez/queuez_state_validation.h"
 #include "../snapshot/snapshot.h"
+#include "../snapshot/internal.h"
 #include "queuez_push_reporting.h"
 #include "queuez_update_frame.h"
 
@@ -78,6 +80,37 @@ namespace {
 }
 
 } // namespace
+
+bool append_inventory_notification(
+    Scratch& scratch,
+    const queuez::SessionState& before,
+    std::uint64_t mutatedInstanceSoid,
+    std::span<const std::byte, state::kAesKeySize> key,
+    std::array<std::byte, state::kBapNonceSize>& nonce,
+    std::span<std::byte> response,
+    std::size_t& written,
+    queuez::SessionState& after) noexcept {
+    after = before;
+    if (!before.family4Active || before.family4RootSoid == 0) return false;
+    snapshot::Prepared prepared{};
+    if (mutatedInstanceSoid == 0
+        || !snapshot::prepare_item_update(scratch, before.family4RootSoid,
+                                          before.family4Version + 1,
+                                          mutatedInstanceSoid, prepared)
+        || !queuez::stage_family4_replacement(before, prepared.family, after)) {
+        return false;
+    }
+    const std::size_t beforeBytes = written;
+    if (!queuez_frame::append(scratch, prepared.family, prepared.rawClearSize,
+                              prepared.compressedClearSize, key, nonce, response, written)) {
+        after = before;
+        return false;
+    }
+    middleware::secure_channel::advance_nonce(nonce);
+    queuez_report::push("inventory", queuez::kAccountFamilyType,
+                        prepared.family.objects.size(), written - beforeBytes, 1);
+    return true;
+}
 
 /**
  * Stages the snapshots one subscription needs.

--- a/Sunrise/src/server/bap/encrypted/push/snapshot/family4_selection_move.cpp
+++ b/Sunrise/src/server/bap/encrypted/push/snapshot/family4_selection_move.cpp
@@ -9,6 +9,8 @@
 account_selection_patch_encoder.h"
 #include "../../../../../middleware/datagen/family4/character/character_encoder.h"
 #include "../../../../../middleware/datagen/family4/character/layout.h"
+#include "../../../../../middleware/datagen/family4/instance/instance_encoder.h"
+#include "../../../../../middleware/datagen/family4/instance/layout.h"
 #include "../../../../../state/runtime/runtime.h"
 #include "internal.h"
 #include "snapshot_storage.h"
@@ -135,6 +137,62 @@ bool prepare_selection_move(Scratch& scratch,
         return report_failure("move_commit");
     }
     return true;
+}
+
+bool prepare_item_update(Scratch& scratch,
+                         std::uint64_t familyRootSoid,
+                         std::int32_t familyVersion,
+                         std::uint64_t instanceSoid,
+                         Prepared& prepared) noexcept {
+    if (familyRootSoid == 0 || familyVersion <= kInitialFamilyVersion || instanceSoid == 0) {
+        return report_failure("item_update_input");
+    }
+    const state::AccountState account = state::account_snapshot();
+    const std::optional<std::size_t> selectedIndex = find_character_index(account);
+    Resolved selected{};
+    if (!state::account::valid(account) || !selectedIndex.has_value()
+        || !resolve(account, *selectedIndex, selected)) {
+        return report_failure("item_update_selection");
+    }
+    const family4_datagen::instance::ResolvedInstance* changed = nullptr;
+    for (std::size_t index = 0; index < selected.loadout.itemCount; ++index) {
+        const auto& candidate = selected.loadout.items[index].instance;
+        if (candidate.instanceSoid == instanceSoid) {
+            changed = &candidate;
+            break;
+        }
+    }
+    if (changed == nullptr) return report_failure("item_update_instance");
+
+    Prepared staged{};
+    const auto raw = std::span(scratch.plaintext);
+    std::size_t compressedExtent = 0;
+    if (family4_datagen::character::layout::kObjectSize > raw.size()) {
+        return report_failure("item_update_character_storage");
+    }
+    const auto characterBytes = raw.first(family4_datagen::character::layout::kObjectSize);
+    const auto& character = account.characters[selected.characterIndex];
+    if (!family4_datagen::character::encode(character, selected.loadout,
+                                            selected.lightEvaluation, characterBytes)
+        || !append_object(scratch, characterBytes, selected.characterObjectId, character.soid,
+                          staged.objects[1], compressedExtent)) {
+        return report_failure("item_update_character");
+    }
+    if (family4_datagen::instance::layout::kObjectSize > raw.size()) {
+        return report_failure("item_update_instance_storage");
+    }
+    const auto instanceBytes = raw.first(family4_datagen::instance::layout::kObjectSize);
+    if (!family4_datagen::instance::encode(*changed, instanceBytes)
+        || !append_object(scratch, instanceBytes, selected.itemInstanceObjectId, instanceSoid,
+                          staged.objects[0], compressedExtent)) {
+        return report_failure("item_update_instance_encode");
+    }
+    staged.rawClearSize = (std::max)(family4_datagen::character::layout::kObjectSize,
+                                     family4_datagen::instance::layout::kObjectSize);
+    staged.compressedClearSize = compressedExtent;
+    staged.family = middleware::queuez::Family{kAccountFamilyType, familyRootSoid, familyVersion,
+                                                0, std::span(staged.objects).first(2)};
+    return commit(staged, prepared);
 }
 
 } // namespace sunrise::server::bap::encrypted::push::snapshot

--- a/Sunrise/src/server/bap/encrypted/push/snapshot/family4_snapshot_preparer.cpp
+++ b/Sunrise/src/server/bap/encrypted/push/snapshot/family4_snapshot_preparer.cpp
@@ -29,6 +29,7 @@ namespace family4_datagen = middleware::datagen::family4;
  * @return True when the staged descriptors pass the ownership check.
  */
 [[nodiscard]] bool publish(const middleware::queuez::Subscription& subscription,
+                           std::int32_t familyVersion,
                            std::size_t objectCount,
                            std::size_t compressedExtent,
                            const Reservation& reservation,
@@ -38,7 +39,7 @@ namespace family4_datagen = middleware::datagen::family4;
     staged.family = middleware::queuez::Family{
         kAccountFamilyType,
         subscription.familyRootSoid,
-        kInitialFamilyVersion,
+        familyVersion,
         middleware::queuez::kFullSnapshotFlag,
         std::span(staged.objects).first(objectCount),
     };
@@ -48,9 +49,10 @@ namespace family4_datagen = middleware::datagen::family4;
 } // namespace
 
 /** Builds the Family-4 account, selected-character, and item-instance snapshot. */
-bool prepare(Scratch& scratch,
+bool prepare_versioned(Scratch& scratch,
              const middleware::queuez::Subscription& subscription,
              std::uint32_t accountObjectId,
+             std::int32_t familyVersion,
              const Reservation& reservation,
              Prepared& prepared) noexcept {
     if (reservation.rawWriteOffset > scratch.plaintext.size()
@@ -150,7 +152,16 @@ bool prepare(Scratch& scratch,
             (std::max)(staged.rawClearSize,
                        reservation.rawWriteOffset + family4_datagen::instance::layout::kObjectSize);
     }
-    return publish(subscription, objectCount, compressedExtent, reservation, staged, prepared);
+    return publish(subscription, familyVersion, objectCount, compressedExtent, reservation, staged, prepared);
+}
+
+bool prepare(Scratch& scratch,
+             const middleware::queuez::Subscription& subscription,
+             std::uint32_t accountObjectId,
+             const Reservation& reservation,
+             Prepared& prepared) noexcept {
+    return prepare_versioned(scratch, subscription, accountObjectId, kInitialFamilyVersion,
+                             reservation, prepared);
 }
 
 } // namespace sunrise::server::bap::encrypted::push::snapshot

--- a/Sunrise/src/server/bap/encrypted/push/snapshot/internal.h
+++ b/Sunrise/src/server/bap/encrypted/push/snapshot/internal.h
@@ -90,6 +90,14 @@ inline constexpr std::size_t kSingleObjectCount = 1;
                            const Reservation& reservation,
                            Prepared& prepared) noexcept;
 
+/** Builds a full Family-4 replacement at an active peer's next version. */
+[[nodiscard]] bool prepare_versioned(Scratch& scratch,
+                                     const middleware::queuez::Subscription& subscription,
+                                     std::uint32_t accountObjectId,
+                                     std::int32_t familyVersion,
+                                     const Reservation& reservation,
+                                     Prepared& prepared) noexcept;
+
 /**
  * Builds the Family-4 increment that moves the character object to the picked character.
  * @param scratch Object and compression storage owned by the lock.
@@ -100,6 +108,13 @@ inline constexpr std::size_t kSingleObjectCount = 1;
 [[nodiscard]] bool prepare_selection_move(Scratch& scratch,
                                           const queuez::SelectCharacter& select,
                                           Prepared& prepared) noexcept;
+
+/** Builds a minimal next-version update for one item and its owning character. */
+[[nodiscard]] bool prepare_item_update(Scratch& scratch,
+                                       std::uint64_t familyRootSoid,
+                                       std::int32_t familyVersion,
+                                       std::uint64_t instanceSoid,
+                                       Prepared& prepared) noexcept;
 
 /** Selected-character mappings the character and item-instance encoders need. */
 struct Resolved {

--- a/Sunrise/src/server/bap/encrypted/queuez/queuez_outcome_staging.cpp
+++ b/Sunrise/src/server/bap/encrypted/queuez/queuez_outcome_staging.cpp
@@ -68,6 +68,13 @@ bool stage_service_outcome(Scratch& scratch,
                                                   bannerAfter)) {
             after = bannerAfter;
         }
+    } else if (outcome.hasInventoryMutation) {
+        if (!push::append_inventory_notification(scratch, before, outcome.mutatedInstanceSoid,
+                                                 key, nonce, response, written, after)) {
+            core::log::write(core::log::Channel::server, core::log::Level::warn,
+                             "ev=queuez stage=inventory result=fail");
+            return true;
+        }
     } else {
         return true;
     }
@@ -81,8 +88,16 @@ bool stage_service_outcome(Scratch& scratch,
                          core::log::Level::warn,
                          "ev=queuez stage=publish result=unrecorded");
     }
-    publication.armsFamily4Repush = armsRepush;
-    publication.family4RepushRoot = armsRepush ? outcome.subscription.familyRootSoid : 0;
+    // Inventory mutations are appended behind their correlated Web Service reply. This client
+    // build completes the task from that first frame but does not always dispatch its trailing
+    // QueueZ notification to the live item-detail screen. Give it the same delayed standalone
+    // Family-4 delivery used by the initial subscription.
+    const bool inventoryRepush = outcome.hasInventoryMutation && before.family4Active
+                                 && before.family4RootSoid != 0;
+    publication.armsFamily4Repush = armsRepush || inventoryRepush;
+    publication.family4RepushRoot = inventoryRepush
+                                        ? before.family4RootSoid
+                                        : (armsRepush ? outcome.subscription.familyRootSoid : 0);
     return true;
 }
 

--- a/Sunrise/src/server/bap/encrypted/queuez/queuez_state_validation.h
+++ b/Sunrise/src/server/bap/encrypted/queuez/queuez_state_validation.h
@@ -20,7 +20,12 @@ namespace sunrise::server::bap::encrypted::queuez {
  */
 [[nodiscard]] bool stage_family4_snapshot(const SessionState& before,
                                           const middleware::queuez::Family& family,
-                                          SessionState& after) noexcept;
+                                           SessionState& after) noexcept;
+
+/** Stages a next-version incremental after-image after an inventory mutation. */
+[[nodiscard]] bool stage_family4_replacement(const SessionState& before,
+                                             const middleware::queuez::Family& family,
+                                             SessionState& after) noexcept;
 
 /**
  * Decides whether one family-zero subscription publishes, and as which kind of frame.

--- a/Sunrise/src/server/bap/encrypted/queuez/staging/queuez_family_staging.cpp
+++ b/Sunrise/src/server/bap/encrypted/queuez/staging/queuez_family_staging.cpp
@@ -102,6 +102,37 @@ bool stage_family4_snapshot(const SessionState& before,
     return true;
 }
 
+bool stage_family4_replacement(const SessionState& before,
+                               const middleware::queuez::Family& family,
+                               SessionState& after) noexcept {
+    after = before;
+    if (!valid(before) || !before.family4Active || family.type != kAccountFamilyType
+        || family.rootSoid != before.family4RootSoid
+        || family.version != before.family4Version + 1
+        || family.flags != 0 || family.objects.empty()
+        || family.objects.size() > kResidentCapacity
+        || family.objects.size() > static_cast<std::size_t>((std::numeric_limits<std::uint8_t>::max)())) {
+        return false;
+    }
+    SessionState candidate = before;
+    candidate.family4Version = family.version;
+    for (const auto& object : family.objects) {
+        if (object.id == 0 || object.version == 0 || object.payload.empty()) return false;
+        std::size_t resident = 0;
+        while (resident < candidate.family4ResidentCount
+               && candidate.family4Residents[resident].objectSoid != object.version) {
+            ++resident;
+        }
+        if (resident == candidate.family4ResidentCount) {
+            if (candidate.family4ResidentCount >= candidate.family4Residents.size()) return false;
+            ++candidate.family4ResidentCount;
+        }
+        candidate.family4Residents[resident] = {object.version, object.id};
+    }
+    after = candidate;
+    return true;
+}
+
 /** Stages the family-zero publication policy. */
 bool stage_family0_subscription(const SessionState& before,
                                 std::uint64_t selectedCharacter,

--- a/Sunrise/src/server/web_service/web_service_runtime.cpp
+++ b/Sunrise/src/server/web_service/web_service_runtime.cpp
@@ -1,7 +1,9 @@
 #include "web_service_runtime.h"
 
 #include <array>
+#include <algorithm>
 #include <cstdio>
+#include <cstring>
 
 #include "../../core/logging/log.h"
 #include "../../middleware/web_service/messages/opcode205.h"
@@ -24,14 +26,71 @@ constexpr std::size_t kOpcodeLineCapacity = 64;
  * the opcodes the Client sends are what drive its queuez state machine.
  * @param opcode Parsed wire opcode.
  */
-void report_opcode(std::uint32_t opcode) noexcept {
-    std::array<char, kOpcodeLineCapacity> line{};
-    const int written =
-        std::snprintf(line.data(), line.size(), "ev=ws stage=request opcode=%u", opcode);
+void report_opcode(const middleware::web_service::Message& message) noexcept {
+    std::array<char, core::log::kLineCapacity> line{};
+    int written = std::snprintf(line.data(),
+                                line.size(),
+                                "ev=ws stage=request opcode=%u tx=%u bytes=%zu head=",
+                                message.opcode,
+                                message.transactionId,
+                                message.payload.size());
+    constexpr std::size_t kPreviewBytes = 32;
+    const std::size_t preview = (std::min)(message.payload.size(), kPreviewBytes);
+    for (std::size_t index = 0;
+         written > 0 && index < preview
+         && static_cast<std::size_t>(written) + 2 < line.size();
+         ++index) {
+        const int appended = std::snprintf(line.data() + written,
+                                           line.size() - static_cast<std::size_t>(written),
+                                           "%02X",
+                                           std::to_integer<unsigned>(message.payload[index]));
+        if (appended <= 0) {
+            break;
+        }
+        written += appended;
+    }
     if (written > 0) {
         core::log::write(core::log::Channel::server,
                          core::log::Level::info,
                          {line.data(), static_cast<std::size_t>(written)});
+    }
+
+    // Mutation requests are still being mapped. Preserve their complete payload in bounded
+    // chunks so settings saves and collection withdrawals can be decoded from one test run.
+    const bool mutationCandidate = message.opcode == 701
+                                   || (message.opcode >= 1200 && message.opcode < 1400);
+    constexpr std::size_t kChunkBytes = 48;
+    if (!mutationCandidate) {
+        return;
+    }
+    for (std::size_t offset = 0; offset < message.payload.size(); offset += kChunkBytes) {
+        std::array<char, core::log::kLineCapacity> chunkLine{};
+        int chunkWritten = std::snprintf(chunkLine.data(),
+                                         chunkLine.size(),
+                                         "ev=ws stage=payload opcode=%u offset=%zu data=",
+                                         message.opcode,
+                                         offset);
+        const std::size_t chunkSize =
+            (std::min)(kChunkBytes, message.payload.size() - offset);
+        for (std::size_t index = 0;
+             chunkWritten > 0 && index < chunkSize
+             && static_cast<std::size_t>(chunkWritten) + 2 < chunkLine.size();
+             ++index) {
+            const int appended =
+                std::snprintf(chunkLine.data() + chunkWritten,
+                              chunkLine.size() - static_cast<std::size_t>(chunkWritten),
+                              "%02X",
+                              std::to_integer<unsigned>(message.payload[offset + index]));
+            if (appended <= 0) {
+                break;
+            }
+            chunkWritten += appended;
+        }
+        if (chunkWritten > 0) {
+            core::log::write(core::log::Channel::server,
+                             core::log::Level::info,
+                             {chunkLine.data(), static_cast<std::size_t>(chunkWritten)});
+        }
     }
 }
 
@@ -73,6 +132,65 @@ void select_character(const middleware::web_service::Message& message, Outcome& 
                          core::log::Level::info,
                          {line.data(), static_cast<std::size_t>(written)});
     }
+}
+
+void reacquire_collection_item(const middleware::web_service::Message& message,
+                               Outcome& outcome) noexcept {
+    if (message.payload.size() != 3) return;
+    const std::uint32_t value = std::to_integer<std::uint8_t>(message.payload[0])
+                                | (std::to_integer<std::uint8_t>(message.payload[1]) << 8U)
+                                | (std::to_integer<std::uint8_t>(message.payload[2]) << 16U);
+    if (value > UINT16_MAX) return;
+    std::uint64_t instanceSoid = 0;
+    if (!state::reacquire_collection_item(static_cast<std::uint16_t>(value), instanceSoid)) {
+        core::log::write(core::log::Channel::server, core::log::Level::warn,
+                         "ev=ws1820 stage=reacquire result=refused");
+        return;
+    }
+    outcome.hasInventoryMutation = true;
+    outcome.acquiredInstanceSoid = instanceSoid;
+    std::array<char, 128> line{};
+    const int count = std::snprintf(line.data(), line.size(),
+                                    "ev=ws1820 stage=reacquire result=ok index=%u soid=0x%llX",
+                                    value, static_cast<unsigned long long>(instanceSoid));
+    if (count > 0) core::log::write(core::log::Channel::server, core::log::Level::info,
+                                    {line.data(), static_cast<std::size_t>(count)});
+}
+
+void apply_item_plug(const middleware::web_service::Message& message, Outcome& outcome) noexcept {
+    if (message.payload.size() != 24) return;
+    const auto read_u32_be = [&](std::size_t offset) noexcept {
+        std::uint32_t value = 0;
+        for (std::size_t byte = 0; byte < 4; ++byte)
+            value = (value << 8U) | std::to_integer<std::uint8_t>(message.payload[offset + byte]);
+        return value;
+    };
+    const auto read_u64_be = [&](std::size_t offset) noexcept {
+        std::uint64_t value = 0;
+        for (std::size_t byte = 0; byte < 8; ++byte)
+            value = (value << 8U) | std::to_integer<std::uint8_t>(message.payload[offset + byte]);
+        return value;
+    };
+    const std::uint32_t plugSelector = read_u32_be(0);
+    const std::uint32_t socketSelector = read_u32_be(4);
+    const std::uint64_t marker = read_u64_be(8);
+    const std::uint64_t encodedInstance = read_u64_be(16);
+    if (marker != 1 || socketSelector < 2 || (socketSelector - 2) % 4 != 0
+        || plugSelector < 0x18000000U) return;
+    const std::uint32_t plugIndex = (plugSelector >> 12U) - 0x18000U;
+    const std::uint32_t lane = (socketSelector - 2U) / 4U;
+    const std::uint64_t instanceSoid = 0x4000000000000000ULL | (encodedInstance >> 2U);
+    if (plugIndex > UINT16_MAX || lane >= state::account::inventory::kPlugCapacity
+        || !state::apply_item_plug(instanceSoid, static_cast<std::uint8_t>(lane),
+                                  static_cast<std::uint16_t>(plugIndex))) {
+        core::log::write(core::log::Channel::server, core::log::Level::warn,
+                         "ev=ws1901 stage=plug result=refused");
+        return;
+    }
+    outcome.hasInventoryMutation = true;
+    outcome.acquiredInstanceSoid = instanceSoid;
+    core::log::write(core::log::Channel::server, core::log::Level::info,
+                     "ev=ws1901 stage=plug result=ok");
 }
 
 /**
@@ -134,7 +252,7 @@ bool consume(std::span<const std::byte> request,
             core::log::Channel::server, core::log::Level::warn, "ev=ws stage=parse result=fail");
         return false;
     }
-    report_opcode(message.opcode);
+    report_opcode(message);
 
     if (message.opcode == middleware::web_service::messages::opcode205::kOpcode) {
         const auto investment = state::investment_snapshot();
@@ -196,6 +314,10 @@ bool consume(std::span<const std::byte> request,
     if (message.opcode == middleware::web_service::messages::opcode504::kOpcode) {
         // The selection is State, not a response field, so it publishes after the reply encodes.
         select_character(message, outcome);
+    } else if (message.opcode == 1820) {
+        reacquire_collection_item(message, outcome);
+    } else if (message.opcode == 1901) {
+        apply_item_plug(message, outcome);
     }
     return true;
 }

--- a/Sunrise/src/server/web_service/web_service_runtime.h
+++ b/Sunrise/src/server/web_service/web_service_runtime.h
@@ -15,6 +15,9 @@ struct Outcome {
     /** An opcode-504 pick moved the selection and its Family-4 object still has to follow. */
     bool hasSelectedCharacter{};
     std::uint64_t selectedCharacterSoid{};
+    /** A collection withdrawal changed the selected character's inventory. */
+    bool hasInventoryMutation{};
+    std::uint64_t acquiredInstanceSoid{};
 };
 
 /**

--- a/Sunrise/src/state/account/account_state.cpp
+++ b/Sunrise/src/state/account/account_state.cpp
@@ -21,7 +21,10 @@ bool valid(const AccountState& state) noexcept {
         return false;
     }
     bool selected = false;
-    std::array<std::uint64_t, kCharacterCapacity * inventory::kEquipmentSlotCount> itemSoids{};
+    std::array<std::uint64_t,
+               kCharacterCapacity
+                   * (inventory::kEquipmentSlotCount + inventory::kCharacterInventoryCapacity)>
+        itemSoids{};
     std::size_t itemSoidCount = 0;
     for (std::size_t index = 0; index < state.characterCount; ++index) {
         const CharacterState& character = state.characters[index];
@@ -30,7 +33,7 @@ bool valid(const AccountState& state) noexcept {
             || character.gender > CharacterGender::female
             || character.characterClass > CharacterClass::warlock
             || !std::isfinite(character.appearanceValue)
-            || !inventory::valid(character.equipment)) {
+            || !inventory::valid(character.equipment) || !inventory::valid(character.inventory)) {
             return false;
         }
         selected = selected || character.selected;
@@ -50,6 +53,12 @@ bool valid(const AccountState& state) noexcept {
                 return false;
             }
             itemSoids[itemSoidCount++] = item->instanceSoid;
+        }
+        for (std::size_t itemIndex = 0; itemIndex < character.inventory.itemCount; ++itemIndex) {
+            const inventory::Item& item = character.inventory.items[itemIndex];
+            const auto end = itemSoids.cbegin() + static_cast<std::ptrdiff_t>(itemSoidCount);
+            if (std::find(itemSoids.cbegin(), end, item.instanceSoid) != end) return false;
+            itemSoids[itemSoidCount++] = item.instanceSoid;
         }
     }
     return true;

--- a/Sunrise/src/state/account/account_state.h
+++ b/Sunrise/src/state/account/account_state.h
@@ -90,6 +90,8 @@ struct CharacterState {
     std::uint8_t classAbilityEntry{kDefaultClassAbilityEntry};
     /** Authored loadout keyed only by stable semantic equipment slots. */
     account::inventory::Equipment equipment;
+    /** Runtime-owned items acquired from collections and retained between snapshots. */
+    account::inventory::CharacterInventory inventory;
 };
 
 /** Account identity shared by backend object families. */

--- a/Sunrise/src/state/account/inventory/inventory_state.cpp
+++ b/Sunrise/src/state/account/inventory/inventory_state.cpp
@@ -87,4 +87,16 @@ bool valid(const Equipment& equipment) noexcept {
     return true;
 }
 
+bool valid(const CharacterInventory& inventory) noexcept {
+    if (inventory.itemCount > inventory.items.size()) {
+        return false;
+    }
+    for (std::size_t index = 0; index < inventory.itemCount; ++index) {
+        if (!valid(inventory.items[index])) {
+            return false;
+        }
+    }
+    return true;
+}
+
 } // namespace sunrise::state::account::inventory

--- a/Sunrise/src/state/account/inventory/inventory_state.h
+++ b/Sunrise/src/state/account/inventory/inventory_state.h
@@ -31,6 +31,8 @@ enum class EquipmentSlot : std::uint8_t {
 
 /** One fixed entry exists for every semantic equipment slot. */
 inline constexpr std::size_t kEquipmentSlotCount = static_cast<std::size_t>(EquipmentSlot::count);
+/** Maximum number of unequipped character items exposed by the native character object. */
+inline constexpr std::size_t kCharacterInventoryCapacity = 144;
 /** An authored item can pick at most 12 ordinary socket lanes. */
 inline constexpr std::size_t kPlugCapacity = 12;
 /** The engine no-definition hash cannot identify an authored item or plug. */
@@ -72,6 +74,12 @@ struct Equipment {
     std::array<std::optional<Item>, kEquipmentSlotCount> slots{};
 };
 
+/** Persistent unequipped items owned by one character. */
+struct CharacterInventory {
+    std::array<Item, kCharacterInventoryCapacity> items{};
+    std::size_t itemCount{};
+};
+
 /**
  * Finds the semantic State slot for one exact JSON equipment name.
  * @param name Borrowed case-sensitive equipment name.
@@ -96,5 +104,8 @@ struct Equipment {
  * @return True when every used slot holds a whole item.
  */
 [[nodiscard]] bool valid(const Equipment& equipment) noexcept;
+
+/** Checks the occupied prefix of one character's unequipped inventory. */
+[[nodiscard]] bool valid(const CharacterInventory& inventory) noexcept;
 
 } // namespace sunrise::state::account::inventory

--- a/Sunrise/src/state/build_data/cache/records/format.h
+++ b/Sunrise/src/state/build_data/cache/records/format.h
@@ -24,7 +24,7 @@ inline constexpr std::array<char, 8> kCacheMagic{'S', 'U', 'N', 'R', 'I', 'S', '
  * Current build-data cache format. An older cache is rebuilt rather than read, so a bump needs
  * no other edit. Bump it whenever a domain's stored shape changes.
  */
-inline constexpr std::uint32_t kCacheFormatVersion = 22;
+inline constexpr std::uint32_t kCacheFormatVersion = 25;
 /** Signed -1 on disk means there is no equipment slot. */
 inline constexpr std::int8_t kAbsentEquipmentSlot = -1;
 /** The standard 64-bit FNV-1a offset basis starts the payload checksum. */

--- a/Sunrise/src/state/build_data/items/details/definition.h
+++ b/Sunrise/src/state/build_data/items/details/definition.h
@@ -8,11 +8,11 @@
 namespace sunrise::state::build_data::items::details {
 
 /**
- * Configured equipment plus every plug those items socket. 16 slots on 3 characters is 48 items,
- * and each item sockets up to 12 plugs whose own details the character record needs. The size
- * covers both sets with duplicates removed.
+ * Equippable installed-build items plus their initial plugs. Collection reacquisition names a
+ * native index, so the server must be able to instantiate items that were not present in the
+ * initial settings file.
  */
-inline constexpr std::size_t kDefinitionCapacity = 768;
+inline constexpr std::size_t kDefinitionCapacity = 16'384;
 /** Family item instances have 12 fixed ordinary socket lanes. */
 inline constexpr std::size_t kInitialPlugCapacity = 12;
 /** Native equipment ids run from 0 to 19. */

--- a/Sunrise/src/state/build_data/items/item_catalog.h
+++ b/Sunrise/src/state/build_data/items/item_catalog.h
@@ -7,7 +7,10 @@
 namespace sunrise::state::build_data::items {
 
 /** Signed native definition indices give 32,768 item rows. */
-inline constexpr std::size_t kDefinitionCapacity = 32768;
+// Collection requests carry the native item-table index as an unsigned 16-bit value. Season 11
+// definitions extend well beyond 0x7FFF (for example 0xB992), so a half-range catalog silently
+// made otherwise valid collection withdrawals unresolvable.
+inline constexpr std::size_t kDefinitionCapacity = 65536;
 /** All bucket bits set mark a valid item row whose inventory bucket was not found. */
 inline constexpr std::uint8_t kUnresolvedBucketId = 0xFF;
 

--- a/Sunrise/src/state/build_data/runtime.h
+++ b/Sunrise/src/state/build_data/runtime.h
@@ -79,6 +79,10 @@ publish_item_definitions(std::span<const items::Definition> definitions) noexcep
 [[nodiscard]] bool find_item_definition_hash(std::uint32_t definitionHash,
                                              items::Definition& definition) noexcept;
 
+/** Finds one installed-build item by the native index carried by collection requests. */
+[[nodiscard]] bool find_item_definition_index(std::uint16_t definitionIndex,
+                                              items::Definition& definition) noexcept;
+
 /** @return True when a complete configured-detail domain, empty or not, is published. */
 [[nodiscard]] bool configured_item_details_ready() noexcept;
 

--- a/Sunrise/src/state/build_data/runtime/build_data_routing_catalogs.cpp
+++ b/Sunrise/src/state/build_data/runtime/build_data_routing_catalogs.cpp
@@ -6,6 +6,12 @@
 
 namespace sunrise::state::build_data {
 
+bool find_item_definition_index(std::uint16_t definitionIndex,
+                                items::Definition& definition) noexcept {
+    definition = {};
+    return item_definitions_ready() && items::find_index(definitionIndex, definition);
+}
+
 /** @return True when the whole inventory-bucket descriptor table is in State. */
 bool inventory_bucket_descriptors_ready() noexcept {
     return inventory::buckets::count() != 0;

--- a/Sunrise/src/state/runtime/runtime.h
+++ b/Sunrise/src/state/runtime/runtime.h
@@ -59,6 +59,18 @@ void shutdown() noexcept;
 /** @return A copy of the active account state, read under the lock. */
 [[nodiscard]] AccountState account_snapshot() noexcept;
 
+/** Adds one valid collection item to the selected character's matching inventory bucket. */
+[[nodiscard]] bool reacquire_collection_item(std::uint16_t definitionIndex,
+                                             std::uint64_t& instanceSoid) noexcept;
+
+/** Atomically writes the current equipment and inventory overlay beside settings.json. */
+[[nodiscard]] bool persist_inventory_state() noexcept;
+
+/** Replaces one ordinary socket lane on an owned item instance. */
+[[nodiscard]] bool apply_item_plug(std::uint64_t instanceSoid,
+                                   std::uint8_t socketLane,
+                                   std::uint16_t plugDefinitionIndex) noexcept;
+
 /** @return A copy of the evaluated content state, read under the lock. */
 [[nodiscard]] InvestmentState investment_snapshot() noexcept;
 

--- a/Sunrise/src/state/runtime/state_account_runtime.cpp
+++ b/Sunrise/src/state/runtime/state_account_runtime.cpp
@@ -1,13 +1,29 @@
 #include <Windows.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 
 #include "runtime.h"
 #include "state.h"
 #include "storage/internal.h"
+#include "../build_data/runtime.h"
+#include "../../core/filesystem/path.h"
 
 namespace sunrise::state {
+
+namespace {
+constexpr std::uint32_t kInventoryStateMagic = 0x564E4953U;
+constexpr std::uint32_t kInventoryStateVersion = 1;
+struct InventoryStateHeader {
+    std::uint32_t magic{}, version{}, recordSize{}, characterCount{};
+};
+struct InventoryCharacterRecord {
+    std::uint64_t characterSoid{};
+    account::inventory::Equipment equipment{};
+    account::inventory::CharacterInventory inventory{};
+};
+}
 
 /** Stores the active account key without publishing an incomplete account. */
 bool set_primary_soid(std::uint64_t primarySoid) noexcept {
@@ -73,6 +89,164 @@ AccountState account_snapshot() noexcept {
     const AccountState snapshot = runtime::storage::g_state.account;
     ReleaseSRWLockShared(&runtime::storage::g_stateLock);
     return snapshot;
+}
+
+bool reacquire_collection_item(std::uint16_t definitionIndex,
+                               std::uint64_t& instanceSoid) noexcept {
+    instanceSoid = 0;
+    build_data::items::Definition definition{};
+    build_data::items::details::Definition detail{};
+    if (!build_data::find_item_definition_index(definitionIndex, definition)
+        || !build_data::find_configured_item_detail(definitionIndex, detail)
+        || definition.definitionHash != detail.definitionHash
+        || definition.bucketId != detail.bucketId || !detail.equipmentSlot.has_value()) {
+        return false;
+    }
+
+    AcquireSRWLockExclusive(&runtime::storage::g_stateLock);
+    AccountState candidate = runtime::storage::g_state.account;
+    CharacterState* selected = nullptr;
+    for (std::size_t index = 0; index < candidate.characterCount; ++index) {
+        if (candidate.characters[index].selected) selected = &candidate.characters[index];
+    }
+    if (selected == nullptr || selected->inventory.itemCount >= selected->inventory.items.size()) {
+        ReleaseSRWLockExclusive(&runtime::storage::g_stateLock);
+        return false;
+    }
+
+    constexpr std::size_t kUnequippedPerSlot = 9;
+    std::size_t matching = 0;
+    std::uint64_t largestSoid = 0x4000000000000000ULL;
+    for (std::size_t characterIndex = 0; characterIndex < candidate.characterCount;
+         ++characterIndex) {
+        const CharacterState& character = candidate.characters[characterIndex];
+        for (const auto& equipped : character.equipment.slots) {
+            if (equipped.has_value()) largestSoid = (std::max)(largestSoid, equipped->instanceSoid);
+        }
+        for (std::size_t itemIndex = 0; itemIndex < character.inventory.itemCount; ++itemIndex) {
+            const auto& item = character.inventory.items[itemIndex];
+            largestSoid = (std::max)(largestSoid, item.instanceSoid);
+            build_data::items::Definition ownedDefinition{};
+            build_data::items::details::Definition ownedDetail{};
+            if (&character == selected
+                && build_data::find_item_definition_hash(item.definitionHash, ownedDefinition)
+                && build_data::find_configured_item_detail(ownedDefinition.definitionIndex,
+                                                           ownedDetail)
+                && ownedDetail.equipmentSlot == detail.equipmentSlot) {
+                ++matching;
+            }
+        }
+    }
+    if (matching >= kUnequippedPerSlot || largestSoid == UINT64_MAX) {
+        ReleaseSRWLockExclusive(&runtime::storage::g_stateLock);
+        return false;
+    }
+
+    account::inventory::Item item{};
+    item.instanceSoid = largestSoid + 1;
+    item.definitionHash = definition.definitionHash;
+    item.level = selected->level;
+    item.quantity = 1;
+    item.sockets.policy = account::inventory::SocketPolicy::nativeDefaults;
+    selected->inventory.items[selected->inventory.itemCount++] = item;
+    if (!account::valid(candidate)) {
+        ReleaseSRWLockExclusive(&runtime::storage::g_stateLock);
+        return false;
+    }
+    runtime::storage::g_state.account = candidate;
+    instanceSoid = item.instanceSoid;
+    ReleaseSRWLockExclusive(&runtime::storage::g_stateLock);
+    (void)persist_inventory_state();
+    return true;
+}
+
+bool persist_inventory_state() noexcept {
+    HMODULE module = nullptr;
+    if (!GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS
+                               | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                           reinterpret_cast<LPCWSTR>(&persist_inventory_state), &module)) return false;
+    core::path::Buffer path{};
+    if (!core::path::artifact_directory(module, path)
+        || !core::path::append(path, L"\\inventory_state.bin")) return false;
+    const AccountState snapshot = account_snapshot();
+    if (!account::valid(snapshot)) return false;
+    const HANDLE file = CreateFileW(path.chars.data(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS,
+                                    FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (file == INVALID_HANDLE_VALUE) return false;
+    const InventoryStateHeader header{kInventoryStateMagic, kInventoryStateVersion,
+                                      sizeof(InventoryCharacterRecord),
+                                      static_cast<std::uint32_t>(snapshot.characterCount)};
+    DWORD written = 0;
+    bool complete = WriteFile(file, &header, sizeof header, &written, nullptr) != FALSE
+                    && written == sizeof header;
+    for (std::size_t index = 0; complete && index < snapshot.characterCount; ++index) {
+        const CharacterState& character = snapshot.characters[index];
+        const InventoryCharacterRecord record{character.soid, character.equipment,
+                                              character.inventory};
+        complete = WriteFile(file, &record, sizeof record, &written, nullptr) != FALSE
+                   && written == sizeof record;
+    }
+    FlushFileBuffers(file);
+    CloseHandle(file);
+    return complete;
+}
+
+bool apply_item_plug(std::uint64_t instanceSoid,
+                     std::uint8_t socketLane,
+                     std::uint16_t plugDefinitionIndex) noexcept {
+    build_data::items::Definition plugDefinition{};
+    if (!build_data::find_item_definition_index(plugDefinitionIndex, plugDefinition)) return false;
+    AcquireSRWLockExclusive(&runtime::storage::g_stateLock);
+    AccountState candidate = runtime::storage::g_state.account;
+    account::inventory::Item* target = nullptr;
+    for (std::size_t characterIndex = 0; characterIndex < candidate.characterCount; ++characterIndex) {
+        CharacterState& character = candidate.characters[characterIndex];
+        for (auto& equipped : character.equipment.slots) {
+            if (equipped.has_value() && equipped->instanceSoid == instanceSoid) target = &*equipped;
+        }
+        for (std::size_t itemIndex = 0; itemIndex < character.inventory.itemCount; ++itemIndex) {
+            if (character.inventory.items[itemIndex].instanceSoid == instanceSoid)
+                target = &character.inventory.items[itemIndex];
+        }
+    }
+    build_data::items::Definition baseDefinition{};
+    build_data::items::details::Definition detail{};
+    if (target == nullptr
+        || !build_data::find_item_definition_hash(target->definitionHash, baseDefinition)
+        || !build_data::find_configured_item_detail(baseDefinition.definitionIndex, detail)
+        || socketLane >= detail.ordinarySocketCount || socketLane >= target->sockets.plugs.size()) {
+        ReleaseSRWLockExclusive(&runtime::storage::g_stateLock);
+        return false;
+    }
+    account::inventory::Sockets sockets = target->sockets;
+    if (sockets.policy != account::inventory::SocketPolicy::authored) {
+        sockets = {};
+        sockets.policy = account::inventory::SocketPolicy::authored;
+        sockets.plugCount = detail.ordinarySocketCount;
+        for (std::size_t lane = 0; lane < sockets.plugCount; ++lane) {
+            const std::uint16_t initial = detail.initialPlugIndices[lane];
+            if (initial == build_data::items::details::kUnavailableItemIndex) continue;
+            build_data::items::Definition initialDefinition{};
+            if (!build_data::find_item_definition_index(initial, initialDefinition)) {
+                ReleaseSRWLockExclusive(&runtime::storage::g_stateLock);
+                return false;
+            }
+            sockets.plugs[lane] = initialDefinition.definitionHash;
+        }
+    } else if (sockets.plugCount != detail.ordinarySocketCount) {
+        ReleaseSRWLockExclusive(&runtime::storage::g_stateLock);
+        return false;
+    }
+    sockets.plugs[socketLane] = plugDefinition.definitionHash;
+    target->sockets = sockets;
+    if (!account::valid(candidate)) {
+        ReleaseSRWLockExclusive(&runtime::storage::g_stateLock);
+        return false;
+    }
+    runtime::storage::g_state.account = candidate;
+    ReleaseSRWLockExclusive(&runtime::storage::g_stateLock);
+    (void)persist_inventory_state();
+    return true;
 }
 
 } // namespace sunrise::state

--- a/Sunrise/src/state/runtime/state_runtime.cpp
+++ b/Sunrise/src/state/runtime/state_runtime.cpp
@@ -9,6 +9,7 @@
 #include <limits>
 #include <span>
 
+#include "../../core/filesystem/path.h"
 #include "../../core/logging/log.h"
 #include "../../core/settings/settings.h"
 #include "../activity/defaults/activity_defaults_validation.h"
@@ -27,6 +28,60 @@ SRWLOCK g_stateLock{SRWLOCK_INIT};
 } // namespace runtime::storage
 
 namespace {
+
+core::path::Buffer g_inventoryStatePath{};
+constexpr std::uint32_t kInventoryStateMagic = 0x564E4953U; // SINV
+constexpr std::uint32_t kInventoryStateVersion = 1;
+struct InventoryStateHeader {
+    std::uint32_t magic{};
+    std::uint32_t version{};
+    std::uint32_t recordSize{};
+    std::uint32_t characterCount{};
+};
+struct InventoryCharacterRecord {
+    std::uint64_t characterSoid{};
+    account::inventory::Equipment equipment{};
+    account::inventory::CharacterInventory inventory{};
+};
+
+void configure_inventory_state_path(void* module) noexcept {
+    g_inventoryStatePath = {};
+    if (module != nullptr && core::path::artifact_directory(module, g_inventoryStatePath)) {
+        (void)core::path::append(g_inventoryStatePath, L"\\inventory_state.bin");
+    }
+}
+
+void overlay_persisted_inventory(AccountState& accountState) noexcept {
+    if (g_inventoryStatePath.length == 0) return;
+    const AccountState baseline = accountState;
+    const HANDLE file = CreateFileW(g_inventoryStatePath.chars.data(), GENERIC_READ, FILE_SHARE_READ,
+                                    nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (file == INVALID_HANDLE_VALUE) return;
+    InventoryStateHeader header{};
+    DWORD read = 0;
+    bool complete = ReadFile(file, &header, sizeof header, &read, nullptr) != FALSE
+                    && read == sizeof header && header.magic == kInventoryStateMagic
+                    && header.version == kInventoryStateVersion
+                    && header.recordSize == sizeof(InventoryCharacterRecord)
+                    && header.characterCount <= kCharacterCapacity;
+    for (std::size_t recordIndex = 0; complete && recordIndex < header.characterCount;
+         ++recordIndex) {
+        InventoryCharacterRecord record{};
+        complete = ReadFile(file, &record, sizeof record, &read, nullptr) != FALSE
+                   && read == sizeof record;
+        for (std::size_t characterIndex = 0; complete && characterIndex < accountState.characterCount;
+             ++characterIndex) {
+            if (accountState.characters[characterIndex].soid == record.characterSoid) {
+                accountState.characters[characterIndex].equipment = record.equipment;
+                accountState.characters[characterIndex].inventory = record.inventory;
+            }
+        }
+    }
+    CloseHandle(file);
+    if (!complete || !account::valid(accountState)) {
+        accountState = baseline;
+    }
+}
 
 /** Network-order IPv4 loopback returned by the in-process SignOn route. */
 constexpr std::uint32_t kLoopbackAddress = 0x7F000001;
@@ -77,7 +132,11 @@ bool initialize(void* module,
     if (!account::valid(initialAccount) || !activity::defaults::valid(activityDefaults)) {
         return false;
     }
-    if (!build_data::initialize(module, runtime::equipment::configured_hash(initialAccount))) {
+    configure_inventory_state_path(module);
+    AccountState restoredAccount = initialAccount;
+    overlay_persisted_inventory(restoredAccount);
+    if (!account::valid(restoredAccount)
+        || !build_data::initialize(module, runtime::equipment::configured_hash(restoredAccount))) {
         return false;
     }
     {
@@ -87,8 +146,8 @@ bool initialize(void* module,
             std::snprintf(line.data(),
                           line.size(),
                           "ev=account stage=identity primary=0x%016llX characters=%zu",
-                          static_cast<unsigned long long>(initialAccount.primarySoid),
-                          initialAccount.characterCount);
+                          static_cast<unsigned long long>(restoredAccount.primarySoid),
+                          restoredAccount.characterCount);
         if (written > 0) {
             core::log::write(core::log::Channel::state,
                              core::log::Level::info,
@@ -107,7 +166,7 @@ bool initialize(void* module,
     initialized.signOn.relayAddress = kLoopbackAddress;
     initialized.signOn.relayPort = kDefaultRelayPort;
     initialized.signOn.tokenLifetimeSeconds = kDefaultTokenLifetimeSeconds;
-    initialized.account = initialAccount;
+    initialized.account = restoredAccount;
     initialized.activity.defaults = activityDefaults;
     initialized.investment.family5.objectSoid = kGlobalFamily5Soid;
     // Only the override lists come from settings. Identity and gate stay owned by State.
@@ -119,8 +178,8 @@ bool initialize(void* module,
     // The arm is account-wide and rides the first ws-503, which goes out before any pick. Nothing
     // is selected at boot, so it is armed when any authored character carries the bypass. The
     // per-character objB byte is the other half, and it still decides which character it opens.
-    for (std::size_t index = 0; index < initialAccount.characterCount; ++index) {
-        if (initialAccount.characters[index].contentBypass) {
+    for (std::size_t index = 0; index < restoredAccount.characterCount; ++index) {
+        if (restoredAccount.characters[index].contentBypass) {
             initialized.investment.family5.contentGateArm = true;
             break;
         }


### PR DESCRIPTION
## Summary

- persist inventory and equipment changes
- publish incremental Family 4 item updates
- handle plug mutations

## Limitations

- collection reacquisition is incomplete
- open item screens may require reopening to refresh

## Test

Release x64 build succeeded with the v143 toolset.