### PR TITLE
Add No Turnback and Godmode player options

### DIFF
--- a/Sunrise/Sunrise.vcxproj
+++ b/Sunrise/Sunrise.vcxproj
@@ -227,6 +227,8 @@
     <ClCompile Include="src\client\hooks\sword_skate\sword_skate.cpp" />
     <ClCompile Include="src\client\hooks\fly\fly.cpp" />
     <ClCompile Include="src\client\hooks\infinite_ammo\infinite_ammo.cpp" />
+    <ClCompile Include="src\client\hooks\no_turnback\no_turnback.cpp" />
+    <ClCompile Include="src\client\hooks\godmode\godmode.cpp" />
     <ClCompile Include="src\client\input\window_focus.cpp" />
     <ClCompile Include="src\client\hooks\teleport\teleport_lifecycle.cpp" />
     <ClCompile Include="src\client\hooks\teleport\teleport_move.cpp" />
@@ -912,6 +914,8 @@
     <ClInclude Include="src\client\hooks\sword_skate\sword_skate.h" />
     <ClInclude Include="src\client\hooks\fly\fly.h" />
     <ClInclude Include="src\client\hooks\infinite_ammo\infinite_ammo.h" />
+    <ClInclude Include="src\client\hooks\no_turnback\no_turnback.h" />
+    <ClInclude Include="src\client\hooks\godmode\godmode.h" />
     <ClInclude Include="src\client\input\window_focus.h" />
     <ClInclude Include="src\client\hooks\teleport\internal.h" />
     <ClInclude Include="src\client\hooks\teleport\runtime.h" />

--- a/Sunrise/src/client/hooks/godmode/godmode.cpp
+++ b/Sunrise/src/client/hooks/godmode/godmode.cpp
@@ -1,0 +1,110 @@
+/** Godmode. Replaces the damage value instruction while enabled and restores it when disabled. */
+
+#include "godmode.h"
+
+#include <Windows.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdio>
+#include <cstring>
+#include <string_view>
+
+#include "../../../core/logging/log.h"
+#include "../../patterns/image_scan.h"
+#include "../../player/player_settings_store.h"
+
+namespace sunrise::client::hooks::godmode {
+namespace {
+
+constexpr std::string_view kInstructionText = "8B 74 24 ? 48 63 58";
+constexpr auto kInstruction =
+    patterns::signature<patterns::signature_length(kInstructionText)>(kInstructionText);
+constexpr std::array<std::byte, 4> kOriginal{
+    std::byte{0x8B}, std::byte{0x74}, std::byte{0x24}, std::byte{0x38}};
+constexpr std::array<std::byte, 4> kPatch{
+    std::byte{0x83}, std::byte{0xCE}, std::byte{0xFF}, std::byte{0x90}};
+
+SRWLOCK g_lock{SRWLOCK_INIT};
+std::byte* g_instruction{};
+
+/** @param reason Key naming the step that failed. @return False, for a direct return. */
+[[nodiscard]] bool fail(const char* reason) noexcept {
+    std::array<char, 96> line{};
+    const int written = std::snprintf(
+        line.data(), line.size(), "ev=godmode stage=patch result=fail reason=%s", reason);
+    if (written > 0) {
+        core::log::write(core::log::Channel::client,
+                         core::log::Level::warn,
+                         {line.data(), static_cast<std::size_t>(written)});
+    }
+    return false;
+}
+
+/** Writes one validated instruction and restores its page protection. */
+[[nodiscard]] bool write(bool enabled) noexcept {
+    const auto& expected = enabled ? kOriginal : kPatch;
+    const auto& replacement = enabled ? kPatch : kOriginal;
+    if (g_instruction == nullptr) {
+        return false;
+    }
+    if (std::memcmp(g_instruction, replacement.data(), replacement.size()) == 0) {
+        return true;
+    }
+    if (std::memcmp(g_instruction, expected.data(), expected.size()) != 0) {
+        return false;
+    }
+    DWORD originalProtection = 0;
+    if (VirtualProtect(
+            g_instruction, replacement.size(), PAGE_EXECUTE_READWRITE, &originalProtection)
+        == FALSE) {
+        return false;
+    }
+    std::memcpy(g_instruction, replacement.data(), replacement.size());
+    FlushInstructionCache(GetCurrentProcess(), g_instruction, replacement.size());
+    DWORD ignored = 0;
+    return VirtualProtect(g_instruction, replacement.size(), originalProtection, &ignored) != FALSE;
+}
+
+} // namespace
+
+bool install() noexcept {
+    AcquireSRWLockExclusive(&g_lock);
+    if (g_instruction != nullptr) {
+        ReleaseSRWLockExclusive(&g_lock);
+        return true;
+    }
+    g_instruction = patterns::scan_main_image_unique(kInstruction, "godmode");
+    if (g_instruction == nullptr) {
+        ReleaseSRWLockExclusive(&g_lock);
+        return fail("signature");
+    }
+    if (!write(client::player::get().godmodeEnabled)) {
+        g_instruction = nullptr;
+        ReleaseSRWLockExclusive(&g_lock);
+        return fail("bytes");
+    }
+    ReleaseSRWLockExclusive(&g_lock);
+    core::log::write(core::log::Channel::client,
+                     core::log::Level::info,
+                     "ev=godmode stage=install result=ok");
+    return true;
+}
+
+bool set_enabled(bool enabled) noexcept {
+    AcquireSRWLockExclusive(&g_lock);
+    const bool applied = write(enabled);
+    ReleaseSRWLockExclusive(&g_lock);
+    return applied || fail("write");
+}
+
+void uninstall() noexcept {
+    AcquireSRWLockExclusive(&g_lock);
+    if (g_instruction != nullptr && !write(false)) {
+        (void)fail("restore");
+    }
+    g_instruction = nullptr;
+    ReleaseSRWLockExclusive(&g_lock);
+}
+
+} // namespace sunrise::client::hooks::godmode

