### PR TITLE
feat: Add persistence across user sessions

### DIFF
--- a/Sunrise/Sunrise.vcxproj
+++ b/Sunrise/Sunrise.vcxproj
@@ -376,6 +376,7 @@
     <ClCompile Include="src\steam\interfaces\tables\table_runtime.cpp" />
     <ClCompile Include="src\steam\interfaces\steam_interface_factory.cpp" />
     <ClCompile Include="src\state\runtime\state_runtime.cpp" />
+    <ClCompile Include="src\state\runtime\persistence\runtime_state_file.cpp" />
     <ClCompile Include="src\state\activity\activity_session_lookup.cpp" />
     <ClCompile Include="src\state\activity\activity_world_arrival.cpp" />
     <ClCompile Include="src\state\activity\membership\activity_membership_query.cpp" />
@@ -1006,6 +1007,7 @@
     <ClInclude Include="src\state\runtime\state_rolled_socket_plugs.h" />
     <ClInclude Include="src\state\runtime\state.h" />
     <ClInclude Include="src\state\runtime\storage\internal.h" />
+    <ClInclude Include="src\state\runtime\persistence\runtime_state_file.h" />
     <ClInclude Include="src\state\activity\definition.h" />
     <ClInclude Include="src\state\activity\defaults\definition.h" />
     <ClInclude Include="src\state\activity\defaults\activity_defaults_snapshot.h" />

--- a/Sunrise/src/core/runtime/core_runtime.cpp
+++ b/Sunrise/src/core/runtime/core_runtime.cpp
@@ -14,6 +14,7 @@
 #include "../../server/runtime/server_runtime.h"
 #include "../../state/content_manifest/content_manifest_state_runtime.h"
 #include "../../state/entitlements/entitlement_runtime.h"
+#include "../../state/runtime/persistence/runtime_state_file.h"
 #include "../../state/runtime/runtime.h"
 #include "../../state/unlocks/unlocks_runtime.h"
 #include "../filesystem/path.h"
@@ -127,6 +128,13 @@ bool initialize(void* module) noexcept {
         } else if (!client::initialize(module)) {
             stage = "client";
         }
