### PR TITLE
ci: add a clang-format check

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,34 @@
+name: Format
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  format:
+    name: clang-format
+    # Formatting does not depend on the platform, so this does not need the Windows image the
+    # build runs on.
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install clang-format
+        # Pinned, because clang-format changes its line breaking between releases and an
+        # unpinned tool would start failing runs that no commit caused. Every 20.1.x release
+        # leaves this tree untouched. 19 disagrees on one file and 21 on two, so moving the
+        # pin off 20.1 means reformatting those first.
+        run: pip install clang-format==20.1.8
+
+      - name: Check formatting
+        # Sunrise/vendor is third party and keeps the formatting it ships with.
+        # Formatting in place and then diffing prints the exact edit a contributor has to make,
+        # which the tool's own --dry-run report does not.
+        run: |
+          find Sunrise/src Sunrise/resources \( -name '*.cpp' -o -name '*.h' \) -print0 \
+            | xargs -0 -r clang-format -i --style=file
+          git diff --exit-code


### PR DESCRIPTION
## What

Adds `.github/workflows/format.yml`, a second workflow that runs clang-format over `Sunrise/src`
and `Sunrise/resources` and fails when a file is not formatted.

## Why

The contributing rules ask for the provided clang-format config to be followed, but nothing
enforced it, so every pull request had to be checked by hand.

## Effects

- **No source file changes.** The tree is already conformant under the pinned version, so the
  check is green on `master` as it stands.
- Runs on `ubuntu-latest` rather than the Windows image, because formatting does not depend on
  the platform. It costs well under a minute and does not touch the release build.
- `Sunrise/vendor` is excluded and keeps the formatting it ships with.
- On failure it prints the exact diff to apply, rather than a list of line numbers.

## About the pinned version

clang-format changes its line breaking between releases, so an unpinned tool would start failing
runs that no commit caused. I measured all 1073 files of the tree at 48d0e05 against several
releases:

| clang-format | files it would reformat |
| --- | --- |
| 18.1.8 | 1: `core/ui/scaling/dpi/ui_dpi_scaling.cpp` |
| 19.1.7 | 1: the same file |
| **20.1.0 to 20.1.8** | **0** |
| 21.1.8 | 2: `client/hooks/network/bubble_authority/bubble_authority_replacements.cpp`, `client/hooks/queuez/svc123_null_payload_guard.cpp` |
| 22.1.8 | 2: the same two |

20.1 is the line that agrees with the tree, so that is what the workflow pins. Moving the pin to
21 or later means reformatting those two files first, which belongs in its own pull request.

## How it was verified

Two runs on my fork, on the same gate:

- [unmodified tree](https://github.com/Kalivins/Sunrise/actions/runs/32158530112), green
- [same tree plus one deliberate misformat](https://github.com/Kalivins/Sunrise/actions/runs/32158678208), red, printing the diff

so a green run means something rather than the check silently passing.

## Not included

clang-tidy. It needs a compilation database and a full Windows build, which is a much larger
change, and the rules ask for one feature per pull request. Glad to follow up with it separately
if you want it.
