### PR TITLE
Rebuild a cache written by any other format version

### DIFF
--- a/Sunrise/src/state/build_data/cache/read/cache_file_reader.cpp
+++ b/Sunrise/src/state/build_data/cache/read/cache_file_reader.cpp
@@ -74,13 +74,16 @@ namespace {
 }
 
 /**
- * Every format below the current one is out of date, so a version bump needs no edit here.
- * Listing them one by one left a bumped version unknown, and a valid old cache read as corrupt.
+ * A cache written by any other format is out of date, so a version bump needs no edit here.
+ * Listing them one by one left a bumped version unknown, and a valid cache read as corrupt.
+ * A newer file is another build's cache rather than a damaged one, so it rebuilds the same way.
+ * Reading it as corrupt instead failed the whole boot until the file was deleted by hand, which
+ * is what downgrading the module did.
  * @param version Cache prefix version.
- * @return True when the cache is older than the current format.
+ * @return True when the cache was not written by the current format.
  */
 [[nodiscard]] bool stale_format(std::uint32_t version) noexcept {
-    return version < records::kCacheFormatVersion;
+    return version != records::kCacheFormatVersion;
 }
 
 /** @return The pending status, or invalid when the file fails to close. */
@@ -148,9 +151,6 @@ LoadStatus load(const wchar_t* path,
     }
     if (stale_format(prefix.version)) {
         return close_with(file, LoadStatus::stale);
-    }
-    if (prefix.version != records::kCacheFormatVersion) {
-        return close_with(file, LoadStatus::invalid);
     }
 
     LARGE_INTEGER beginning{};


### PR DESCRIPTION
`stale_format()` only recognises caches written by an *older* format. A cache written by a *newer* one falls through to `LoadStatus::invalid`, and an invalid cache fails the entire boot — `build_data::initialize` returns false, `state::initialize` propagates it, and Core reports the `state` stage as failed.

The function's own comment records that this defect was already fixed once in the other direction:

> Listing them one by one left a bumped version unknown, and a valid old cache read as corrupt.

A newer file is another build's cache, not a damaged one. It is fully re-derivable from the installed packages, so it should rebuild exactly as an older one does. In practice this is what makes switching between module builds fail: the format version bumps often, so moving back to an earlier build leaves a cache that build cannot read, and the boot dies until the file is deleted by hand.

## Change

`stale_format()` now reports any version that is not the current one, and the branch that mapped a bare version mismatch to `invalid` is removed as unreachable.

## Unchanged

Corruption is still rejected: bad magic, payload checksum mismatch, exact-size mismatch, count and required-domain validation, and a header whose version disagrees with the prefix all still return `invalid`. Only "written by a different format version" moves from `invalid` to `stale`. Older caches keep their existing behaviour.

## Verification

- Builds clean (`cache_file_reader.cpp`, MSVC v145 x64).
- `clang-format --style=file --dry-run --Werror` reports no changes.
- Confirmed the corruption paths still route to `invalid` after the change, so the narrower classification does not weaken file validation.