### PR TITLE
Fix inventory replacements keeping their ordering

### DIFF
--- a/Sunrise/src/state/runtime/state_account_runtime.cpp
+++ b/Sunrise/src/state/runtime/state_account_runtime.cpp
@@ -256,6 +256,33 @@ bool prepare_equipment_swap(std::uint64_t requestedInstanceSoid,
         return false;
     }
 
+    if (previousInstanceSoid != 0) {
+        // The serial on an unequipped row is also the Client's stable ordering token for that
+        // bucket.  Giving the displaced item a fresh, greatest serial makes the Client rebuild it
+        // in the first grid cell even though the character object places it in the selected row.
+        // Transfer the selected row's prior token along with the row instead: the newly equipped
+        // item still has a fresh generation, while the displaced item occupies the grid cell the
+        // player clicked.
+        authored_inventory::Item& displaced = after.inventory.values[inventoryIndex];
+        if (displaced.instanceSoid != previousInstanceSoid) {
+            return false;
+        }
+        displaced.mutationSerial = requestedPosition.mutationSerial;
+
+        AccountState checkedAccount = account;
+        checkedAccount.characters[characterIndex] = after;
+        family4_loadout::ResolvedLoadout checkedLoadout{};
+        ResolvedPosition displacedPosition{};
+        if (!account::valid(checkedAccount)
+            || !family4_loadout::resolve(checkedAccount, characterIndex, checkedLoadout)
+            || !find_resolved_position(checkedLoadout, previousInstanceSoid, displacedPosition)
+            || displacedPosition.equipped || displacedPosition.equipmentSlot != requestedNativeSlot
+            || displacedPosition.inventoryRow != requestedPosition.inventoryRow
+            || displacedPosition.mutationSerial != requestedPosition.mutationSerial) {
+            return false;
+        }
+    }
+
     mutation.beforeCharacter = before;
     mutation.afterCharacter = after;
     mutation.characterSoid = before.soid;


### PR DESCRIPTION
I noticed on the latest update, when switching equipped weapon, the order gets reset (if I equip a weapon in the third slot in my inventory, the unequipped weapon goes into the first slot no matter what). See video below for current behavior:


https://github.com/user-attachments/assets/80e9e9c8-401c-4eaf-8452-d74dc0b05181

My change matches both the live game and Shadowkeep way back when where an unequipped weapon will replace the new weapon being equipped. Fixed behavior:


https://github.com/user-attachments/assets/8ea929e2-03f6-45a7-878c-2b1a095d2705

And working with full inventory:

https://github.com/user-attachments/assets/d15fca15-0af1-4a64-b450-364a62b77529

Note that I wasn't sure about the mutationSerial and its docs as described in the code. I think the way it was described is incorrect, since setting the mutationSerial like I do here works for preserving the order after switching weapons. I think it might also act as a position index? Maybe other maintainers can confirm? Thanks for the great work y'all!

Edit: also wanted to add the Shadowkeep video example. At 31:22 in this video, the player switches weapons matching the live game behavior. https://www.youtube.com/watch?v=3w_bYQiG0i0