### PR TITLE
bubble names, teleport distance, & fov setting

### DIFF
--- a/Sunrise/Sunrise.vcxproj
+++ b/Sunrise/Sunrise.vcxproj
@@ -84,7 +84,9 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ResourceCompile Include="resources\sunrise.rc" />
+    <ResourceCompile Include="resources\sunrise.rc">
+      <AdditionalInputs>%(AdditionalInputs);$(MSBuildThisFileDirectory)resources\default_settings.json</AdditionalInputs>
+    </ResourceCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="resources\default_settings.json" />
@@ -396,6 +398,8 @@
     <ClCompile Include="src\state\build_data\scenarios\scenario_catalog.cpp" />
     <ClCompile Include="src\state\build_data\spawn_sets\spawn_set_catalog.cpp" />
     <ClCompile Include="src\state\build_data\hash_names\hash_name_catalog.cpp" />
+    <ClCompile Include="src\state\build_data\hash_names\overlay\name_overlay_catalog.cpp" />
+    <ClCompile Include="src\state\build_data\hash_names\overlay\name_overlay_load.cpp" />
     <ClCompile Include="src\state\activity\forced\activity_forced_destination.cpp" />
     <ClCompile Include="src\state\build_data\runtime\build_data_roster_runtime.cpp" />
     <ClCompile Include="src\client\content\scenarios\scenario_build.cpp" />
@@ -865,6 +869,8 @@
     <ClInclude Include="src\state\build_data\spawn_sets\spawn_set_catalog.h" />
     <ClInclude Include="src\state\build_data\hash_names\hash_name_catalog.h" />
     <ClInclude Include="src\state\build_data\hash_names\definition.h" />
+    <ClInclude Include="src\state\build_data\hash_names\overlay\name_overlay_catalog.h" />
+    <ClInclude Include="src\state\build_data\hash_names\overlay\name_overlay_load.h" />
     <ClInclude Include="src\state\build_data\spawn_sets\definition.h" />
     <ClInclude Include="src\state\build_data\vendors\definition.h" />
     <ClInclude Include="src\state\build_data\vendors\vendor_catalog.h" />

