### PR TITLE
Orbit slice set changing

### DIFF
--- a/Sunrise/Sunrise.vcxproj
+++ b/Sunrise/Sunrise.vcxproj
@@ -211,6 +211,7 @@
     <ClCompile Include="src\client\hooks\bootflow\orbit_handoff.cpp" />
     <ClCompile Include="src\client\hooks\bootflow\owner_activity_slot.cpp" />
     <ClCompile Include="src\client\hooks\bootflow\orbit_slice_set.cpp" />
+    <ClCompile Include="src\client\hooks\bootflow\orbit_seed.cpp" />
     <ClCompile Include="src\client\hooks\bootflow\region_private.cpp" />
     <ClCompile Include="src\client\hooks\bootflow\profile_setup_skip.cpp" />
     <ClCompile Include="src\client\hooks\bootflow\join_request_ready.cpp" />

--- a/Sunrise/resources/default_settings.json
+++ b/Sunrise/resources/default_settings.json
@@ -35,7 +35,8 @@
     "region_private": true,
     "pin_replicated_record": true,
     "hold_spawn": true,
-    "spawn_hold_ms": 30000
+    "spawn_hold_ms": 30000,
+    "orbit_slice_set": ""
   },
   "server": {
     "bap_port": 30974,

--- a/Sunrise/src/client/hooks/bootflow/bootflow_hook_lifecycle.cpp
+++ b/Sunrise/src/client/hooks/bootflow/bootflow_hook_lifecycle.cpp
@@ -19,6 +19,7 @@ std::atomic_bool g_installed{false};
 bool install() noexcept {
     const bool hold = install_character_select_hold();
     const bool sliceSet = install_orbit_slice_set();
+    const bool orbitSeed = install_orbit_seed();
     const bool skip = install_profile_setup_skip();
     const bool composition = install_composition_check();
     const bool handoff = install_orbit_handoff();
@@ -28,10 +29,10 @@ bool install() noexcept {
     const bool worldStep = install_world_step();
     const bool spawn = install_spawn_hold();
     const bool fade = install_fade_release();
-    const bool anyFix = hold || sliceSet || skip || composition || handoff || joinReady || ownerSlot
-                        || regionPrivate || worldStep || spawn || fade;
+    const bool anyFix = hold || sliceSet || orbitSeed || skip || composition || handoff
+                        || joinReady || ownerSlot || regionPrivate || worldStep || spawn || fade;
     g_installed.store(anyFix, std::memory_order_release);
-    return hold && sliceSet && skip && composition && handoff && joinReady && ownerSlot
+    return hold && sliceSet && orbitSeed && skip && composition && handoff && joinReady && ownerSlot
            && regionPrivate && worldStep && spawn && fade;
 }
 
@@ -46,6 +47,7 @@ void uninstall() noexcept {
     uninstall_orbit_handoff();
     uninstall_composition_check();
     uninstall_profile_setup_skip();
+    uninstall_orbit_seed();
     uninstall_orbit_slice_set();
     uninstall_character_select_hold();
     g_installed.store(false, std::memory_order_release);

--- a/Sunrise/src/client/hooks/bootflow/bootflow_hook_lifecycle.h
+++ b/Sunrise/src/client/hooks/bootflow/bootflow_hook_lifecycle.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#include <string_view>
+
 namespace sunrise::client::hooks::bootflow {
+
+void note_destination(std::string_view packageName) noexcept;
 
 /**
  * Attaches the boot-step fixes that carry sign-in through to character select.

--- a/Sunrise/src/client/hooks/bootflow/internal.h
+++ b/Sunrise/src/client/hooks/bootflow/internal.h
@@ -36,6 +36,10 @@ void uninstall_profile_setup_skip() noexcept;
 /** Detaches the orbit slice-set picker. */
 void uninstall_orbit_slice_set() noexcept;
 
+[[nodiscard]] bool install_orbit_seed() noexcept;
+
+void uninstall_orbit_seed() noexcept;
+
 /**
  * Attaches the solo composition fix, which clears the count the matchmaking check rejects.
  * @return True when the target is found and the detour attaches.

--- a/Sunrise/src/client/hooks/bootflow/orbit_seed.cpp
+++ b/Sunrise/src/client/hooks/bootflow/orbit_seed.cpp
@@ -1,0 +1,424 @@
+#include <Windows.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <algorithm>
+#include <string_view>
+
+#include "../../../core/filesystem/path.h"
+#include "../../../core/logging/log.h"
+#include "../../../core/settings/settings.h"
+#include "../../../state/build_data/runtime.h"
+#include "bootflow_hook_lifecycle.h"
+#include "internal.h"
+
+namespace sunrise::client::hooks::bootflow {
+namespace {
+
+constexpr std::string_view kSeedSignatureText = "E8 ? ? ? ? 4C 8B C8 BF C5 9D 1C 81";
+constexpr auto kSeedSignature =
+    signature<signature_length(kSeedSignatureText)>(kSeedSignatureText);
+
+constexpr std::size_t kSeedImmediateOffset = 9;
+constexpr std::size_t kDefaultLoadOffset = 0x43;
+constexpr std::size_t kDefaultLoadSize = 3;
+constexpr std::array<std::byte, kDefaultLoadSize> kDefaultLoadExpected{
+    std::byte{0x8B}, std::byte{0x79}, std::byte{0x14}};
+constexpr std::array<std::byte, kDefaultLoadSize> kDefaultLoadPatch{
+    std::byte{0x90}, std::byte{0x90}, std::byte{0x90}};
+
+constexpr std::wstring_view kMapFileSuffix = L"\\orbit_map.txt";
+constexpr std::size_t kMapFileCapacity = 64 * 1024;
+constexpr std::size_t kMapCapacity = 512;
+constexpr std::size_t kDestinationCapacity = 40;
+constexpr std::size_t kOrbitNameCapacity = 48;
+constexpr std::uint32_t kHashBasis = 0x811C9DC5U;
+constexpr std::uint32_t kHashPrime = 0x01000193U;
+constexpr std::string_view kOrbitPrefix = "orbit";
+
+struct MapEntry {
+    std::array<char, kDestinationCapacity> destination{};
+    std::uint8_t destinationLength{};
+    std::uint32_t orbitHash{};
+};
+
+std::array<MapEntry, kMapCapacity> g_map{};
+std::size_t g_mapCount = 0;
+std::uint32_t g_defaultHash = 0;
+std::uint32_t g_applied = 0;
+bool g_listed = false;
+SRWLOCK g_lock = SRWLOCK_INIT;
+
+std::byte* g_immediate = nullptr;
+std::byte* g_defaultLoad = nullptr;
+std::uint32_t g_originalSeed = 0;
+std::array<std::byte, kDefaultLoadSize> g_originalLoad{};
+
+[[nodiscard]] bool write_bytes(std::byte* address, const void* source, std::size_t size) noexcept {
+    DWORD previous = 0;
+    if (VirtualProtect(address, size, PAGE_EXECUTE_READWRITE, &previous) == FALSE) {
+        return false;
+    }
+    std::memcpy(address, source, size);
+    DWORD restored = 0;
+    const bool reset = VirtualProtect(address, size, previous, &restored) != FALSE;
+    (void)FlushInstructionCache(GetCurrentProcess(), address, size);
+    return reset;
+}
+
+[[nodiscard]] std::uint32_t hash_of(std::string_view text) noexcept {
+    std::uint32_t value = kHashBasis;
+    for (const char character : text) {
+        value = (value * kHashPrime) ^ static_cast<std::uint8_t>(character);
+    }
+    return value;
+}
+
+[[nodiscard]] std::string_view trim(std::string_view text) noexcept {
+    const auto blank = [](char value) noexcept {
+        return value == ' ' || value == '\t' || value == '\r';
+    };
+    while (!text.empty() && blank(text.front())) {
+        text.remove_prefix(1);
+    }
+    while (!text.empty() && blank(text.back())) {
+        text.remove_suffix(1);
+    }
+    return text;
+}
+
+[[nodiscard]] bool lowercase_name(std::string_view text, std::size_t limit,
+                                  std::array<char, kOrbitNameCapacity>& output,
+                                  std::uint8_t& length) noexcept {
+    output = {};
+    length = 0;
+    if (text.empty() || text.size() > limit) {
+        return false;
+    }
+    for (std::size_t index = 0; index < text.size(); ++index) {
+        char value = text[index];
+        if (value >= 'A' && value <= 'Z') {
+            value = static_cast<char>(value - 'A' + 'a');
+        }
+        const bool usable = (value >= 'a' && value <= 'z') || (value >= '0' && value <= '9')
+                            || value == '_';
+        if (!usable) {
+            return false;
+        }
+        output[index] = value;
+    }
+    length = static_cast<std::uint8_t>(text.size());
+    return true;
+}
+
+void load_map(void* module) noexcept {
+    g_mapCount = 0;
+    core::path::Buffer file;
+    if (!core::path::artifact_directory(module, file)
+        || !core::path::append(file, kMapFileSuffix)) {
+        return;
+    }
+    const HANDLE handle = CreateFileW(file.chars.data(),
+                                      GENERIC_READ,
+                                      FILE_SHARE_READ,
+                                      nullptr,
+                                      OPEN_EXISTING,
+                                      FILE_ATTRIBUTE_NORMAL,
+                                      nullptr);
+    if (handle == INVALID_HANDLE_VALUE) {
+        return;
+    }
+    static std::array<char, kMapFileCapacity> document{};
+    LARGE_INTEGER measured{};
+    DWORD read = 0;
+    const bool sized = GetFileSizeEx(handle, &measured) != FALSE && measured.QuadPart >= 0
+                       && static_cast<std::uint64_t>(measured.QuadPart) <= document.size();
+    const auto wanted = sized ? static_cast<DWORD>(measured.QuadPart) : 0;
+    const bool complete =
+        sized
+        && (wanted == 0
+            || (ReadFile(handle, document.data(), wanted, &read, nullptr) != FALSE
+                && read == wanted));
+    (void)CloseHandle(handle);
+    if (!complete) {
+        return;
+    }
+
+    const std::string_view text(document.data(), read);
+    std::size_t start = 0;
+    std::size_t rejected = 0;
+    for (std::size_t index = 0; index <= text.size(); ++index) {
+        if (index != text.size() && text[index] != '\n') {
+            continue;
+        }
+        const std::string_view line = trim(text.substr(start, index - start));
+        start = index + 1;
+        if (line.empty() || line.front() == '#') {
+            continue;
+        }
+        const std::size_t split = line.find('=');
+        if (split == std::string_view::npos || g_mapCount >= g_map.size()) {
+            ++rejected;
+            continue;
+        }
+        std::array<char, kOrbitNameCapacity> destination{};
+        std::array<char, kOrbitNameCapacity> orbit{};
+        std::uint8_t destinationLength = 0;
+        std::uint8_t orbitLength = 0;
+        if (!lowercase_name(trim(line.substr(0, split)), kDestinationCapacity, destination,
+                            destinationLength)
+            || !lowercase_name(trim(line.substr(split + 1)), kOrbitNameCapacity, orbit,
+                               orbitLength)) {
+            ++rejected;
+            continue;
+        }
+        MapEntry& entry = g_map[g_mapCount++];
+        entry = {};
+        std::copy_n(destination.begin(), destinationLength, entry.destination.begin());
+        entry.destinationLength = destinationLength;
+        entry.orbitHash = hash_of({orbit.data(), orbitLength});
+    }
+
+    std::array<char, core::log::kLineCapacity> line{};
+    const int written = std::snprintf(line.data(),
+                                      line.size(),
+                                      "ev=bootflow stage=orbit_map pairs=%zu rejected=%zu",
+                                      g_mapCount,
+                                      rejected);
+    if (written > 0) {
+        core::log::write(core::log::Channel::client,
+                         core::log::Level::info,
+                         {line.data(), static_cast<std::size_t>(written)});
+    }
+}
+
+void list_stems() noexcept {
+    if (g_listed || !state::build_data::scenario_layouts_ready()) {
+        return;
+    }
+    g_listed = true;
+    HMODULE self = nullptr;
+    if (GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS
+                               | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                           reinterpret_cast<LPCWSTR>(&list_stems),
+                           &self)
+        == FALSE) {
+        return;
+    }
+    core::path::Buffer file;
+    if (!core::path::artifact_directory(self, file)
+        || !core::path::append(file, L"\\orbit_stems.txt")) {
+        return;
+    }
+    static std::array<state::build_data::scenarios::Definition,
+                      state::build_data::scenarios::kDefinitionCapacity>
+        layouts{};
+    std::size_t count = 0;
+    if (!state::build_data::snapshot_scenario_layouts(layouts, count)) {
+        return;
+    }
+    const HANDLE handle = CreateFileW(file.chars.data(),
+                                      GENERIC_WRITE,
+                                      0,
+                                      nullptr,
+                                      CREATE_ALWAYS,
+                                      FILE_ATTRIBUTE_NORMAL,
+                                      nullptr);
+    if (handle == INVALID_HANDLE_VALUE) {
+        return;
+    }
+    std::array<char, 256> row{};
+    for (std::size_t index = 0; index < count; ++index) {
+        const state::build_data::scenarios::Definition& layout = layouts[index];
+        const int written = std::snprintf(row.data(),
+                                          row.size(),
+                                          "%.*s = %.*s\r\n",
+                                          static_cast<int>(layout.nameLength),
+                                          layout.name.data(),
+                                          static_cast<int>(layout.spawnStemLength),
+                                          layout.spawnStem.data());
+        if (written <= 0) {
+            continue;
+        }
+        DWORD wrote = 0;
+        (void)WriteFile(handle, row.data(), static_cast<DWORD>(written), &wrote, nullptr);
+    }
+    (void)CloseHandle(handle);
+    std::array<char, core::log::kLineCapacity> line{};
+    const int written = std::snprintf(line.data(),
+                                      line.size(),
+                                      "ev=bootflow stage=orbit_stems rows=%zu",
+                                      count);
+    if (written > 0) {
+        core::log::write(core::log::Channel::client,
+                         core::log::Level::info,
+                         {line.data(), static_cast<std::size_t>(written)});
+    }
+}
+
+[[nodiscard]] bool match_name(std::string_view candidate, std::uint32_t& hash) noexcept {
+    std::array<char, kOrbitNameCapacity> wanted{};
+    std::uint8_t length = 0;
+    if (!lowercase_name(candidate, kDestinationCapacity, wanted, length)) {
+        return false;
+    }
+    const std::string_view name(wanted.data(), length);
+    std::size_t best = 0;
+    for (std::size_t index = 0; index < g_mapCount; ++index) {
+        const MapEntry& entry = g_map[index];
+        const std::string_view key(entry.destination.data(), entry.destinationLength);
+        if (key.size() > name.size() || name.compare(0, key.size(), key) != 0) {
+            continue;
+        }
+        if (key.size() != name.size() && name[key.size()] != '_') {
+            continue;
+        }
+        if (key.size() > best) {
+            best = key.size();
+            hash = entry.orbitHash;
+        }
+    }
+    return best != 0;
+}
+
+[[nodiscard]] std::string_view stem_of(std::string_view packageName) noexcept {
+    static state::build_data::scenarios::Definition layout{};
+    layout = {};
+    if (!state::build_data::find_scenario_layout(packageName, layout)) {
+        return {};
+    }
+    return {layout.spawnStem.data(), layout.spawnStemLength};
+}
+
+void report(std::uint32_t hash, const char* result) noexcept {
+    std::array<char, core::log::kLineCapacity> line{};
+    const int written = std::snprintf(line.data(),
+                                      line.size(),
+                                      "ev=bootflow stage=orbit_seed hash=0x%08X result=%s",
+                                      hash,
+                                      result);
+    if (written > 0) {
+        core::log::write(core::log::Channel::client,
+                         std::string_view(result) == "ok" ? core::log::Level::info
+                                                          : core::log::Level::warn,
+                         {line.data(), static_cast<std::size_t>(written)});
+    }
+}
+
+} // namespace
+
+bool install_orbit_seed() noexcept {
+    if (g_immediate != nullptr) {
+        return true;
+    }
+    const std::uint32_t hash = core::settings::get().client.orbitSliceSetHash;
+    if (hash == 0) {
+        return true;
+    }
+    std::byte* const match = scan_main_image_unique(kSeedSignature, "orbit_slice_set_seed");
+    if (match == nullptr) {
+        report(hash, "target");
+        return false;
+    }
+    std::byte* const immediate = match + kSeedImmediateOffset;
+    std::byte* const defaultLoad = match + kDefaultLoadOffset;
+    std::array<std::byte, kDefaultLoadSize> present{};
+    std::memcpy(present.data(), defaultLoad, present.size());
+    if (present != kDefaultLoadExpected) {
+        report(hash, "shape");
+        return false;
+    }
+    std::uint32_t previousSeed = 0;
+    std::memcpy(&previousSeed, immediate, sizeof previousSeed);
+    if (!write_bytes(immediate, &hash, sizeof hash)) {
+        report(hash, "write");
+        return false;
+    }
+    if (!write_bytes(defaultLoad, kDefaultLoadPatch.data(), kDefaultLoadPatch.size())) {
+        (void)write_bytes(immediate, &previousSeed, sizeof previousSeed);
+        report(hash, "write");
+        return false;
+    }
+    g_immediate = immediate;
+    g_defaultLoad = defaultLoad;
+    g_originalSeed = previousSeed;
+    g_originalLoad = present;
+    g_defaultHash = hash;
+    g_applied = hash;
+    HMODULE self = nullptr;
+    if (GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS
+                               | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                           reinterpret_cast<LPCWSTR>(&install_orbit_seed),
+                           &self)
+        != FALSE) {
+        load_map(self);
+    }
+    report(hash, "ok");
+    return true;
+}
+
+void note_destination(std::string_view packageName) noexcept {
+    AcquireSRWLockExclusive(&g_lock);
+    if (g_immediate == nullptr) {
+        ReleaseSRWLockExclusive(&g_lock);
+        return;
+    }
+    list_stems();
+    if (packageName.size() >= kOrbitPrefix.size()
+        && packageName.compare(0, kOrbitPrefix.size(), kOrbitPrefix) == 0) {
+        ReleaseSRWLockExclusive(&g_lock);
+        return;
+    }
+    const std::string_view stem = stem_of(packageName);
+    std::uint32_t wanted = g_defaultHash;
+    const char* source = "default";
+    if (match_name(packageName, wanted)) {
+        source = "name";
+    } else if (!stem.empty() && match_name(stem, wanted)) {
+        source = "stem";
+    }
+    bool wrote = false;
+    if (wanted != 0 && wanted != g_applied && write_bytes(g_immediate, &wanted, sizeof wanted)) {
+        g_applied = wanted;
+        wrote = true;
+    }
+    std::array<char, core::log::kLineCapacity> line{};
+    const int written = std::snprintf(line.data(),
+                                      line.size(),
+                                      "ev=bootflow stage=orbit_follow from=%.*s stem=%.*s "
+                                      "hash=0x%08X source=%s changed=%u",
+                                      static_cast<int>(packageName.size()),
+                                      packageName.data(),
+                                      static_cast<int>(stem.size()),
+                                      stem.data(),
+                                      wanted,
+                                      source,
+                                      wrote ? 1U : 0U);
+    ReleaseSRWLockExclusive(&g_lock);
+    if (written > 0) {
+        core::log::write(core::log::Channel::client,
+                         core::log::Level::info,
+                         {line.data(), static_cast<std::size_t>(written)});
+    }
+}
+
+void uninstall_orbit_seed() noexcept {
+    if (g_immediate == nullptr) {
+        return;
+    }
+    (void)write_bytes(g_defaultLoad, g_originalLoad.data(), g_originalLoad.size());
+    (void)write_bytes(g_immediate, &g_originalSeed, sizeof g_originalSeed);
+    g_immediate = nullptr;
+    g_defaultLoad = nullptr;
+    g_originalSeed = 0;
+    g_originalLoad = {};
+    g_mapCount = 0;
+    g_defaultHash = 0;
+    g_applied = 0;
+    g_listed = false;
+}
+
+} // namespace sunrise::client::hooks::bootflow

--- a/Sunrise/src/core/settings/client/client_settings_parser.cpp
+++ b/Sunrise/src/core/settings/client/client_settings_parser.cpp
@@ -1,6 +1,31 @@
 #include "../parser.h"
 
 namespace sunrise::core::settings::parser {
+namespace {
+
+constexpr std::uint32_t kHashBasis = 0x811C9DC5U;
+constexpr std::uint32_t kHashPrime = 0x01000193U;
+
+[[nodiscard]] std::uint32_t orbit_hash(std::string_view name) noexcept {
+    if (name.empty() || name.size() > 48) {
+        return 0;
+    }
+    std::uint32_t value = kHashBasis;
+    for (char character : name) {
+        if (character >= 'A' && character <= 'Z') {
+            character = static_cast<char>(character - 'A' + 'a');
+        }
+        const bool usable = (character >= 'a' && character <= 'z')
+                            || (character >= '0' && character <= '9') || character == '_';
+        if (!usable) {
+            return 0;
+        }
+        value = (value * kHashPrime) ^ static_cast<std::uint8_t>(character);
+    }
+    return value;
+}
+
+} // namespace
 
 /** Parses Client-owned configuration over deterministic defaults. */
 bool Parser::client_settings(client::Settings& output) noexcept {
@@ -16,6 +41,7 @@ bool Parser::client_settings(client::Settings& output) noexcept {
     bool hasPinReplicatedRecord = false;
     bool hasHoldSpawn = false;
     bool hasSpawnHoldMs = false;
+    bool hasOrbitSliceSet = false;
     if (consume('}')) {
         return true;
     }
@@ -67,6 +93,16 @@ bool Parser::client_settings(client::Settings& output) noexcept {
             }
             candidate.spawnHoldMs = value;
             hasSpawnHoldMs = true;
+        } else if (key == "orbit_slice_set") {
+            std::string_view name;
+            if (hasOrbitSliceSet || !string(name)) {
+                return false;
+            }
+            if (!name.empty() && orbit_hash(name) == 0) {
+                return false;
+            }
+            candidate.orbitSliceSetHash = orbit_hash(name);
+            hasOrbitSliceSet = true;
         } else if (!skip_value(0)) {
             return false;
         }

--- a/Sunrise/src/core/settings/client/definition.h
+++ b/Sunrise/src/core/settings/client/definition.h
@@ -49,6 +49,7 @@ struct Settings {
     bool holdSpawn{true};
     /** How long the spawn waits for a load. `hold_spawn` decides whether it waits at all. */
     std::uint64_t spawnHoldMs{kDefaultSpawnHoldMs};
+    std::uint32_t orbitSliceSetHash{};
 };
 
 } // namespace sunrise::core::settings::client

--- a/Sunrise/src/server/bap/encrypted/activity_host_manager/activity_host_manager_route.cpp
+++ b/Sunrise/src/server/bap/encrypted/activity_host_manager/activity_host_manager_route.cpp
@@ -12,6 +12,7 @@ activity_manager_selection_parser.h"
 #include "../../../../middleware/bap/activity_host_manager/response/activity_manager_response.h"
 #include "../../../../state/activity/defaults/activity_defaults_snapshot.h"
 #include "../../../../state/activity/forced/activity_forced_destination.h"
+#include "../../../../client/hooks/bootflow/bootflow_hook_lifecycle.h"
 #include "../../../../state/activity/runtime.h"
 #include "../../../../state/build_data/runtime.h"
 
@@ -168,6 +169,9 @@ prepare_allocation(const request_selection::ActivityManagerSelectionResult& pars
     if (state::activity::forced::apply(destination)) {
         report_forced(destination);
     }
+    client::hooks::bootflow::note_destination(
+        {reinterpret_cast<const char*>(destination.packageName.data()),
+         destination.packageNameLength});
     return state::activity::prepare_session(destination, sessionId, allocation);
 }
 


### PR DESCRIPTION
This feature adds the ability to set a default orbit bubble when first starting up (in settings.json) as well as orbit bubble swapping based on last destination visited.

Users will need to provide orbit bubble strings themselves to enter into the settings.json for default orbit. And will also need to provide their own bubble_map.txt file structured with package names and their respective orbit bubbles. This .txt file would go into the Sunrise folder and is setup in a way users can customize what orbit bubble is loaded after each visited destination.

For ex:
tangled_shore = orbit_reef_d2
advent_summer_event = orbit_earth_d2

But you can also get creative with it and do:
tangled_shore = orbit_venus_d2

An orbit_stems.txt file will be created when launching Sunrise with the purpose of referencing which activities in the game belong to which package. (I'm sure there's an easier alternative but this is what I got for now)