### PR TITLE
Fix C1060 (compiler out of heap space) by forcing the 64-bit compiler host

### DIFF
--- a/Sunrise/Sunrise.vcxproj
+++ b/Sunrise/Sunrise.vcxproj
@@ -16,6 +16,7 @@
     <RootNamespace>sunrise</RootNamespace>
     <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <ProjectName>Sunrise</ProjectName>
+    <PreferredToolArchitecture>x64</PreferredToolArchitecture>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">


### PR DESCRIPTION
﻿## Problem
A stock `msbuild Sunrise.sln /p:Configuration=Release /p:Platform=x64` build dies on `physics_state_runtime.cpp`:

```
error C1060: compiler is out of heap space
This diagnostic occurred in the compiler generated function '...::Storage::Storage(void)'
```

The default x86-**hosted** cl.exe is capped at ~4 GB of address space per process, and the compiler-generated `Storage` constructor in that TU blows past it. System RAM doesn't help - this reproduces on an 80 GB machine.

## Fix
One line: `<PreferredToolArchitecture>x64</PreferredToolArchitecture>` in the project Globals, so MSBuild always uses the x64-hosted toolchain. With it, the file compiles fine and the full Release|x64 build succeeds.

- No change to the produced `steam_api64.dll`
- MSBuild/Windows only; the CMake / Linux cross-build path is untouched
- Same effect as passing `/p:PreferredToolArchitecture=x64` on every build invocation, but nobody has to know to do that

Happy to move this to a `Directory.Build.props` instead if you'd prefer it kept out of the vcxproj.
