### PR TITLE
Detach the membership probe at client shutdown

### DIFF
--- a/Sunrise/src/client/runtime/client_runtime_lifecycle.cpp
+++ b/Sunrise/src/client/runtime/client_runtime_lifecycle.cpp
@@ -12,6 +12,7 @@
 #include "../hooks/graphics/graphics_hook_lifecycle.h"
 #include "../hooks/inactivity/inactivity_override.h"
 #include "../hooks/infinite_ammo/infinite_ammo.h"
+#include "../hooks/membership_probe/membership_probe.h"
 #include "../hooks/network/runtime.h"
 #include "../hooks/noclip/runtime.h"
 #include "../hooks/package_trust/package_trust_bypass.h"
@@ -77,6 +78,15 @@ bool shutdown() noexcept {
         core::log::write(core::log::Channel::client,
                          core::log::Level::error,
                          "ev=shutdown stage=package_trust result=fail");
+        ReleaseSRWLockExclusive(&runtime::g_lock);
+        return false;
+    }
+    // Attached last, so it detaches first. The probe reads through a detour, so one left in
+    // place is a branch into code a later unload unmaps.
+    if (!hooks::membership_probe::uninstall()) {
+        core::log::write(core::log::Channel::client,
+                         core::log::Level::error,
+                         "ev=shutdown stage=membership_probe result=fail");
         ReleaseSRWLockExclusive(&runtime::g_lock);
         return false;
     }


### PR DESCRIPTION
`membership_probe` is installed during main activation but never detached.
Every other client hook is uninstalled in `client::shutdown()`; this one is
absent from that sequence, so its detour stays attached after the Client layer
reports a clean shutdown.

The hook's own header states the requirement:

> Detaches the probe so a later unload cannot leave a detour into unmapped code.

`uninstall()` is implemented and is simply never called. The practical risk is
latent rather than active — the module normally lives for the process lifetime,
so nothing gets the chance to fall through the stale branch — but it breaks the
guarantee `shutdown()` exists to provide, and that guarantee is what lets Core
tear down Server and State once Client reports success.

## Change

One call, placed immediately before `hooks::bitmap::uninstall()`. The probe is
installed last in `activate_required_main_locked`, so it detaches first. A
failed detach is reported and aborts the shutdown, matching `retail_log`, the
other diagnostic hook whose `uninstall()` returns a status.

## Unchanged

Install order, the probe's behaviour while attached, every other hook's teardown
order and failure handling, and the shutdown sequence past this point. No new
files, so `Sunrise.vcxproj` needs no entry.

## Verification

- Builds clean (`client_runtime_lifecycle.cpp`, MSVC v145 x64).
- `clang-format --style=file --dry-run --Werror` reports no changes.
- Verified against the source that every hook declaring `uninstall()` is now
  called at shutdown; `egress` remains the only installed hook without one,
  which is deliberate — it is module-pinned to outlive Steam shutdown.