+    }
+    if (stage == nullptr) {
+        // The overlay carries the player's saved loadout on top of the authored account. It is
+        // deliberately not a boot stage: a bad overlay is reported and skipped, because losing a
+        // session's changes is worth far less than refusing to start. Nothing between State coming
+        // up and here reads the account, so applying it this late is safe.
+        state::persistence::load(module);
     }
     if (stage != nullptr) {
         report_stage_failure(stage);

--- a/Sunrise/src/state/runtime/persistence/runtime_state_file.cpp
+++ b/Sunrise/src/state/runtime/persistence/runtime_state_file.cpp
@@ -1,0 +1,463 @@
+#include "runtime_state_file.h"
+
+#include <Windows.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <optional>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
+#include "../../../core/filesystem/path.h"
+#include "../../../core/logging/log.h"
+#include "../../account/account_state.h"
+#include "../runtime.h"
+#include "../storage/internal.h"
+
+namespace sunrise::state::persistence {
+namespace {
+
+namespace authored = account::inventory;
+
+/** The overlay sits beside settings.json in the owned folder, as build_data.bin already does. */
+constexpr std::wstring_view kFileSuffix = L"\\runtime-state.bin";
+/** Sibling the write lands on before it is renamed over the target. */
+constexpr std::wstring_view kTemporarySuffix = L"\\runtime-state.bin.tmp";
+/** Identifies the file before a single byte of it is trusted. */
+constexpr std::uint32_t kMagic = 0x53525354U;
+/**
+ * On-disk layout version. Raise it whenever a record below changes shape.
+ *
+ * A version this reader does not know drops the overlay and boots the authored account, which is
+ * the safe direction. There are no older versions to migrate from yet, so an unknown version is
+ * simply refused.
+ */
+constexpr std::uint32_t kVersion = 1;
+
+#pragma pack(push, 1)
+
+/**
+ * One item, written field by field rather than as its in-memory shape.
+ *
+ * The in-memory item is not trivially copyable and its layout is free to change, so every field is
+ * named here. That is what lets the struct above be edited without silently invalidating files.
+ */
+struct ItemRecord {
+    std::uint64_t instanceSoid{};
+    std::uint32_t definitionHash{};
+    std::int32_t level{};
+    std::int32_t quantity{};
+    std::int32_t mutationSerial{};
+    std::uint32_t flags{};
+    /** 0 leaves the slot empty; the remaining fields are then ignored. */
+    std::uint8_t present{};
+    std::uint8_t socketPolicy{};
+    std::uint8_t movementAbilityEntry{};
+    std::uint8_t grenadeAbilityEntry{};
+    std::uint8_t superAbilityEntry{};
+    std::uint8_t meleeAbilityEntry{};
+    std::uint8_t classAbilityEntry{};
+    /**
+     * Authoritative plug count, separate from plugPresent.
+     *
+     * `valid(Sockets)` rejects any plug at or past this count, so restoring the plugs without it
+     * fails every item that carries one. plugPresent cannot stand in for it: a count may cover a
+     * socket whose plug is empty.
+     */
+    std::uint8_t plugCount{};
+    std::array<std::uint32_t, authored::kPlugCapacity> plugs{};
+    std::array<std::uint8_t, authored::kPlugCapacity> plugPresent{};
+};
+
+/** One account-wide stack. */
+struct ProfileItemRecord {
+    std::uint64_t instanceSoid{};
+    std::uint32_t definitionHash{};
+    std::int32_t quantity{};
+    std::int32_t mutationSerial{};
+    /** Slack, so one more field can be added without moving every record after it. */
+    std::int32_t reserved{};
+};
+
+/**
+ * The mutable half of the account itself.
+ *
+ * Balances live here rather than on a character because profile items are account-wide. Without
+ * this record a dismantle's reward and a reacquisition's charge both evaporate at the next boot,
+ * which reads like the economy having never run.
+ */
+struct AccountRecord {
+    std::uint64_t accountSoid{};
+    std::uint32_t profileItemCount{};
+    std::uint32_t reserved{};
+    std::array<ProfileItemRecord, authored::kProfileItemCapacity> profileItems{};
+};
+
+/** The mutable half of one character. Identity and appearance stay authored. */
+struct CharacterRecord {
+    std::uint64_t characterSoid{};
+    /** Runtime-only mask of ability entries the player has selected at least once. */
+    std::uint64_t acquiredSubclassAbilityMask{};
+    std::uint32_t nextInventorySerial{};
+    std::uint32_t inventoryCount{};
+    std::uint32_t lastOrbitedDestination{};
+    /** Slack, so one more field can be added without moving every record after it. */
+    std::uint32_t reserved{};
+    std::array<ItemRecord, authored::kEquipmentSlotCount> equipment{};
+    std::array<ItemRecord, authored::kCharacterItemCapacity> inventory{};
+};
+
+/** Fixed prefix, checked in full before any record is read. */
+struct Header {
+    std::uint32_t magic{};
+    std::uint32_t version{};
+    std::uint32_t characterCount{};
+    /** Slack, so one more header field can be added without moving the records after it. */
+    std::uint32_t reserved{};
+};
+
+#pragma pack(pop)
+
+static_assert(std::is_trivially_copyable_v<ItemRecord>);
+static_assert(std::is_trivially_copyable_v<ProfileItemRecord>);
+static_assert(std::is_trivially_copyable_v<AccountRecord>);
+static_assert(std::is_trivially_copyable_v<CharacterRecord>);
+static_assert(std::is_trivially_copyable_v<Header>);
+
+/** The account record sits between the header and the character array. */
+constexpr std::size_t kAccountOffset = sizeof(Header);
+/** Character records start after the single account record. */
+constexpr std::size_t kCharacterOffset = kAccountOffset + sizeof(AccountRecord);
+/**
+ * Largest overlay worth reading into memory.
+ *
+ * Derived from the format rather than picked: a full account at capacity is exactly this size, so
+ * anything larger is not an overlay whatever else it is. The load below still requires an exact
+ * size for the character count it declares; this only bounds the read itself.
+ */
+constexpr std::size_t kMaximumSize =
+    kCharacterOffset + (kCharacterCapacity * sizeof(CharacterRecord));
+
+/** Resolved once at load and reused by every save. Empty until a load has run. */
+core::path::Buffer g_path{};
+core::path::Buffer g_temporaryPath{};
+bool g_pathResolved{};
+
+/** @param stage Which half ran. @param reason Short key naming the outcome. */
+void report(const char* stage, const char* reason) noexcept {
+    std::array<char, 128> line{};
+    const int written =
+        std::snprintf(line.data(), line.size(), "ev=persist stage=%s result=%s", stage, reason);
+    if (written > 0) {
+        core::log::write(core::log::Channel::state,
+                         core::log::Level::info,
+                         {line.data(), static_cast<std::size_t>(written)});
+    }
+}
+
+/** Copies one item into its on-disk record. */
+[[nodiscard]] ItemRecord to_record(const authored::Item& item) noexcept {
+    ItemRecord record{};
+    record.present = 1;
+    record.instanceSoid = item.instanceSoid;
+    record.definitionHash = item.definitionHash;
+    record.level = item.level;
+    record.quantity = item.quantity;
+    record.mutationSerial = item.mutationSerial;
+    record.flags = item.flags;
+    record.socketPolicy = static_cast<std::uint8_t>(item.sockets.policy);
+    record.movementAbilityEntry = item.movementAbilityEntry;
+    record.grenadeAbilityEntry = item.grenadeAbilityEntry;
+    record.superAbilityEntry = item.superAbilityEntry;
+    record.meleeAbilityEntry = item.meleeAbilityEntry;
+    record.classAbilityEntry = item.classAbilityEntry;
+    record.plugCount = static_cast<std::uint8_t>(item.sockets.plugCount);
+    for (std::size_t plug = 0; plug < item.sockets.plugs.size(); ++plug) {
+        if (item.sockets.plugs[plug].has_value()) {
+            record.plugs[plug] = *item.sockets.plugs[plug];
+            record.plugPresent[plug] = 1;
+        }
+    }
+    return record;
+}
+
+/** Copies one optional equipment slot into its on-disk record. */
+[[nodiscard]] ItemRecord to_record(const std::optional<authored::Item>& item) noexcept {
+    return item.has_value() ? to_record(*item) : ItemRecord{};
+}
+
+/** Rebuilds one item from its on-disk record. */
+[[nodiscard]] authored::Item from_record(const ItemRecord& record) noexcept {
+    authored::Item item{};
+    item.instanceSoid = record.instanceSoid;
+    item.definitionHash = record.definitionHash;
+    item.level = record.level;
+    item.quantity = record.quantity;
+    item.mutationSerial = record.mutationSerial;
+    item.flags = record.flags;
+    item.sockets.policy = static_cast<authored::SocketPolicy>(record.socketPolicy);
+    item.movementAbilityEntry = record.movementAbilityEntry;
+    item.grenadeAbilityEntry = record.grenadeAbilityEntry;
+    item.superAbilityEntry = record.superAbilityEntry;
+    item.meleeAbilityEntry = record.meleeAbilityEntry;
+    item.classAbilityEntry = record.classAbilityEntry;
+    item.sockets.plugCount = record.plugCount <= item.sockets.plugs.size()
+                                 ? record.plugCount
+                                 : item.sockets.plugs.size();
+    for (std::size_t plug = 0; plug < item.sockets.plugs.size(); ++plug) {
+        if (record.plugPresent[plug] != 0) {
+            item.sockets.plugs[plug] = record.plugs[plug];
+        }
+    }
+    return item;
+}
+
+/** Rebuilds one equipment slot, which is empty when the record was written empty. */
+[[nodiscard]] std::optional<authored::Item> to_slot(const ItemRecord& record) noexcept {
+    if (record.present == 0) {
+        return std::nullopt;
+    }
+    return from_record(record);
+}
+
+/**
+ * Resolves the overlay path and its write sibling once.
+ * @param module Loaded DLL that owns the artifact directory.
+ * @return True when both paths fit their buffers.
+ */
+[[nodiscard]] bool resolve_paths(void* module) noexcept {
+    if (g_pathResolved) {
+        return true;
+    }
+    core::path::Buffer directory{};
+    if (!core::path::artifact_directory(module, directory)) {
+        return false;
+    }
+    g_path = directory;
+    g_temporaryPath = directory;
+    if (!core::path::append(g_path, kFileSuffix)
+        || !core::path::append(g_temporaryPath, kTemporarySuffix)) {
+        return false;
+    }
+    g_pathResolved = true;
+    return true;
+}
+
+/**
+ * Reads the whole overlay into memory.
+ * @param contents Gets the file bytes, untouched when the file is absent or refused.
+ * @return True only when the complete file was read.
+ */
+[[nodiscard]] bool read_file(std::vector<std::byte>& contents) noexcept {
+    const HANDLE file = CreateFileW(g_path.chars.data(),
+                                    GENERIC_READ,
+                                    FILE_SHARE_READ,
+                                    nullptr,
+                                    OPEN_EXISTING,
+                                    FILE_ATTRIBUTE_NORMAL,
+                                    nullptr);
+    if (file == INVALID_HANDLE_VALUE) {
+        return false;
+    }
+    LARGE_INTEGER size{};
+    const bool sized = GetFileSizeEx(file, &size) != FALSE && size.QuadPart > 0
+                       && static_cast<std::uint64_t>(size.QuadPart) <= kMaximumSize;
+    bool complete = false;
+    if (sized) {
+        contents.resize(static_cast<std::size_t>(size.QuadPart));
+        DWORD read = 0;
+        complete =
+            ReadFile(file, contents.data(), static_cast<DWORD>(contents.size()), &read, nullptr)
+                != FALSE
+            && read == contents.size();
+    }
+    (void)CloseHandle(file);
+    if (!complete) {
+        contents.clear();
+    }
+    return complete;
+}
+
+} // namespace
+
+/** Writes the mutable half of the account, replacing any previous overlay. */
+void save() noexcept {
+    if (!g_pathResolved) {
+        // Nothing has resolved a path, so there is nowhere to write. A load always runs first.
+        return;
+    }
+    const AccountState account = account_snapshot();
+    const Header header{kMagic, kVersion, static_cast<std::uint32_t>(account.characterCount), 0};
+    std::vector<std::byte> contents(kCharacterOffset
+                                    + account.characterCount * sizeof(CharacterRecord));
+    std::memcpy(contents.data(), &header, sizeof header);
+
+    AccountRecord accountRecord{};
+    accountRecord.accountSoid = account.primarySoid;
+    accountRecord.profileItemCount = static_cast<std::uint32_t>(account.profileItemCount);
+    for (std::size_t index = 0; index < account.profileItemCount; ++index) {
+        const authored::ProfileItem& row = account.profileItems[index];
+        accountRecord.profileItems[index] = ProfileItemRecord{
+            row.instanceSoid, row.definitionHash, row.quantity, row.mutationSerial, 0};
+    }
+    std::memcpy(contents.data() + kAccountOffset, &accountRecord, sizeof accountRecord);
+
+    for (std::size_t index = 0; index < account.characterCount; ++index) {
+        const CharacterState& character = account.characters[index];
+        CharacterRecord record{};
+        record.characterSoid = character.soid;
+        record.acquiredSubclassAbilityMask = character.acquiredSubclassAbilityMask;
+        record.nextInventorySerial = character.nextInventorySerial;
+        record.inventoryCount = static_cast<std::uint32_t>(character.inventory.count);
+        record.lastOrbitedDestination = character.lastOrbitedDestination;
+        for (std::size_t slot = 0; slot < character.equipment.slots.size(); ++slot) {
+            record.equipment[slot] = to_record(character.equipment.slots[slot]);
+        }
+        for (std::size_t slot = 0; slot < character.inventory.count; ++slot) {
+            record.inventory[slot] = to_record(character.inventory.values[slot]);
+        }
+        std::memcpy(
+            contents.data() + kCharacterOffset + index * sizeof record, &record, sizeof record);
+    }
+
+    // Written to a sibling and renamed over the target. A crash mid-write then costs the newest
+    // save, never the file the next boot reads.
+    const HANDLE file = CreateFileW(g_temporaryPath.chars.data(),
+                                    GENERIC_WRITE,
+                                    0,
+                                    nullptr,
+                                    CREATE_ALWAYS,
+                                    FILE_ATTRIBUTE_NORMAL,
+                                    nullptr);
+    if (file == INVALID_HANDLE_VALUE) {
+        report("save", "fail_open");
+        return;
+    }
+    DWORD written = 0;
+    bool complete =
+        WriteFile(file, contents.data(), static_cast<DWORD>(contents.size()), &written, nullptr)
+            != FALSE
+        && written == contents.size();
+    complete = CloseHandle(file) != FALSE && complete;
+    if (!complete) {
+        (void)DeleteFileW(g_temporaryPath.chars.data());
+        report("save", "fail_write");
+        return;
+    }
+    if (MoveFileExW(g_temporaryPath.chars.data(), g_path.chars.data(), MOVEFILE_REPLACE_EXISTING)
+        == FALSE) {
+        (void)DeleteFileW(g_temporaryPath.chars.data());
+        report("save", "fail_replace");
+        return;
+    }
+    report("save", "ok");
+}
+
+/** Applies the saved runtime overlay on top of the authored account, when one exists. */
+void load(void* module) noexcept {
+    if (!resolve_paths(module)) {
+        report("load", "fail_path");
+        return;
+    }
+    std::vector<std::byte> contents;
+    if (!read_file(contents)) {
+        // A first run has no overlay, which is the ordinary case and not a failure.
+        report("load", "absent");
+        return;
+    }
+    Header header{};
+    if (contents.size() < sizeof header) {
+        report("load", "fail_short");
+        return;
+    }
+    std::memcpy(&header, contents.data(), sizeof header);
+    const std::size_t expected =
+        kCharacterOffset
+        + static_cast<std::size_t>(header.characterCount) * sizeof(CharacterRecord);
+    if (header.magic != kMagic || header.version != kVersion
+        || header.characterCount > kCharacterCapacity || contents.size() != expected) {
+        report("load", "fail_layout");
+        return;
+    }
+
+    AccountState candidate = account_snapshot();
+    AccountRecord accountRecord{};
+    std::memcpy(&accountRecord, contents.data() + kAccountOffset, sizeof accountRecord);
+    // Matched by key like the characters are. A saved balance belongs to the account it was earned
+    // on, and applying it to a different one would invent currency out of a stale file.
+    if (accountRecord.accountSoid != 0 && accountRecord.accountSoid == candidate.primarySoid
+        && accountRecord.profileItemCount <= candidate.profileItems.size()) {
+        for (std::size_t index = 0; index < candidate.profileItems.size(); ++index) {
+            const ProfileItemRecord& row = accountRecord.profileItems[index];
+            candidate.profileItems[index] = index < accountRecord.profileItemCount
+                                                ? authored::ProfileItem{row.instanceSoid,
+                                                                        row.definitionHash,
+                                                                        row.quantity,
+                                                                        row.mutationSerial}
+                                                : authored::ProfileItem{};
+        }
+        candidate.profileItemCount = accountRecord.profileItemCount;
+    }
+
+    std::size_t applied = 0;
+    for (std::uint32_t index = 0; index < header.characterCount; ++index) {
+        CharacterRecord record{};
+        std::memcpy(&record,
+                    contents.data() + kCharacterOffset
+                        + static_cast<std::size_t>(index) * sizeof record,
+                    sizeof record);
+        // Matched by key, never by position, so reordering the authored characters cannot hand one
+        // character another's loadout.
+        for (std::size_t slot = 0; slot < candidate.characterCount; ++slot) {
+            CharacterState& character = candidate.characters[slot];
+            if (record.characterSoid == 0 || character.soid != record.characterSoid) {
+                continue;
+            }
+            if (record.inventoryCount > character.inventory.values.size()) {
+                break;
+            }
+            for (std::size_t item = 0; item < character.equipment.slots.size(); ++item) {
+                character.equipment.slots[item] = to_slot(record.equipment[item]);
+            }
+            for (std::size_t item = 0; item < character.inventory.values.size(); ++item) {
+                character.inventory.values[item] = item < record.inventoryCount
+                                                       ? from_record(record.inventory[item])
+                                                       : authored::Item{};
+            }
+            character.inventory.count = record.inventoryCount;
+            character.nextInventorySerial = record.nextInventorySerial;
+            character.acquiredSubclassAbilityMask = record.acquiredSubclassAbilityMask;
+            character.lastOrbitedDestination = record.lastOrbitedDestination;
+            ++applied;
+            break;
+        }
+    }
+
+    // The authored account is already known good, so anything the overlay cannot produce validly is
+    // dropped whole rather than partially applied.
+    if (!account::valid(candidate)) {
+        report("load", "fail_invalid");
+        return;
+    }
+    AcquireSRWLockExclusive(&runtime::storage::g_stateLock);
+    runtime::storage::g_state.account = candidate;
+    ReleaseSRWLockExclusive(&runtime::storage::g_stateLock);
+
+    std::array<char, 128> line{};
+    const int written = std::snprintf(line.data(),
+                                      line.size(),
+                                      "ev=persist stage=load result=ok version=%u characters=%zu",
+                                      static_cast<unsigned>(header.version),
+                                      applied);
+    if (written > 0) {
+        core::log::write(core::log::Channel::state,
+                         core::log::Level::info,
+                         {line.data(), static_cast<std::size_t>(written)});
+    }
+}
+
+} // namespace sunrise::state::persistence

--- a/Sunrise/src/state/runtime/persistence/runtime_state_file.h
+++ b/Sunrise/src/state/runtime/persistence/runtime_state_file.h
@@ -1,0 +1,29 @@
+#pragma once
+
+namespace sunrise::state::persistence {
+
+/**
+ * Applies the saved runtime overlay on top of the authored account, when one exists.
+ *
+ * The authored `settings.json` stays the baseline and is never written to. Everything the player
+ * changes at runtime, meaning what is worn, what is carried, and what has been destroyed, lives in
+ * a separate file beside it. Deleting that file restores the authored set exactly, and a corrupt
+ * one costs nothing but the session's changes.
+ *
+ * Fail-safe in every direction: a missing, short, mismatched or invalid overlay is reported and
+ * skipped, leaving the authored account in place. Settings load before the log sinks exist, and a
+ * boot that dies there leaves no log at all, so this never refuses a boot.
+ *
+ * @param module Loaded DLL, used to resolve the owned artifact directory.
+ */
+void load(void* module) noexcept;
+
+/**
+ * Writes the mutable half of the account, replacing any previous overlay.
+ *
+ * Written to a sibling temporary and renamed over the target, so an interrupted write cannot leave
+ * a half-file behind for the next boot to read.
+ */
+void save() noexcept;
+
+} // namespace sunrise::state::persistence

--- a/Sunrise/src/state/runtime/state_account_acquisition_runtime.cpp
+++ b/Sunrise/src/state/runtime/state_account_acquisition_runtime.cpp
@@ -8,6 +8,7 @@
 
 #include "../../middleware/datagen/family4/loadout/loadout_resolver.h"
 #include "../build_data/runtime.h"
+#include "persistence/runtime_state_file.h"
 #include "runtime.h"
 #include "state_account_transaction_helpers.h"
 #include "storage/internal.h"
@@ -285,6 +286,8 @@ bool commit_item_acquisition(PendingItemAcquisition& mutation) noexcept {
                        prepared.inventoryRow,
                        prepared.equipmentSlot,
                        prepared.afterCharacter.nextInventorySerial);
+    // Persisted only once the mutation is committed, so a refused one never reaches the file.
+    persistence::save();
     return true;
 }
 
