### PR TITLE
Ignore the Visual Studio CMake output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 # CMake build files
 /build/
+/out/


### PR DESCRIPTION
`.gitignore` covers `/build/` but not `/out/`, which is the directory Visual Studio's CMake integration writes to. Opening the project in Visual Studio therefore leaves the whole generated tree — the CMake file-API cache, `compile_commands.json`, ninja files, objects and PDBs — showing as untracked, so Source Control lists roughly fifty generated files alongside real changes.

`/out/` is added beside `/build/` under the existing CMake section. One line, no other change.