### PR TITLE
Add cross build scripts for linux and fix issues related to wine

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,30 @@ Destiny 2 Offline Exploration Mod
 This mod is work in progress. Things might break or work in unexpected ways. There is also currently
 a lack of documentation. This will improve over the coming weeks.
 
+## Building on Linux
+
+Cross-compiles the Windows DLL with `clang-cl` + `lld-link` + [xwin](https://github.com/Jake-Shadle/xwin).
+
+Built with: clang/lld/llvm 20.1.8, cmake 3.31.6, ninja 1.12.1, xwin 0.10.0, on Ubuntu 25.10.
+
+Splat the MSVC CRT + Windows SDK once:
+
+```
+xwin --accept-license splat --output ~/.xwin
+```
+
+Then build:
+
+```
+./Sunrise/build.sh
+```
+
+Output: `build/steam_api64.dll`.
+
+Tested running under Wine 11 (winehq-staging 11.12); Proton's bundled Wine 11 works too. The
+system `wine-10.0` (Ubuntu 25.10) fails at `vkCreateInstance` (`res=-7`): DXVK requests Vulkan
+before Wine's display driver is up, so winevulkan falls back to `nulldrv`. Wine ≥ 11 fixes it.
+
 ## Support Me
 
 Leave a start on this repo.

--- a/Sunrise/CMakeLists.txt
+++ b/Sunrise/CMakeLists.txt
@@ -1,0 +1,53 @@
+cmake_minimum_required(VERSION 3.20)
+project(Sunrise CXX C)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
+# Static release CRT (/MT): xwin has no debug CRT.
+cmake_policy(SET CMP0091 NEW)
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded")
+
+file(GLOB_RECURSE SUNRISE_SRC CONFIGURE_DEPENDS
+     "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+
+file(GLOB DETOURS_SRC CONFIGURE_DEPENDS
+     "${CMAKE_CURRENT_SOURCE_DIR}/vendor/detours/*.cpp")
+
+set(IMGUI_SRC
+    vendor/imgui/imgui.cpp
+    vendor/imgui/imgui_draw.cpp
+    vendor/imgui/imgui_tables.cpp
+    vendor/imgui/imgui_widgets.cpp
+    vendor/imgui/backends/imgui_impl_win32.cpp
+    vendor/imgui/backends/imgui_impl_dx11.cpp)
+
+add_library(steam_api64 SHARED ${SUNRISE_SRC} ${DETOURS_SRC} ${IMGUI_SRC})
+
+set_target_properties(steam_api64 PROPERTIES
+    OUTPUT_NAME "steam_api64"
+    PREFIX ""
+    SUFFIX ".dll")
+
+target_include_directories(steam_api64 PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/vendor
+    ${CMAKE_CURRENT_SOURCE_DIR}/vendor/detours
+    ${CMAKE_CURRENT_SOURCE_DIR}/vendor/imgui
+    ${CMAKE_CURRENT_SOURCE_DIR}/vendor/imgui/backends)
+
+# UNICODE/_UNICODE: else RT_RCDATA won't match FindResourceW.
+target_compile_definitions(steam_api64 PRIVATE
+    WIN32 _WINDOWS _USRDLL
+    UNICODE _UNICODE
+    WIN32_LEAN_AND_MEAN NOMINMAX
+    NDEBUG
+    IMGUI_USER_CONFIG="core/ui/imgui_user_config.h")
+
+target_link_libraries(steam_api64 PRIVATE
+    kernel32 user32 gdi32 shell32 dwmapi
+    bcrypt ws2_32 d3dcompiler synchronization)

--- a/Sunrise/build.sh
+++ b/Sunrise/build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+export PATH="$HOME/.cargo/bin:$PATH"
+XWIN="${XWIN_DIR:-$HOME/.xwin}"
+
+cmake -G Ninja -B ../build \
+  -DCMAKE_TOOLCHAIN_FILE=cmake/clang-cl-msvc.cmake \
+  -DXWIN_DIR="$XWIN"
+
+cmake --build ../build -j"$(nproc)"
+
+echo "=> $(cd .. && pwd)/build/steam_api64.dll"

--- a/Sunrise/cmake/clang-cl-msvc.cmake
+++ b/Sunrise/cmake/clang-cl-msvc.cmake
@@ -1,0 +1,41 @@
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR AMD64)
+
+if(NOT DEFINED XWIN_DIR)
+    if(DEFINED ENV{XWIN_DIR})
+        set(XWIN_DIR "$ENV{XWIN_DIR}")
+    else()
+        set(XWIN_DIR "$ENV{HOME}/.xwin")
+    endif()
+endif()
+
+find_program(CLANG_CL NAMES clang-cl clang-cl-20 clang-cl-19 clang-cl-18 PATHS /usr/lib/llvm-20/bin /usr/lib/llvm-19/bin REQUIRED)
+find_program(LLD_LINK NAMES lld-link lld-link-20 PATHS /usr/lib/llvm-20/bin REQUIRED)
+find_program(LLVM_RC NAMES llvm-rc llvm-rc-20 PATHS /usr/lib/llvm-20/bin REQUIRED)
+set(CMAKE_C_COMPILER   "${CLANG_CL}")
+set(CMAKE_CXX_COMPILER "${CLANG_CL}")
+set(CMAKE_RC_COMPILER  "${LLVM_RC}")
+set(CMAKE_LINKER       "${LLD_LINK}")
+
+set(_xwin_incs
+    "-imsvc${XWIN_DIR}/crt/include"
+    "-imsvc${XWIN_DIR}/sdk/include/ucrt"
+    "-imsvc${XWIN_DIR}/sdk/include/um"
+    "-imsvc${XWIN_DIR}/sdk/include/shared"
+    "-imsvc${XWIN_DIR}/sdk/include/winrt")
+list(JOIN _xwin_incs " " _xwin_incs_str)
+
+set(_common "--target=x86_64-pc-windows-msvc -Wno-unused-command-line-argument ${_xwin_incs_str}")
+set(CMAKE_C_FLAGS_INIT   "${_common}")
+set(CMAKE_CXX_FLAGS_INIT "${_common}")
+
+set(_xwin_libs
+    "/libpath:${XWIN_DIR}/crt/lib/x86_64"
+    "/libpath:${XWIN_DIR}/sdk/lib/um/x86_64"
+    "/libpath:${XWIN_DIR}/sdk/lib/ucrt/x86_64")
+list(JOIN _xwin_libs " " _xwin_libs_str)
+set(CMAKE_EXE_LINKER_FLAGS_INIT    "${_xwin_libs_str}")
+set(CMAKE_SHARED_LINKER_FLAGS_INIT "${_xwin_libs_str}")
+set(CMAKE_MODULE_LINKER_FLAGS_INIT "${_xwin_libs_str}")
+
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)

