### PR TITLE
Keep the software mouse cursor visible below 1920x1080

### DIFF
--- a/Sunrise/src/core/ui/theme/sunrise_ui_theme.cpp
+++ b/Sunrise/src/core/ui/theme/sunrise_ui_theme.cpp
@@ -1,5 +1,6 @@
 #include "sunrise_ui_theme.h"
 
+#include <algorithm>
 #include <imgui.h>
 
 #include "../scaling/dpi/ui_dpi_scaling.h"
@@ -107,6 +108,9 @@ void apply() noexcept {
     // Scaling a fresh default style stops repeated monitor changes from building up error.
     const float scale = scaling::dpi::current();
     style.ScaleAllSizes(scale);
+    // ScaleAllSizes truncates this one to a whole number, so any factor below 1 zeroes it and the
+    // cursor draws with no area. Below the authored geometry it holds its authored size instead.
+    style.MouseCursorScale = (std::max)(1.0F, style.MouseCursorScale);
     style.FontSizeBase = fontSizeBase;
     style.FontScaleMain = scale;
     ImGui::GetStyle() = style;


### PR DESCRIPTION
The mouse pointer disappears while a Sunrise surface is open on any display smaller than the authored geometry. It is still drawn, but with no area.

## Cause

`ImGuiStyle::ScaleAllSizes` truncates the cursor scale to a whole number (`imgui.cpp`):

```c
MouseCursorScale = ImTrunc(MouseCursorScale * scale_factor);
```

It starts at `1`, so **every scale factor below `1` leaves it at `0`**, and `RenderMouseCursor` draws the cursor into a rectangle of zero size:

```c
draw_list->AddImage(tex_ref, pos, pos + size * scale, uv[0], uv[1], col_fill);
```

The atlas still carries the cursor and `io.MousePos` is still correct, which is why the interface stays usable while looking broken: buttons highlight and clicks land, with nothing on screen to aim them by.

## Range

`theme::apply()` scales a fresh default style by `scaling::dpi::current()`, which measures the viewport against the authored 1920x1080. Values from that calculation at 96 DPI:

| viewport | scale | `MouseCursorScale` | cursor |
|---|---|---|---|
| 3840x2160 | 1.969 | 1 | visible |
| 2560x1440 | 1.500 | 1 | visible |
| 1920x1080 | 1.125 | 1 | visible |
| 1600x900 | 0.938 | 0 | invisible |
| 1366x768 | 0.900 | 0 | invisible |
| 1280x720 | 0.900 | 0 | invisible |

This is why it can look like a borderless-only bug: exclusive fullscreen usually runs at the monitor resolution and escapes it, a smaller borderless or windowed viewport does not. The viewport size decides it, not the display mode.

## Change

One line in `theme::apply()`, after the existing scaling:

```c
style.MouseCursorScale = (std::max)(1.0F, style.MouseCursorScale);
```

Only the rows that truncated to `0` are affected; the three above the baseline keep the `1` they already had, and no other style value is touched.

## Testing

In game at 1280x720 borderless, where the pointer was missing and now follows the mouse, and at 1920x1080 fullscreen, which was already correct and is unchanged.