@@ -576,6 +579,10 @@ bool commit_profile_item_acquisition(PendingProfileItemAcquisition& mutation) no
                                prepared.previousQuantity,
                                prepared.acquiredQuantity,
                                prepared.appended);
+    // Persisted only once the mutation is committed, so a refused one never reaches the file.
+    if (ready) {
+        persistence::save();
+    }
     return ready;
 }
 

--- a/Sunrise/src/state/runtime/state_account_dismantle_runtime.cpp
+++ b/Sunrise/src/state/runtime/state_account_dismantle_runtime.cpp
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "persistence/runtime_state_file.h"
 #include "runtime.h"
 #include "state_account_transaction_helpers.h"
 #include "storage/internal.h"
@@ -122,6 +123,8 @@ bool commit_item_dismantle(PendingItemDismantle& mutation) noexcept {
                      prepared.equipmentSlot,
                      prepared.movedInventoryItemCount,
                      prepared.afterCharacter.nextInventorySerial);
+    // Persisted only once the mutation is committed, so a refused one never reaches the file.
+    persistence::save();
     return true;
 }
 

--- a/Sunrise/src/state/runtime/state_account_item_action_runtime.cpp
+++ b/Sunrise/src/state/runtime/state_account_item_action_runtime.cpp
@@ -8,6 +8,7 @@
 #include "../../middleware/datagen/family4/loadout/loadout_resolver.h"
 #include "../../middleware/web_service/messages/opcode1901.h"
 #include "../build_data/runtime.h"
