### PR TITLE
build: add Nix development environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,6 @@
+if has nix; then
+	watch_file flake.nix build.zig.zon nix/devShell.nix
+	use flake
+fi
+
+source_env_if_exists .envrc.local

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 /build/
+/.direnv/
+/.envrc.local
+/.xwin/
+/.xwin-cache/
 /.vs/
 /.idea/
 /.vscode/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,85 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1786534138,
+        "narHash": "sha256-Cwffw7dPM56d8spt4/queFQ1cKg69D9qrsp+wfwKvfo=",
+        "rev": "044bfe75bfe4c7bbe043dc17b5e42ea823b84a09",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1052792.044bfe75bfe4/nixexprs.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems",
+        "zig": "zig"
+      }
+    },
+    "systems": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "zig": {
+      "inputs": {
+        "flake-compat": [
+          "flake-compat"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": [
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786667735,
+        "narHash": "sha256-kh/M3vq8w3t6k8Srrs3aU6TWvG5n4nTy9Lm9TNDDj5k=",
+        "owner": "mitchellh",
+        "repo": "zig-overlay",
+        "rev": "7919a249ce33779a50eefcd028403a15c941af31",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mitchellh",
+        "repo": "zig-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,47 @@
+{
+  description = "Sunrise development environment";
+
+  inputs = {
+    nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
+
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+
+    systems = {
+      url = "github:nix-systems/default";
+      flake = false;
+    };
+
+    zig = {
+      url = "github:mitchellh/zig-overlay";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-compat.follows = "flake-compat";
+        systems.follows = "systems";
+      };
+    };
+  };
+
+  outputs = {
+    nixpkgs,
+    zig,
+    ...
+  }: let
+    inherit (nixpkgs) lib legacyPackages;
+
+    # Our supported systems are the same systems as the Zig binaries.
+    platforms = lib.attrNames zig.packages;
+    forAllPlatforms = function:
+      lib.genAttrs platforms (system: function legacyPackages.${system});
+  in {
+    devShells = forAllPlatforms (pkgs: {
+      default = pkgs.callPackage ./nix/devShell.nix {
+        zig = zig.packages.${pkgs.stdenv.hostPlatform.system}."0.16.0";
+      };
+    });
+
+    formatter = forAllPlatforms (pkgs: pkgs.alejandra);
+  };
+}

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -1,0 +1,35 @@
+{
+  mkShell,
+  lib,
+  stdenv,
+  alejandra,
+  llvmPackages_latest,
+  xwin,
+  zig,
+}:
+mkShell {
+  name = "sunrise";
+
+  packages = [
+    alejandra
+    llvmPackages_latest.clang-tools
+    llvmPackages_latest.lld
+    llvmPackages_latest.llvm
+    xwin
+    zig
+  ];
+
+  shellHook =
+    ''
+      export XWIN_DIR="$PWD/.xwin-cache"
+      if [ ! -d "$XWIN_DIR/sdk" ]; then
+        xwin --accept-license splat --include-debug-libs --output "$XWIN_DIR"
+      fi
+
+      unset NIX_CC NIX_CFLAGS_COMPILE NIX_LDFLAGS
+      unset LD CC CXX CFLAGS CPPFLAGS LDFLAGS
+    ''
+    + (lib.optionalString stdenv.hostPlatform.isDarwin ''
+      unset SDKROOT DEVELOPER_DIR
+    '');
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,12 @@
+(import
+  (
+    let
+      flake-compat = (builtins.fromJSON (builtins.readFile ./flake.lock)).nodes.flake-compat;
+    in
+      fetchTarball {
+        url = "https://github.com/edolstra/flake-compat/archive/${flake-compat.locked.rev}.tar.gz";
+        sha256 = flake-compat.locked.narHash;
+      }
+  )
+  {src = ./.;})
+.shellNix


### PR DESCRIPTION
### PR Stack
1. **[#21 — build: add Nix development environment](https://github.com/stanuwu/Sunrise/pull/21)** (Current PR)
2. [#22 — refactor: flatten repository layout](https://github.com/stanuwu/Sunrise/pull/22)
3. [#23 — build: adopt Zig build system and toolchain](https://github.com/stanuwu/Sunrise/pull/23)

---

This change introduces a reproducible development environment via Nix flakes.

This change does not force Nix or Zig into the source code or the native Windows workflow.

## Reproducible Environments via Nix

The Nix shell provides the complete Windows cross-build environment for supported macOS (aarch64), Linux, and Windows (WSL) hosts.

The shell includes Zig 0.16.0, xwin, LLVM, LLD, Clang tools, and Alejandra. It removes host compiler variables within the shell environment, preventing global system compilers from leaking into the environment.

xwin places the Microsoft SDK and debug libraries in `.xwin-cache`. Later builds reuse this local cache. Developers must review the Microsoft SDK license before first use.

The Nix flake guarantees a consistent, reproducible environment out-of-the-box for all contributors.

## Validation

- [x] `nix flake check`
- [x] Nix development shell, `nix-shell`, and direnv entry points
- [x] Nix formatting checks (Alejandra)

## Disclosure
Parts of this pull request were generated using artificial intelligence. All generated code has been thoroughly reviewed and validated by a human contributor.
