### PR TITLE
Extend field of view limit to 155

### DIFF
--- a/Sunrise/src/state/account/settings/settings_state.cpp
+++ b/Sunrise/src/state/account/settings/settings_state.cpp
@@ -37,8 +37,8 @@ constexpr Range<std::int8_t> kAudioVolume{0, 10};
 constexpr Range<std::int8_t> kBrightness{0, 6};
 /** VSync stores the DXGI presentation interval from 0 to 4. */
 constexpr Range<std::uint8_t> kVerticalSyncInterval{0, 4};
-/** Field of view exposes the 55 through 105 degree range. */
-constexpr Range<std::int32_t> kFieldOfView{55, 105};
+/** Field of view accepts the game's full 55 through 155 degree range. */
+constexpr Range<std::int32_t> kFieldOfView{55, 155};
 /** The first unidentified calibration field uses the working renderer fallback. */
 constexpr float kCalibrationPrimary = 10000.0F;
 /** The second unidentified calibration field uses the working renderer alpha. */


### PR DESCRIPTION
allows setting the field of view in the settings.json to above the 105 cap since the game actually supports over 105 and allowing over 105 in the config allows users to manually set it over the ingame cap if they wish.