--- a/Sunrise/src/client/hooks/godmode/godmode.cpp
+++ b/Sunrise/src/client/hooks/godmode/godmode.cpp
@@ -41,7 +41,7 @@ std::byte* g_instruction{};
     return false;
 }
 
-/** Writes one validated instruction and restores its page protection. */
+/** Writes one validated instruction. WriteProcessMemory handles the executable page protection. */
 [[nodiscard]] bool write(bool enabled) noexcept {
     const auto& expected = enabled ? kOriginal : kPatch;
     const auto& replacement = enabled ? kPatch : kOriginal;
@@ -54,16 +54,14 @@ std::byte* g_instruction{};
     if (std::memcmp(g_instruction, expected.data(), expected.size()) != 0) {
         return false;
     }
-    DWORD originalProtection = 0;
-    if (VirtualProtect(
-            g_instruction, replacement.size(), PAGE_EXECUTE_READWRITE, &originalProtection)
-        == FALSE) {
-        return false;
-    }
-    std::memcpy(g_instruction, replacement.data(), replacement.size());
-    FlushInstructionCache(GetCurrentProcess(), g_instruction, replacement.size());
-    DWORD ignored = 0;
-    return VirtualProtect(g_instruction, replacement.size(), originalProtection, &ignored) != FALSE;
+    SIZE_T written = 0;
+    return WriteProcessMemory(GetCurrentProcess(),
+                              g_instruction,
+                              replacement.data(),
+                              replacement.size(),
+                              &written)
+               != FALSE
+           && written == replacement.size();
 }
 
 } // namespace

--- a/Sunrise/src/client/hooks/godmode/godmode.h
+++ b/Sunrise/src/client/hooks/godmode/godmode.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace sunrise::client::hooks::godmode {
+
+/** Resolves the damage instruction and applies the saved setting. */
+[[nodiscard]] bool install() noexcept;
+
+/** Applies or restores the godmode patch. */
+[[nodiscard]] bool set_enabled(bool enabled) noexcept;
+
+/** Restores the original instruction and forgets its resolved address. */
+void uninstall() noexcept;
+
+} // namespace sunrise::client::hooks::godmode