+#include "persistence/runtime_state_file.h"
 #include "runtime.h"
 #include "state_account_transaction_helpers.h"
 #include "storage/internal.h"
@@ -385,6 +386,8 @@ bool commit_socket_plug(PendingSocketPlug& mutation) noexcept {
                        prepared.plugBucketId,
                        prepared.targetEquipped,
                        prepared.itemIndex);
+    // Persisted only once the mutation is committed, so a refused one never reaches the file.
+    persistence::save();
     return true;
 }
 
@@ -511,6 +514,8 @@ bool commit_item_state(PendingItemState& mutation) noexcept {
                       prepared.afterFlags,
                       prepared.targetEquipped,
                       prepared.itemIndex);
+    // Persisted only once the mutation is committed, so a refused one never reaches the file.
+    persistence::save();
     return true;
 }
 
@@ -611,6 +616,8 @@ bool commit_subclass_selection(PendingSubclassSelection& mutation) noexcept {
     // The published ability buckets are keyed to whichever selection is currently active; that
     // just changed, so the domain is stale the moment the account write above becomes visible.
     build_data::invalidate_ability_buckets();
+    // Persisted only once the mutation is committed, so a refused one never reaches the file.
+    persistence::save();
     return true;
 }
 

--- a/Sunrise/src/state/runtime/state_account_runtime.cpp
+++ b/Sunrise/src/state/runtime/state_account_runtime.cpp
@@ -12,6 +12,7 @@
 #include "../../core/logging/log.h"
 #include "../../middleware/datagen/family4/loadout/loadout_resolver.h"
 #include "../build_data/runtime.h"