--- a/Sunrise/resources/default_settings.json
+++ b/Sunrise/resources/default_settings.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 5,
   "core": {
     "logging": {
       "debugger_sink": true,
@@ -203,7 +203,8 @@
           "show_fps": false,
           "hdr_mode": 0,
           "calibration_primary": 10000.0,
-          "calibration_alpha": 0.0
+          "calibration_alpha": 0.0,
+          "field_of_view": 85
         },
         "interface": {
           "subtitles_mode": 0,

--- a/Sunrise/src/client/teleport/teleport_settings_store.h
+++ b/Sunrise/src/client/teleport/teleport_settings_store.h
@@ -9,7 +9,7 @@ inline constexpr float kDefaultDistance = 10.0F;
 /** Smallest offered distance. Zero would leave the key bound to nothing visible. */
 inline constexpr float kMinimumDistance = 1.0F;
 /** Largest offered distance. Past this a press reliably lands through a wall or the floor. */
-inline constexpr float kMaximumDistance = 100.0F;
+inline constexpr float kMaximumDistance = 200.0F;
 /** No key is bound until one is picked, so a fresh install cannot teleport by accident. */
 inline constexpr std::uint32_t kNoKey = 0;
 

--- a/Sunrise/src/core/settings/settings.h
+++ b/Sunrise/src/core/settings/settings.h
@@ -18,7 +18,7 @@ namespace sunrise::core::settings {
  * Raise it when a key is renamed, removed, or changes meaning. Adding a key needs no raise,
  * because a missing key already takes its default. An older file is upgraded in place at load.
  */
-inline constexpr std::uint32_t kSettingsVersion = 3;
+inline constexpr std::uint32_t kSettingsVersion = 5;
 
 /** Parsed read-only process settings. */
 struct Settings {

--- a/Sunrise/src/core/settings/settings_upgrade.cpp
+++ b/Sunrise/src/core/settings/settings_upgrade.cpp
@@ -18,7 +18,7 @@ namespace {
 /** The layout version member, quoted so a value string cannot match it. */
 constexpr std::string_view kVersionMember = "\"version\"";
 /** Members replaced with the bundled default because their value form changed. */
-constexpr std::array<std::string_view, 1> kReplacedMembers{"\"key_bindings\""};
+constexpr std::array<std::string_view, 2> kReplacedMembers{"\"key_bindings\"", "\"display\""};
 /** One splice per replaced member, plus the version member itself. */
 constexpr std::size_t kSpliceCapacity = kReplacedMembers.size() + 1;
 /** Room for the version member and its digits when the file predates versioning. */

--- a/Sunrise/src/core/settings/state/display_parser.cpp
+++ b/Sunrise/src/core/settings/state/display_parser.cpp
@@ -12,6 +12,7 @@ bool Parser::display_settings(state::account::settings::Display& output) noexcep
         hdrMode,
         calibrationPrimary,
         calibrationAlpha,
+        fieldOfView,
         count,
     };
 
@@ -54,6 +55,10 @@ bool Parser::display_settings(state::account::settings::Display& output) noexcep
             }
         } else if (key == "calibration_alpha") {
             if (!mark(Field::calibrationAlpha) || !floating_point(output.calibrationAlpha)) {
+                return false;
+            }
+        } else if (key == "field_of_view") {
+            if (!mark(Field::fieldOfView) || !signed_32(output.fieldOfView)) {
                 return false;
             }
         } else if (!skip_value(0)) {

--- a/Sunrise/src/middleware/datagen/family4/account/preferences/preferences_encoder.cpp
+++ b/Sunrise/src/middleware/datagen/family4/account/preferences/preferences_encoder.cpp
@@ -7,12 +7,10 @@ namespace {
 
 /** Native keybinding halves use input code 0x74 as the unbound sentinel. */
 constexpr std::uint16_t kUnboundInputCode = 0x0074;
-/** Seed version 0 lets the client set up local mirrors once after sign-in. */
-constexpr std::int32_t kOpenSeedVersion = 0;
 /**
  * Seed version 1 closes a gate so the client keeps the replicated values behind it.
- * The keybinding gate stays open so the client seeds its own defaults. The post-processing gate
- * stays closed, or local cvars would overwrite its 3 replicated fields on every sign-in.
+ * Both gates stay closed, or local cvars would overwrite their replicated fields on every
+ * sign-in.
  */
 constexpr std::int32_t kClosedSeedVersion = 1;
 /** Source 0 makes later input reads use the replicated keybinding array. */
@@ -53,7 +51,7 @@ bool encode(const state::account::settings::AccountSettings& settings,
     record = {};
     bindingsRecord = {};
     record.postProcessingSeedVersion = kClosedSeedVersion;
-    bindingsRecord.accountSeedVersion = kOpenSeedVersion;
+    bindingsRecord.accountSeedVersion = kClosedSeedVersion;
     bindingsRecord.sourceSelector = kReplicatedBindingSource;
 
     const auto& controls = settings.controls;
@@ -90,6 +88,7 @@ bool encode(const state::account::settings::AccountSettings& settings,
     record.hdrMode = display.hdrMode;
     record.calibrationPrimary = display.calibrationPrimary;
     record.calibrationAlpha = display.calibrationAlpha;
+    bindingsRecord.fieldOfViewAdjustment = display.fieldOfView;
 
     const auto& interfaceSettings = settings.interface;
     record.subtitlesMode = interfaceSettings.subtitlesMode;

--- a/Sunrise/src/state/account/settings/settings_state.cpp
+++ b/Sunrise/src/state/account/settings/settings_state.cpp
@@ -35,6 +35,7 @@ constexpr Range<std::int8_t> kAudioVolume{0, 10};
 
 /** Brightness stores the 7 menu choices, 0 to 6. */
 constexpr Range<std::int8_t> kBrightness{0, 6};
+constexpr Range<std::int32_t> kFieldOfView{55, 105};
 /** The first unidentified calibration field uses the working renderer fallback. */
 constexpr float kCalibrationPrimary = 10000.0F;
 /** The second unidentified calibration field uses the working renderer alpha. */
@@ -117,7 +118,8 @@ template <typename Value, std::size_t Count>
 [[nodiscard]] bool valid_display(const Display& value) noexcept {
     return within(value.brightness, kBrightness) && within(value.hdrMode, kTwoChoiceSelector)
            && value.calibrationPrimary == kCalibrationPrimary
-           && value.calibrationAlpha == kCalibrationAlpha;
+           && value.calibrationAlpha == kCalibrationAlpha
+           && within(value.fieldOfView, kFieldOfView);
 }
 
 /**

--- a/Sunrise/src/state/account/settings/settings_state.h
+++ b/Sunrise/src/state/account/settings/settings_state.h
@@ -52,6 +52,7 @@ struct Display {
     float calibrationPrimary{};
     /** Second unidentified renderer-calibration scalar. */
     float calibrationAlpha{};
+    std::int32_t fieldOfView{};
 };
 
 /** Authored HUD, subtitle, reticle, and text presentation preferences. */

--- a/Sunrise/src/state/build_data/build_data_runtime.cpp
+++ b/Sunrise/src/state/build_data/build_data_runtime.cpp
@@ -10,6 +10,8 @@
 #include "cache/internal.h"
 #include "constants/investment_constant_catalog.h"
 #include "hash_names/hash_name_catalog.h"
+#include "hash_names/overlay/name_overlay_catalog.h"
+#include "hash_names/overlay/name_overlay_load.h"
 #include "inventory/buckets/inventory_bucket_catalog.h"
 #include "items/details/item_detail_catalog.h"
 #include "progressions/progression_catalog.h"
@@ -34,6 +36,7 @@ constexpr std::wstring_view kCacheFileSuffix = L"\\cache\\build_data.bin";
 
 /** Loads one full cache, or leaves every domain ready for first-boot extraction. */
 bool initialize(void* module, std::uint64_t configuredEquipmentHash) noexcept {
+    (void)hash_names::overlay::load(module);
     runtime::persistence::Context& persistenceState = runtime::persistence::context();
     AcquireSRWLockExclusive(&persistenceState.lock);
     runtime::persistence::clear_locked(persistenceState);
@@ -130,6 +133,7 @@ bool initialize(void* module, std::uint64_t configuredEquipmentHash) noexcept {
 
 /** Clears all generated build mappings and persistence paths. */
 void shutdown() noexcept {
+    hash_names::overlay::clear();
     runtime::persistence::Context& persistenceState = runtime::persistence::context();
     AcquireSRWLockExclusive(&persistenceState.lock);
     runtime::clear_catalogs();

--- a/Sunrise/src/state/build_data/hash_names/overlay/name_overlay_catalog.cpp
+++ b/Sunrise/src/state/build_data/hash_names/overlay/name_overlay_catalog.cpp
@@ -1,0 +1,49 @@
+#include "name_overlay_catalog.h"
+
+#include <algorithm>
+
+#include "../../table.h"
+#include "../hash_name_catalog.h"
+
+namespace sunrise::state::build_data::hash_names::overlay {
+namespace {
+
+Lock g_lock;
+Table<Name, kNameCapacity> g_names;
+
+} // namespace
+
+void clear() noexcept {
+    const Lock::Exclusive guard(g_lock);
+    g_names.clear();
+}
+
+bool replace(std::span<const Name> names) noexcept {
+    if (!hash_names::valid(names)) {
+        return false;
+    }
+    const Lock::Exclusive guard(g_lock);
+    return g_names.replace(names);
+}
+
+bool find(std::uint32_t hash, Name& name) noexcept {
+    name = {};
+    const Lock::Shared guard(g_lock);
+    const std::span<const Name> rows = g_names.rows();
+    const auto found =
+        std::lower_bound(rows.begin(), rows.end(), hash, [](const Name& row, std::uint32_t key) {
+            return row.hash < key;
+        });
+    const bool present = found != rows.end() && found->hash == hash;
+    if (present) {
+        name = *found;
+    }
+    return present;
+}
+
+std::size_t count() noexcept {
+    const Lock::Shared guard(g_lock);
+    return g_names.count();
+}
+
+} // namespace sunrise::state::build_data::hash_names::overlay

--- a/Sunrise/src/state/build_data/hash_names/overlay/name_overlay_catalog.h
+++ b/Sunrise/src/state/build_data/hash_names/overlay/name_overlay_catalog.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+
+#include "../definition.h"
+
+namespace sunrise::state::build_data::hash_names::overlay {
+
+void clear() noexcept;
+
+[[nodiscard]] bool replace(std::span<const Name> names) noexcept;
+
+[[nodiscard]] bool find(std::uint32_t hash, Name& name) noexcept;
+
+[[nodiscard]] std::size_t count() noexcept;
+
+} // namespace sunrise::state::build_data::hash_names::overlay

--- a/Sunrise/src/state/build_data/hash_names/overlay/name_overlay_load.cpp
+++ b/Sunrise/src/state/build_data/hash_names/overlay/name_overlay_load.cpp
@@ -1,0 +1,191 @@
+#include "name_overlay_load.h"
+
+#include <Windows.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdio>
+#include <span>
+#include <string_view>
+
+#include "../../../../core/filesystem/path.h"
+#include "../../../../core/logging/log.h"
+#include "../definition.h"
+#include "name_overlay_catalog.h"
+
+namespace sunrise::state::build_data::hash_names::overlay {
+namespace {
+
+constexpr std::size_t kFileCapacity = 512 * 1024;
+constexpr std::uint32_t kHashBasis = 0x811C9DC5U;
+constexpr std::uint32_t kHashPrime = 0x01000193U;
+constexpr char kCommentMarker = '#';
+
+struct Report {
+    std::size_t lines{};
+    std::size_t accepted{};
+    std::size_t rejected{};
+    std::size_t collisions{};
+};
+
+[[nodiscard]] std::uint32_t hash_of(std::string_view text) noexcept {
+    std::uint32_t value = kHashBasis;
+    for (const char character : text) {
+        value = (value * kHashPrime) ^ static_cast<std::uint8_t>(character);
+    }
+    return value;
+}
+
+[[nodiscard]] std::string_view trim(std::string_view text) noexcept {
+    const auto blank = [](char value) noexcept {
+        return value == ' ' || value == '\t' || value == '\r';
+    };
+    while (!text.empty() && blank(text.front())) {
+        text.remove_prefix(1);
+    }
+    while (!text.empty() && blank(text.back())) {
+        text.remove_suffix(1);
+    }
+    return text;
+}
+
+[[nodiscard]] bool parse(std::string_view line, Name& row) noexcept {
+    row = {};
+    if (line.empty() || line.size() > kNameLength) {
+        return false;
+    }
+    for (std::size_t index = 0; index < line.size(); ++index) {
+        char value = line[index];
+        if (value >= 'A' && value <= 'Z') {
+            value = static_cast<char>(value - 'A' + 'a');
+        }
+        if (!name_character(value)) {
+            return false;
+        }
+        row.name[index] = value;
+    }
+    row.nameLength = static_cast<std::uint8_t>(line.size());
+    row.hash = hash_of({row.name.data(), row.nameLength});
+    return true;
+}
+
+[[nodiscard]] bool
+read_file(const wchar_t* path, std::span<char> buffer, std::size_t& size) noexcept {
+    size = 0;
+    const HANDLE file = CreateFileW(path,
+                                    GENERIC_READ,
+                                    FILE_SHARE_READ,
+                                    nullptr,
+                                    OPEN_EXISTING,
+                                    FILE_ATTRIBUTE_NORMAL,
+                                    nullptr);
+    if (file == INVALID_HANDLE_VALUE) {
+        return false;
+    }
+    LARGE_INTEGER measured{};
+    DWORD read = 0;
+    const bool sized = GetFileSizeEx(file, &measured) != FALSE && measured.QuadPart >= 0
+                       && static_cast<std::uint64_t>(measured.QuadPart) <= buffer.size();
+    const auto wanted = sized ? static_cast<DWORD>(measured.QuadPart) : 0;
+    const bool complete =
+        sized
+        && (wanted == 0
+            || (ReadFile(file, buffer.data(), wanted, &read, nullptr) != FALSE && read == wanted));
+    const bool closed = CloseHandle(file) != FALSE;
+    size = complete ? static_cast<std::size_t>(read) : 0;
+    return complete && closed;
+}
+
+[[nodiscard]] std::span<Name>
+build_rows(std::string_view document, std::span<Name> rows, Report& report) noexcept {
+    report = {};
+    std::size_t written = 0;
+    std::size_t start = 0;
+    for (std::size_t index = 0; index <= document.size(); ++index) {
+        if (index != document.size() && document[index] != '\n') {
+            continue;
+        }
+        const std::string_view line = trim(document.substr(start, index - start));
+        start = index + 1;
+        if (line.empty() || line.front() == kCommentMarker) {
+            continue;
+        }
+        ++report.lines;
+        Name row{};
+        if (!parse(line, row) || written >= rows.size()) {
+            ++report.rejected;
+            continue;
+        }
+        rows[written++] = row;
+    }
+    const std::span<Name> read = rows.first(written);
+    std::stable_sort(read.begin(), read.end(), [](const Name& left, const Name& right) noexcept {
+        return left.hash < right.hash;
+    });
+    std::size_t unique = 0;
+    for (std::size_t index = 0; index < read.size(); ++index) {
+        if (unique != 0 && read[unique - 1].hash == read[index].hash) {
+            if (read[unique - 1].nameLength != read[index].nameLength
+                || !std::equal(read[index].name.begin(),
+                               read[index].name.begin() + read[index].nameLength,
+                               read[unique - 1].name.begin())) {
+                ++report.collisions;
+            }
+            continue;
+        }
+        read[unique++] = read[index];
+    }
+    report.accepted = unique;
+    return read.first(unique);
+}
+
+void report_load(const Report& report, const char* result) noexcept {
+    std::array<char, core::log::kLineCapacity> line{};
+    const int written = std::snprintf(line.data(),
+                                      line.size(),
+                                      "ev=build_data stage=name_overlay lines=%zu names=%zu "
+                                      "rejected=%zu collisions=%zu result=%s",
+                                      report.lines,
+                                      report.accepted,
+                                      report.rejected,
+                                      report.collisions,
+                                      result);
+    if (written <= 0) {
+        return;
+    }
+    const bool lost = report.lines != 0 && report.accepted == 0;
+    core::log::write(core::log::Channel::state,
+                     lost ? core::log::Level::warn : core::log::Level::info,
+                     {line.data(), static_cast<std::size_t>(written)});
+}
+
+} // namespace
+
+bool load(void* module) noexcept {
+    clear();
+    if (module == nullptr) {
+        return true;
+    }
+    core::path::Buffer file;
+    if (!core::path::artifact_directory(module, file) || !core::path::append(file, kFileSuffix)) {
+        report_load({}, "path");
+        return false;
+    }
+    static std::array<char, kFileCapacity> document{};
+    static std::array<Name, kNameCapacity> rows{};
+    std::size_t size = 0;
+    if (!read_file(file.chars.data(), document, size)) {
+        report_load({}, GetLastError() == ERROR_FILE_NOT_FOUND ? "absent" : "read");
+        return true;
+    }
+    Report report{};
+    const std::span<const Name> parsed = build_rows({document.data(), size}, rows, report);
+    if (!replace(parsed)) {
+        report_load(report, "publish");
+        return false;
+    }
+    report_load(report, "ok");
+    return true;
+}
+
+} // namespace sunrise::state::build_data::hash_names::overlay

--- a/Sunrise/src/state/build_data/hash_names/overlay/name_overlay_load.h
+++ b/Sunrise/src/state/build_data/hash_names/overlay/name_overlay_load.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <string_view>
+
+namespace sunrise::state::build_data::hash_names::overlay {
+
+inline constexpr std::wstring_view kFileSuffix = L"\\bubble_names.txt";
+
+[[nodiscard]] bool load(void* module) noexcept;
+
+} // namespace sunrise::state::build_data::hash_names::overlay

--- a/Sunrise/src/state/build_data/runtime/build_data_catalog_runtime.cpp
+++ b/Sunrise/src/state/build_data/runtime/build_data_catalog_runtime.cpp
@@ -4,6 +4,7 @@
 #include "../abilities/ability_bucket_catalog.h"
 #include "../constants/investment_constant_catalog.h"
 #include "../hash_names/hash_name_catalog.h"
+#include "../hash_names/overlay/name_overlay_catalog.h"
 #include "../inventory/buckets/inventory_bucket_catalog.h"
 #include "../items/details/item_detail_catalog.h"
 #include "../progressions/progression_catalog.h"
@@ -164,7 +165,10 @@ bool publish_hash_names(std::span<const hash_names::Name> names) noexcept {
 /** Finds one bubble's internal name by its hash. */
 bool find_hash_name(std::uint32_t hash, hash_names::Name& name) noexcept {
     name = {};
-    return hash_names_ready() && hash_names::find(hash, name);
+    if (hash_names_ready() && hash_names::find(hash, name)) {
+        return true;
+    }
+    return hash_names::overlay::find(hash, name);
 }
 
 /** @return True when a complete spawn-set catalog, empty or not, is published. */


### PR DESCRIPTION
- Users can now add a bubble_names.txt into their Sunrise folder to fill out missing bubble names in Activity Override list. (users have to provide the .txt file and names themselves)
- Increased teleport max distance to 200 units. (up from 100)
- Added field_of_view option to settings.json.