--- a/Sunrise/src/client/hooks/no_turnback/no_turnback.cpp
+++ b/Sunrise/src/client/hooks/no_turnback/no_turnback.cpp
@@ -1,0 +1,114 @@
+/** No turnback. Changes the called check's result while enabled and restores it when disabled. */
+
+#include "no_turnback.h"
+
+#include <Windows.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdio>
+#include <cstring>
+#include <string_view>
+
+#include "../../../core/logging/log.h"
+#include "../../patterns/image_scan.h"
+#include "../../player/player_settings_store.h"
+
+namespace sunrise::client::hooks::no_turnback {
+namespace {
+
+constexpr std::string_view kCallText = "E8 ? ? ? ? 0F 10 0B 84 C0";
+constexpr auto kCall = patterns::signature<patterns::signature_length(kCallText)>(kCallText);
+constexpr std::size_t kNearCallOperand = 1;
+constexpr std::size_t kNearCallLength = 5;
+constexpr std::size_t kResultOffset = 0x6F;
+constexpr std::array<std::byte, 2> kOriginal{std::byte{0xB0}, std::byte{0x01}};
+constexpr std::array<std::byte, 2> kPatch{std::byte{0xB0}, std::byte{0x00}};
+
+SRWLOCK g_lock{SRWLOCK_INIT};
+std::byte* g_result{};
+
+/** @param reason Key naming the step that failed. @return False, for a direct return. */
+[[nodiscard]] bool fail(const char* reason) noexcept {
+    std::array<char, 96> line{};
+    const int written = std::snprintf(
+        line.data(), line.size(), "ev=no_turnback stage=patch result=fail reason=%s", reason);
+    if (written > 0) {
+        core::log::write(core::log::Channel::client,
+                         core::log::Level::warn,
+                         {line.data(), static_cast<std::size_t>(written)});
+    }
+    return false;
+}
+
+/** Writes one validated instruction and restores its page protection. */
+[[nodiscard]] bool write(bool enabled) noexcept {
+    const auto& expected = enabled ? kOriginal : kPatch;
+    const auto& replacement = enabled ? kPatch : kOriginal;
+    if (g_result == nullptr) {
+        return false;
+    }
+    if (std::memcmp(g_result, replacement.data(), replacement.size()) == 0) {
+        return true;
+    }
+    if (std::memcmp(g_result, expected.data(), expected.size()) != 0) {
+        return false;
+    }
+    DWORD originalProtection = 0;
+    if (VirtualProtect(g_result, replacement.size(), PAGE_EXECUTE_READWRITE, &originalProtection)
+        == FALSE) {
+        return false;
+    }
+    std::memcpy(g_result, replacement.data(), replacement.size());
+    FlushInstructionCache(GetCurrentProcess(), g_result, replacement.size());
+    DWORD ignored = 0;
+    return VirtualProtect(g_result, replacement.size(), originalProtection, &ignored) != FALSE;
+}
+
+} // namespace
+
+bool install() noexcept {
+    AcquireSRWLockExclusive(&g_lock);
+    if (g_result != nullptr) {
+        ReleaseSRWLockExclusive(&g_lock);
+        return true;
+    }
+    std::byte* const call = patterns::scan_main_image_unique(kCall, "no_turnback");
+    auto* const target = call == nullptr
+                             ? nullptr
+                             : static_cast<std::byte*>(patterns::resolve_relative(
+                                   call + kNearCallOperand, call + kNearCallLength));
+    if (target == nullptr) {
+        ReleaseSRWLockExclusive(&g_lock);
+        return fail("signature");
+    }
+    g_result = target + kResultOffset;
+    if (!write(client::player::get().noTurnbackEnabled)) {
+        g_result = nullptr;
+        ReleaseSRWLockExclusive(&g_lock);
+        return fail("bytes");
+    }
+    ReleaseSRWLockExclusive(&g_lock);
+    core::log::write(core::log::Channel::client,
+                     core::log::Level::info,
+                     "ev=no_turnback stage=install result=ok");
+    return true;
+}
+
+bool set_enabled(bool enabled) noexcept {
+    AcquireSRWLockExclusive(&g_lock);
+    const bool applied = write(enabled);
+    ReleaseSRWLockExclusive(&g_lock);
+    return applied || fail("write");
+}
+
+void uninstall() noexcept {
+    AcquireSRWLockExclusive(&g_lock);
+    if (g_result != nullptr && !write(false)) {
+        (void)fail("restore");
+    }
+    g_result = nullptr;
+    ReleaseSRWLockExclusive(&g_lock);
+}
+
+} // namespace sunrise::client::hooks::no_turnback

--- a/Sunrise/src/client/hooks/no_turnback/no_turnback.cpp
+++ b/Sunrise/src/client/hooks/no_turnback/no_turnback.cpp
@@ -41,7 +41,7 @@ std::byte* g_result{};
     return false;
 }
 