+#include "persistence/runtime_state_file.h"
 #include "runtime.h"
 #include "state.h"
 #include "state_account_transaction_helpers.h"
@@ -638,6 +639,8 @@ bool commit_equipment_swap(PendingEquipmentSwap& mutation) noexcept {
                      prepared.movedItemCount,
                      previousDefinitionHash,
                      requestedDefinitionHash);
+    // Persisted only once the mutation is committed, so a refused one never reaches the file.
+    persistence::save();
     return true;
 }
 


### PR DESCRIPTION
## Persist runtime inventory and equipment across restarts

Every change a player makes at runtime is currently lost on exit. Equip something,
dismantle something, insert a mod, and the next boot rebuilds the account from
`settings.json` as though none of it happened. This adds a small binary overlay beside
`settings.json` holding the mutable half of the account, applied over the authored one at
startup.

`settings.json` stays the baseline and is never written to. Deleting `runtime-state.bin`
restores the authored account exactly.

### How it works

`state::persistence::load()` runs once from `core_runtime` after every boot stage
succeeds. `state::persistence::save()` runs at the end of the seven commit functions that
mutate the account: equipment swap, item and profile acquisition, dismantle, socket plug,
item state, and subclass selection. Saving from the commit rather than the request means a
refused mutation never reaches the file. Each call sits after the state lock is released,
since SRW locks are not recursive and `save()` takes a snapshot.