--- a/Sunrise/src/middleware/encoding/byte_order.h
+++ b/Sunrise/src/middleware/encoding/byte_order.h
@@ -36,6 +36,17 @@ read_u16_be(std::span<const std::byte, kU16Size> input) noexcept {
 }
 
 /**
+ * Reverses the four bytes of a 32-bit value.
+ * @param value Host-order value.
+ * @return The value with its four bytes reversed.
+ */
+[[nodiscard]] inline constexpr std::uint32_t 
+byteswap_u32(std::uint32_t value) noexcept {
+    return ((value & 0x000000FFu) << 24) | ((value & 0x0000FF00u) << 8)
+           | ((value & 0x00FF0000u) >> 8) | ((value & 0xFF000000u) >> 24);
+}
+
+/**
  * Reads one unsigned 32-bit big-endian wire value.
  * @param input Exact 4-byte wire field.
  * @return Host-order unsigned value.

--- a/Sunrise/src/middleware/signon/response.cpp
+++ b/Sunrise/src/middleware/signon/response.cpp
@@ -6,6 +6,7 @@
 #include <span>
 #include <string_view>
 
+#include "../encoding/byte_order.h"
 #include "config/signon_config_blob.h"
 #include "extended/signon_extended_fields.h"
 #include "internal.h"
@@ -74,7 +75,7 @@ bool encode_success(const state::SignOnState& state,
                                 && success.bytes(kAuthenticationKeyField, state.authenticationKey)
                                 && success.bytes(kSessionTokenField, state.sessionToken)
                                 && success.varint(kExpiryField, expirySeconds)
-                                && success.varint(kRelayAddressField, state.relayAddress)
+                                && success.varint(kRelayAddressField, encoding::byteswap_u32(state.relayAddress))
                                 && success.varint(kRelayPortField, state.relayPort)
                                 && extended::append(success, state.relayAddress);
     if (!successEncoded) {

--- a/Sunrise/src/steam/runtime/steam_lifecycle.cpp
+++ b/Sunrise/src/steam/runtime/steam_lifecycle.cpp
@@ -46,9 +46,7 @@ bool g_platformActivationAttempted{};
 
 /** Starts the Steam shim and its exported state. */
 bool initialize(void* module) noexcept {
-    if (!client::hooks::egress::install()) {
-        return false;
-    }
+    (void)client::hooks::egress::install();
     AcquireSRWLockExclusive(&g_lifecycleLock);
     if (g_initialized.load(std::memory_order_acquire)) {
         ReleaseSRWLockExclusive(&g_lifecycleLock);


### PR DESCRIPTION
## Summary

Adds Linux cross-compilation support and fixes two bugs that surfaced while testing the mod under Wine. 

## Linux cross-build

New `CMakeLists.txt`, a `cmake/clang-cl-msvc.cmake` toolchain, and `build.sh` that
cross-compile `steam_api64.dll` on Linux with `clang-cl` + `lld-link` +
[xwin](https://github.com/Jake-Shadle/xwin) (MSVC CRT + Windows SDK). 
Output goes to `build/`, matching the `.vcxproj` `OutDir`.
The MSVC build is unchanged.

## Fix: SignOn `relayAddress` byte order

`relayAddress` (SignOn success field 6) was written as a varint in network order
(`0x7F000001` = `127.0.0.1`), but the client reads it as little-endian octets so 
it dialed `1.0.0.127:30974` and the BAP connection timed out. 
It now goes out byte-swapped (`0x0100007F`). 
The relay port (field 7) is read host-order and was already correct.

Why it was never caught: on Windows the egress guard hooks Winsock and rewrites every
outbound connect to loopback (port preserved), so the wrong address still reaches the
local listener.
Under Wine the guard can't install (see below), so the real address is used and the bug becomes visible.
It is a latent encoding bug. 
Windows users are unaffected, but the field is now correct on both.

## Fix: egress guard is non-fatal under Wine

`steam::initialize` bailed when `egress::install()` failed.
Under Wine, Detours can't hook the builtin Winsock/DNS exports, so the install fails and `core::initialize` never
ran (no logging, unmodded client). 
The result is now ignored instead of fatal; the air-gap is provided host-side.
`install()` is idempotent, so this doesn't change hook behavior on Windows the install still succeeds and the path is identical.

## Tested

Boots, renders, connects to the in-process server, and loads a destination under Wine 11 on Linux.

Requires to be tested on windows to make sure everything is still fine.