-/** Writes one validated instruction and restores its page protection. */
+/** Writes one validated instruction. WriteProcessMemory handles the executable page protection. */
 [[nodiscard]] bool write(bool enabled) noexcept {
     const auto& expected = enabled ? kOriginal : kPatch;
     const auto& replacement = enabled ? kPatch : kOriginal;
@@ -54,15 +54,14 @@ std::byte* g_result{};
     if (std::memcmp(g_result, expected.data(), expected.size()) != 0) {
         return false;
     }
-    DWORD originalProtection = 0;
-    if (VirtualProtect(g_result, replacement.size(), PAGE_EXECUTE_READWRITE, &originalProtection)
-        == FALSE) {
-        return false;
-    }
-    std::memcpy(g_result, replacement.data(), replacement.size());
-    FlushInstructionCache(GetCurrentProcess(), g_result, replacement.size());
-    DWORD ignored = 0;
-    return VirtualProtect(g_result, replacement.size(), originalProtection, &ignored) != FALSE;
+    SIZE_T written = 0;
+    return WriteProcessMemory(GetCurrentProcess(),
+                              g_result,
+                              replacement.data(),
+                              replacement.size(),
+                              &written)
+               != FALSE
+           && written == replacement.size();
 }
 
 } // namespace

--- a/Sunrise/src/client/hooks/no_turnback/no_turnback.h
+++ b/Sunrise/src/client/hooks/no_turnback/no_turnback.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace sunrise::client::hooks::no_turnback {
+
+/** Resolves the turnback result and applies the saved setting. */
+[[nodiscard]] bool install() noexcept;
+
+/** Applies or restores the turnback result patch. */
+[[nodiscard]] bool set_enabled(bool enabled) noexcept;
+
+/** Restores the original instruction and forgets its resolved address. */
+void uninstall() noexcept;
+
+} // namespace sunrise::client::hooks::no_turnback

