### PR TITLE
Report the framed prefix for refused incident bodies

### DIFF
--- a/Sunrise/src/middleware/bap/activity_message/activity_incident_parser.cpp
+++ b/Sunrise/src/middleware/bap/activity_message/activity_incident_parser.cpp
@@ -52,11 +52,17 @@ const char* verdict_name(Verdict verdict) noexcept {
     return "unknown";
 }
 
-/** Validates one incident body from its first target to the end of its payload. */
-Verdict validate(std::span<const std::byte> payload, Incident& parsed) noexcept {
-    parsed = {};
-    encoding::bits::Reader reader(payload);
+namespace {
 
+/**
+ * Frames one incident body, stopping at the first rule it breaks.
+ * A failed read leaves the cursor on the last complete field, so the caller can measure
+ * the prefix that framed whatever the verdict is.
+ * @param reader Reader sitting at the primary target field.
+ * @param parsed Already cleared. Receives every field reached before the verdict.
+ * @return accepted, or the first rule the body broke.
+ */
+[[nodiscard]] Verdict frame(encoding::bits::Reader& reader, Incident& parsed) noexcept {
     std::uint64_t field = 0;
     if (!reader.read(kTargetWidth, field)) {
         return Verdict::truncated;
@@ -131,9 +137,21 @@ Verdict validate(std::span<const std::byte> payload, Incident& parsed) noexcept 
         parsed.payload[index] = static_cast<std::byte>(field);
     }
     parsed.hasPayload = true;
+    return Verdict::accepted;
+}
+
+} // namespace
+
+/** Validates one incident body from its first target to the end of its payload. */
+Verdict validate(std::span<const std::byte> payload, Incident& parsed) noexcept {
+    parsed = {};
+    encoding::bits::Reader reader(payload);
+    const Verdict verdict = frame(reader, parsed);
+    // A refused body still reports the prefix that framed before the rule broke, so a
+    // receipt row separates a body that broke late from one that framed no field at all.
     parsed.consumedBits = static_cast<std::uint32_t>(payload.size() * encoding::kBitsPerByte
                                                      - reader.remaining_bits());
-    return Verdict::accepted;
+    return verdict;
 }
 
 } // namespace sunrise::middleware::bap::activity_message::incident

--- a/Sunrise/src/middleware/bap/activity_message/incident.h
+++ b/Sunrise/src/middleware/bap/activity_message/incident.h
@@ -73,7 +73,11 @@ struct Incident {
     /** Both optional words, read only when the optional block is present. */
     std::uint32_t optionalWordA{};
     std::uint32_t optionalWordB{};
-    /** Bits the body used. Below the payload's own bit count means trailing padding. */
+    /**
+     * Bits the body used, whatever the verdict. On an accepted body, below the payload's
+     * own bit count means trailing padding. On a refused one it is the prefix that framed
+     * before the rule broke.
+     */
     std::uint32_t consumedBits{};
     /** Set when a compressed selector is present. Its bytes stay opaque. */
     bool hasCompressedSelector{};
@@ -91,7 +95,8 @@ struct Incident {
  * Every target index is range and poison checked before anything else, because an out-of-range
  * index is a crash in the consumer rather than a decode error.
  * @param payload Activity message payload after the envelope.
- * @param parsed Cleared first. Receives every field reached before the verdict.
+ * @param parsed Cleared first. Receives every field reached before the verdict, and the
+ * framed prefix in `consumedBits` whether or not the body passed.
  * @return accepted, or the first rule the body broke.
  */
 [[nodiscard]] Verdict validate(std::span<const std::byte> payload, Incident& parsed) noexcept;


### PR DESCRIPTION
## Summary

`incident::validate` only recorded `Incident::consumedBits` on the accepted path, so every refused
incident reported a framed prefix of zero bits. This moves the framing walk into a helper and
stamps `consumedBits` once, on every path, from the reader's own cursor.

## What was wrong

`validate` assigned `parsed.consumedBits` as its last statement before `return Verdict::accepted`.
All thirteen early returns left the field at the zero it was cleared to, so the value was only ever
meaningful for a body that passed.

The route already tries to use it for bodies that did not pass. In
`server/bap/encrypted/activity_message/receipts/activity_message_receipts.cpp`, `frame_incident`
ends its rejection branch with:

```cpp
const Verdict outcome = verdict == incident::Verdict::targetPoisoned
                                || verdict == incident::Verdict::targetOutOfRange
                            ? Verdict::quarantined
                            : Verdict::malformed;
return {outcome, parsed.consumedBits};
```

That `parsed.consumedBits` was provably always zero, so the branch read as if it carried a framing
fact while it carried nothing.

The zero then travelled on. `Framed::consumedBits` becomes `Arrival::consumedBits`, which becomes
`ActivityReceipt::lastConsumedBits`, whose contract in `state/activity/receipts/` is "Bits the
parser consumed. Zero when the type has no parser of its own." A quarantined incident therefore
recorded the same value as a message type that is never parsed at all, and the registry could not
separate a body that broke on its very first field from one that framed almost completely and broke
on its payload length.

Incident is the only framing-only body where this matters. The fixed-size peer-ledger bodies
(`parse_release`, `parse_leave`, `parse_migration`) legitimately report zero on failure, because a
short fixed body frames nothing. Incident is variable length, `Incident` already retains every
field reached before the verdict, and `validate` documents that it does.

## What changed

- `activity_incident_parser.cpp`: the framing walk moves into `frame(reader, parsed)` in an
  anonymous namespace, returning the same `Verdict` from the same thirteen points. `validate` now
  calls it and assigns `consumedBits` once, after it returns, from
  `payload.size() * kBitsPerByte - reader.remaining_bits()` — the same expression the accepted path
  used before.
- `incident.h`: documentation only. `Incident::consumedBits` and `validate`'s `@param parsed` now
  state that the field is populated whatever the verdict.

This relies on the reader's existing contract. `Reader::can_consume` makes failure sticky without
moving the cursor, so after a failed read `remaining_bits()` still reports the position of the last
complete field, which is exactly the framed prefix.

The second anonymous namespace block after a public function follows the shape already used by
`activity_sensor_auth_blocks.cpp` in this directory.

## Effects

No wire behaviour changes. No verdict changes. The accepted path produces byte-identical results.
The only change is that receipt rows for quarantined and malformed incidents now carry the bit
offset where framing stopped instead of zero.

Measured against a set of bodies built with the project's own `bits::Writer`, before and after:

| body                  | verdict             | before | after |
|-----------------------|---------------------|--------|-------|
| accepted, all counts 0 | accepted            | 29     | 29    |
| primary target 795     | target_poisoned     | 0      | 13    |
| primary target 7763    | target_out_of_range | 0      | 13    |
| declares 3 extras, carries 1 | truncated     | 0      | 31    |
| declares 501 payload bytes | payload_too_long | 0      | 29    |

13 is the primary target field alone, 29 is the five fixed fields, and 31 is the fixed prefix plus
the one extra target that was actually present — each the correct framed prefix for that body.

## Testing

The repository has no test harness, so the table above was produced outside it: the two parser
revisions were compiled against the project's real `bit_reader.cpp` and `bit_writer.cpp` with
clang 17 `-std=c++20 -Wall -Wextra` and run against bodies built by `bits::Writer`. Both changed
files are `clang-format --style=file` clean against the repository's `.clang-format`.

I am on macOS and cannot run the mod itself, so this has not been exercised against the game. The
change is confined to a diagnostic field on the receive path and does not alter any verdict or any
byte on the wire, but flagging it so it is reviewed with that in mind.