Persisted per character: equipment slots, the unequipped item array and its count, the
next inventory serial, `acquiredSubclassAbilityMask` and `lastOrbitedDestination`.
Account-wide: the profile item rows and their count. Identity and appearance are left
alone.

### The file

Fixed-size packed records with a magic and version in the header, written field by field
rather than by copying the in-memory structs, so the state model can change shape without
silently invalidating files. Written to a `.tmp` sibling and renamed over the target, so a
crash mid-write costs the newest save and not the file the next boot reads. Characters and
the account are matched by SOID and never by position, so reordering authored characters
cannot hand one character another's loadout.

`Sockets::plugCount` is stored explicitly rather than inferred from which plugs are
present. `valid(Sockets)` rejects any plug at or past the count, and a count may
legitimately cover a socket whose plug is empty, so neither can be derived from the other.
Restoring without it fails validation on every item carrying a mod.

### Failure handling

The overlay never stops a boot. A missing, short, oversized, mismatched or invalid file is
logged and skipped, leaving the authored account in place: `absent` on a first run,
`fail_layout` on a header or size mismatch, `fail_invalid` when the result does not pass
`account::valid`, and `ok` with the version and character count otherwise. The write side
reports `fail_open`, `fail_write` and `fail_replace` separately.

### Testing

Built Release x64 against v145 (and v143 for those still on VS 2022). Verified the round trip by equipping across several
characters, quitting, and confirming the loadout returned on the next boot. Also confirmed
that deleting the file falls back to the authored account and that an older layout is
refused rather than misread. Equip, dismantle and socket paths have been exercised
directly; profile acquisition and subclass selection are wired identically but have had
less time in front of them.