--- a/Sunrise/src/client/player/player_settings_store.cpp
+++ b/Sunrise/src/client/player/player_settings_store.cpp
@@ -70,6 +70,8 @@ void boolean_for(std::string_view text, std::string_view key, bool& output) noex
  */
 void parse(std::string_view text, Settings& output) noexcept {
     boolean_for(text, "\"infinite_ammo_enabled\"", output.infiniteAmmoEnabled);
+    boolean_for(text, "\"no_turnback_enabled\"", output.noTurnbackEnabled);
+    boolean_for(text, "\"godmode_enabled\"", output.godmodeEnabled);
 }
 
 /**
@@ -85,8 +87,14 @@ void parse(std::string_view text, Settings& output) noexcept {
     std::array<char, kFileCapacity> document{};
     const int size = std::snprintf(document.data(),
                                    document.size(),
-                                   "{\n  \"infinite_ammo_enabled\": %s\n}\n",
-                                   settings.infiniteAmmoEnabled ? "true" : "false");
+                                   "{\n"
+                                   "  \"infinite_ammo_enabled\": %s,\n"
+                                   "  \"no_turnback_enabled\": %s,\n"
+                                   "  \"godmode_enabled\": %s\n"
+                                   "}\n",
+                                   settings.infiniteAmmoEnabled ? "true" : "false",
+                                   settings.noTurnbackEnabled ? "true" : "false",
+                                   settings.godmodeEnabled ? "true" : "false");
     if (size <= 0) {
         return false;
     }

--- a/Sunrise/src/client/player/player_settings_store.h
+++ b/Sunrise/src/client/player/player_settings_store.h
@@ -5,6 +5,8 @@ namespace sunrise::client::player {
 /** Runtime player configuration. This module owns it; Core settings do not carry it. */
 struct Settings {
     bool infiniteAmmoEnabled{false};
+    bool noTurnbackEnabled{false};
+    bool godmodeEnabled{false};
 };
 
 /**

--- a/Sunrise/src/client/runtime/client_hook_activation.cpp
+++ b/Sunrise/src/client/runtime/client_hook_activation.cpp
@@ -18,11 +18,13 @@
 #include "../hooks/config_getter/config_getter_lifecycle.h"
 #include "../hooks/cursor/runtime.h"
 #include "../hooks/graphics/graphics_hook_lifecycle.h"
+#include "../hooks/godmode/godmode.h"
 #include "../hooks/inactivity/inactivity_override.h"
 #include "../hooks/infinite_ammo/infinite_ammo.h"
 #include "../hooks/membership_probe/membership_probe.h"
 #include "../hooks/network/runtime.h"
 #include "../hooks/noclip/runtime.h"
+#include "../hooks/no_turnback/no_turnback.h"
 #include "../hooks/package_trust/package_trust_bypass.h"
 #include "../hooks/polled_input/runtime.h"
 #include "../hooks/queuez/queuez_hook_lifecycle.h"
@@ -175,6 +177,9 @@ void clear_game_targets() noexcept {
     (void)hooks::noclip::install();
     // Attaches whether or not the feature is on, so the interface can enable it without a restart.
     (void)hooks::infinite_ammo::install();
+    // Both patches resolve while disabled so their Player controls can switch them immediately.
+    (void)hooks::no_turnback::install();
+    (void)hooks::godmode::install();
     // Resolves the activity config getter here; the hold itself runs on the frame tick.
     (void)hooks::inactivity::install();
     (void)hooks::queuez::install();

--- a/Sunrise/src/client/runtime/client_runtime_lifecycle.cpp
+++ b/Sunrise/src/client/runtime/client_runtime_lifecycle.cpp
@@ -6,10 +6,12 @@
 #include "../hooks/config_getter/config_getter_lifecycle.h"
 #include "../hooks/cursor/runtime.h"
 #include "../hooks/graphics/graphics_hook_lifecycle.h"
+#include "../hooks/godmode/godmode.h"
 #include "../hooks/inactivity/inactivity_override.h"
 #include "../hooks/infinite_ammo/infinite_ammo.h"
 #include "../hooks/network/runtime.h"
 #include "../hooks/noclip/runtime.h"
+#include "../hooks/no_turnback/no_turnback.h"
 #include "../hooks/package_trust/package_trust_bypass.h"
 #include "../hooks/polled_input/runtime.h"
 #include "../hooks/queuez/queuez_hook_lifecycle.h"
@@ -65,6 +67,8 @@ bool shutdown() noexcept {
     hooks::bitmap::uninstall();
     hooks::bootflow::uninstall();
     hooks::infinite_ammo::uninstall();
+    hooks::godmode::uninstall();
+    hooks::no_turnback::uninstall();
     hooks::inactivity::uninstall();
     hooks::noclip::uninstall();
     hooks::teleport::uninstall();

--- a/Sunrise/src/client/ui/player/player_panel.cpp
+++ b/Sunrise/src/client/ui/player/player_panel.cpp
@@ -8,7 +8,9 @@
 #include <imgui.h>
 
 #include "../../../core/ui/components/toggle/ui_toggle_component.h"
+#include "../../hooks/godmode/godmode.h"
 #include "../../hooks/inactivity/inactivity_override.h"
+#include "../../hooks/no_turnback/no_turnback.h"
 #include "../../inactivity/inactivity_settings_store.h"
 #include "../../player/player_settings_store.h"
 
@@ -172,6 +174,36 @@ void draw() noexcept {
                                                                settings.infiniteAmmoEnabled);
     if (changed) {
         (void)client::player::publish(settings);
+    }
+
+    ImGui::Spacing();
+    ImGui::Spacing();
+    ImGui::TextUnformatted("No Turnback");
+    ImGui::Separator();
+    ImGui::TextWrapped("Disable turnback-zone enforcement.");
+    ImGui::Spacing();
+
+    if (toggle::control("Enabled##no_turnback", settings.noTurnbackEnabled)) {
+        if (hooks::no_turnback::set_enabled(settings.noTurnbackEnabled)) {
+            (void)client::player::publish(settings);
+        } else {
+            settings.noTurnbackEnabled = !settings.noTurnbackEnabled;
+        }
+    }
+
+    ImGui::Spacing();
+    ImGui::Spacing();
+    ImGui::TextUnformatted("Godmode");
+    ImGui::Separator();
+    ImGui::TextWrapped("Prevent the player from taking damage.");
+    ImGui::Spacing();
+
+    if (toggle::control("Enabled##godmode", settings.godmodeEnabled)) {
+        if (hooks::godmode::set_enabled(settings.godmodeEnabled)) {
+            (void)client::player::publish(settings);
+        } else {
+            settings.godmodeEnabled = !settings.godmodeEnabled;
+        }
     }
 
     ImGui::Spacing();


### PR DESCRIPTION
## Summary

- add a persistent No Turnback toggle to the Player tab
- add a persistent Godmode toggle to the Player tab
- keep each feature in its own hook module
- validate original instructions before patching
- restore original instructions when disabled or during shutdown