### PR TITLE
Fix client shutdown lock leak

### DIFF
--- a/Sunrise/src/client/runtime/client_runtime_lifecycle.cpp
+++ b/Sunrise/src/client/runtime/client_runtime_lifecycle.cpp
@@ -56,9 +56,11 @@ bool shutdown() noexcept {
     hooks::teleport::uninstall();
     hooks::queuez::uninstall();
     if (!hooks::config_getter::uninstall()) {
+        ReleaseSRWLockExclusive(&runtime::g_lock);
         return false;
     }
     if (!hooks::assert_handler::uninstall()) {
+        ReleaseSRWLockExclusive(&runtime::g_lock);
         return false;
     }
     if (!hooks::retail_log::uninstall()) {


### PR DESCRIPTION
This is a simple fix with a small scope, so it should be easy to approve.

Upon hooks::config_getter::uninstall() or hooks::assert_handler::uninstall() failing, runtime::g_lock is now released.
This ensures the runtime::g_lock is always released before returning from function that acquired this lock.
This lock is only used in 3 functions, each time being acquired at the start of the function and released by the time it returns. There is no reason why that pattern should be any different for these two return statements since the purpose of this lock is just to keep these functions from running concurrently.
Whether or not it is currently likely for someone to experience the theoretical freeze by this lock leak, we should get it out of the way.