### PR TITLE
Persist account state with SQLite

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -74,5 +74,5 @@ ExtraArgsBefore:
   - -Wdocumentation
 FormatStyle: file
 CheckOptions:
-  portability-restrict-system-includes.Includes: '-*,Windows.h,WinSock2.h,WS2tcpip.h,MSWSock.h,WinDNS.h,TlHelp32.h,Shellapi.h,bcrypt.h,d3d11.h,detours.h,dxgi.h,wincodec.h,imgui.h,imgui_impl_dx11.h,imgui_impl_win32.h,intrin.h,algorithm,array,atomic,bit,bitset,cctype,charconv,chrono,climits,cmath,cstdarg,cstddef,cstdint,cstdio,cstdlib,cstring,cwchar,limits,memory,new,optional,span,string_view,type_traits,utility,variant,vector'
+  portability-restrict-system-includes.Includes: '-*,Windows.h,WinSock2.h,WS2tcpip.h,MSWSock.h,WinDNS.h,TlHelp32.h,Shellapi.h,bcrypt.h,d3d11.h,detours.h,dxgi.h,wincodec.h,winsqlite/winsqlite3.h,imgui.h,imgui_impl_dx11.h,imgui_impl_win32.h,intrin.h,algorithm,array,atomic,bit,bitset,cctype,charconv,chrono,climits,cmath,cstdarg,cstddef,cstdint,cstdio,cstdlib,cstring,cwchar,limits,memory,new,optional,span,string_view,type_traits,utility,variant,vector'
 ...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,16 @@ jobs:
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@v2
 
+      - name: Build SQLite persistence test
+        run: >
+          msbuild tests/SQLitePersistenceTests.vcxproj /m
+          /p:Configuration=Release
+          /p:Platform=x64
+          /verbosity:minimal
+
+      - name: Run SQLite persistence test
+        run: .\tests\build\x64\Release\SQLitePersistenceTests.exe
+
       - name: Build
         run: >
           msbuild Sunrise.sln /m

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 # CMake build files
 /build/
 /out/
+/tests/build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,7 @@ target_link_libraries(steam_api64 PRIVATE
     kernel32 bcrypt user32 gdi32 dwmapi
     d3dcompiler shell32 ws2_32 synchronization
     windowscodecs
+    winsqlite3
 )
 
 set_target_properties(steam_api64 PROPERTIES

--- a/Sunrise/src/core/runtime/core_runtime.cpp
+++ b/Sunrise/src/core/runtime/core_runtime.cpp
@@ -14,7 +14,7 @@
 #include "../../server/runtime/server_runtime.h"
 #include "../../state/content_manifest/content_manifest_state_runtime.h"
 #include "../../state/entitlements/entitlement_runtime.h"
-#include "../../state/runtime/runtime.h"
+#include "../../state/persistence/sqlite_account_store.h"
 #include "../../state/unlocks/unlocks_runtime.h"
 #include "../filesystem/path.h"
 #include "../logging/log.h"
@@ -114,9 +114,9 @@ bool initialize(void* module) noexcept {
             stage = "ui_logs";
         } else if (!state::entitlements::publish(settings::get().server.entitlements)) {
             stage = "entitlements";
-        } else if (!state::initialize(module,
-                                      settings::get().initialAccount,
-                                      settings::get().initialActivityDefaults)) {
+        } else if (!state::persistence::initialize(module,
+                                                   settings::get().initialAccount,
+                                                   settings::get().initialActivityDefaults)) {
             stage = "state";
         } else if (!initialize_content_manifest(module)) {
             stage = "content_manifest";
@@ -139,7 +139,7 @@ bool initialize(void* module) noexcept {
         server::shutdown();
         middleware::shutdown();
         state::content_manifest::shutdown();
-        state::shutdown();
+        state::persistence::shutdown();
         state::entitlements::clear();
         ui::modules::logs::shutdown();
         ui::modules::hud::shutdown();
@@ -165,6 +165,13 @@ bool shutdown() noexcept {
         ReleaseSRWLockExclusive(&g_runtimeLock);
         return true;
     }
+    // Preserve a coherent snapshot before hook teardown, which can require a later retry. State
+    // stays live until Client fully detaches, and a successful teardown writes the final image.
+    if (!state::persistence::checkpoint("shutdown_attempt")) {
+        // Keep every runtime layer live so a later shutdown attempt can retry the durable write.
+        ReleaseSRWLockExclusive(&g_runtimeLock);
+        return false;
+    }
     if (!client::shutdown()) {
         // Server and State must remain valid while any Client hook is attached.
         ReleaseSRWLockExclusive(&g_runtimeLock);
@@ -174,7 +181,7 @@ bool shutdown() noexcept {
     server::shutdown();
     middleware::shutdown();
     state::content_manifest::shutdown();
-    state::shutdown();
+    state::persistence::shutdown();
     state::entitlements::clear();
     ui::modules::logs::shutdown();
     ui::modules::hud::shutdown();

--- a/Sunrise/src/state/persistence/sqlite/account_load.h
+++ b/Sunrise/src/state/persistence/sqlite/account_load.h
@@ -1,0 +1,320 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+
+#include "../../account/account_state.h"
+#include "database.h"
+#include "settings_codec.h"
+
+namespace sunrise::state::persistence::sqlite::detail {
+/** Outcome of attempting to restore one account. */
+enum class LoadResult {
+    disabled,
+    missing,
+    loaded,
+    schemaNewer,
+    formatNewer,
+    invalid,
+};
+
+/** Loads one exact plug prefix for an already-read item row. */
+[[nodiscard]] inline bool load_plugs(sqlite3* database,
+                                     std::size_t characterPosition,
+                                     int location,
+                                     std::size_t itemPosition,
+                                     account::inventory::Item& item) noexcept {
+    Statement statement(
+        database,
+        "SELECT plug_position, definition_hash FROM item_plugs "
+        "WHERE account_id = 1 AND character_position = ? AND location = ? "
+        "AND item_position = ? ORDER BY plug_position;");
+    if (statement.get() == nullptr
+        || !bind_count(statement.get(), 1, characterPosition)
+        || sqlite3_bind_int(statement.get(), 2, location) != SQLITE_OK
+        || !bind_count(statement.get(), 3, itemPosition)) {
+        return false;
+    }
+    std::size_t seen = 0;
+    int step = SQLITE_ROW;
+    while ((step = sqlite3_step(statement.get())) == SQLITE_ROW) {
+        std::size_t position = 0;
+        if (!column_count(statement.get(), 0, account::inventory::kPlugCapacity, position)
+            || position != seen || seen >= item.sockets.plugCount) {
+            return false;
+        }
+        if (sqlite3_column_type(statement.get(), 1) == SQLITE_NULL) {
+            item.sockets.plugs[seen].reset();
+        } else {
+            std::uint32_t definitionHash = 0;
+            if (!column_u32(statement.get(), 1, definitionHash)) {
+                return false;
+            }
+            item.sockets.plugs[seen] = definitionHash;
+        }
+        ++seen;
+    }
+    return step == SQLITE_DONE && seen == item.sockets.plugCount;
+}
+
+/** Loads every equipment and inventory item belonging to one character row. */
+[[nodiscard]] inline bool load_items(sqlite3* database,
+                                     std::size_t characterPosition,
+                                     std::size_t expectedInventoryCount,
+                                     CharacterState& character) noexcept {
+    Statement statement(
+        database,
+        "SELECT location, position, instance_soid, definition_hash, item_level, quantity, "
+        "mutation_serial, flags, socket_policy, plug_count, movement_ability_entry, "
+        "grenade_ability_entry, super_ability_entry, melee_ability_entry, class_ability_entry "
+        "FROM character_items WHERE account_id = 1 AND character_position = ? "
+        "ORDER BY location, position;");
+    if (statement.get() == nullptr
+        || !bind_count(statement.get(), 1, characterPosition)) {
+        return false;
+    }
+    std::array<bool, account::inventory::kEquipmentSlotCount> equipmentSeen{};
+    std::size_t inventorySeen = 0;
+    int step = SQLITE_ROW;
+    while ((step = sqlite3_step(statement.get())) == SQLITE_ROW) {
+        const int location = sqlite3_column_int(statement.get(), 0);
+        const std::size_t capacity =
+            location == kEquipmentItemLocation ? account::inventory::kEquipmentSlotCount
+                                               : account::inventory::kCharacterItemCapacity;
+        std::size_t position = 0;
+        account::inventory::Item item{};
+        std::uint8_t socketPolicy = 0;
+        if ((location != kEquipmentItemLocation && location != kInventoryItemLocation)
+            || !column_count(statement.get(), 1, capacity, position) || position >= capacity) {
+            return false;
+        }
+        item.instanceSoid = unsigned_integer(sqlite3_column_int64(statement.get(), 2));
+        if (!column_u32(statement.get(), 3, item.definitionHash)
+            || !column_i32(statement.get(), 4, item.level)
+            || !column_i32(statement.get(), 5, item.quantity)
+            || !column_i32(statement.get(), 6, item.mutationSerial)
+            || !column_u32(statement.get(), 7, item.flags)
+            || !column_u8(statement.get(), 8, socketPolicy)
+            || !column_count(statement.get(),
+                             9,
+                             account::inventory::kPlugCapacity,
+                             item.sockets.plugCount)
+            || !column_u8(statement.get(), 10, item.movementAbilityEntry)
+            || !column_u8(statement.get(), 11, item.grenadeAbilityEntry)
+            || !column_u8(statement.get(), 12, item.superAbilityEntry)
+            || !column_u8(statement.get(), 13, item.meleeAbilityEntry)
+            || !column_u8(statement.get(), 14, item.classAbilityEntry)) {
+            return false;
+        }
+        item.sockets.policy = static_cast<account::inventory::SocketPolicy>(socketPolicy);
+        if (!load_plugs(database, characterPosition, location, position, item)) {
+            return false;
+        }
+        if (location == kEquipmentItemLocation) {
+            if (equipmentSeen[position]) {
+                return false;
+            }
+            equipmentSeen[position] = true;
+            character.equipment.slots[position] = item;
+        } else {
+            if (position != inventorySeen || inventorySeen >= expectedInventoryCount) {
+                return false;
+            }
+            character.inventory.values[inventorySeen++] = item;
+        }
+    }
+    character.inventory.count = inventorySeen;
+    return step == SQLITE_DONE && inventorySeen == expectedInventoryCount;
+}
+
+/** Loads and validates one complete account row and every normalized child row. */
+[[nodiscard]] inline LoadResult load_account(void* module, AccountState& output) noexcept {
+    output = {};
+    if (module == nullptr) {
+        return LoadResult::disabled;
+    }
+    Database database;
+    const OpenResult opened = open_database(module, database);
+    if (opened == OpenResult::newer) {
+        return LoadResult::schemaNewer;
+    }
+    if (opened != OpenResult::opened) {
+        return LoadResult::invalid;
+    }
+
+    Statement root(database.get(),
+                   "SELECT format_version, primary_soid, dismantle_reward_count, "
+                   "profile_item_count, character_count, settings_payload "
+                   "FROM account_state WHERE singleton = 1;");
+    if (root.get() == nullptr) {
+        return LoadResult::invalid;
+    }
+    const int rootStep = sqlite3_step(root.get());
+    if (rootStep == SQLITE_DONE) {
+        return LoadResult::missing;
+    }
+    AccountState candidate{};
+    if (rootStep != SQLITE_ROW) {
+        return LoadResult::invalid;
+    }
+    const sqlite3_int64 accountFormat = sqlite3_column_int64(root.get(), 0);
+    if (accountFormat > kAccountFormatVersion) {
+        return LoadResult::formatNewer;
+    }
+    if (accountFormat != kAccountFormatVersion) {
+        return LoadResult::invalid;
+    }
+    candidate.primarySoid = unsigned_integer(sqlite3_column_int64(root.get(), 1));
+    if (!column_count(root.get(),
+                      2,
+                      candidate.dismantleRewards.size(),
+                      candidate.dismantleRewardCount)
+        || !column_count(root.get(),
+                         3,
+                         candidate.profileItems.size(),
+                         candidate.profileItemCount)
+        || !column_count(root.get(),
+                         4,
+                         candidate.characters.size(),
+                         candidate.characterCount)) {
+        return LoadResult::invalid;
+    }
+    const int payloadSize = sqlite3_column_bytes(root.get(), 5);
+    const auto* payload = static_cast<const std::byte*>(sqlite3_column_blob(root.get(), 5));
+    if (payloadSize <= 0 || payload == nullptr) {
+        return LoadResult::invalid;
+    }
+    const SettingsDecodeResult settings =
+        decode_settings({payload, static_cast<std::size_t>(payloadSize)}, candidate.settings);
+    if (settings == SettingsDecodeResult::incompatible) {
+        return LoadResult::formatNewer;
+    }
+    if (payloadSize > static_cast<int>(kSettingsPayloadCapacity)
+        || settings != SettingsDecodeResult::decoded
+        || sqlite3_step(root.get()) != SQLITE_DONE) {
+        return LoadResult::invalid;
+    }
+
+    Statement rewards(
+        database.get(),
+        "SELECT position, definition_hash, quantity, tier_mask, class_mask, masterwork "
+        "FROM dismantle_rewards WHERE account_id = 1 ORDER BY position;");
+    if (rewards.get() == nullptr) {
+        return LoadResult::invalid;
+    }
+    std::size_t rewardSeen = 0;
+    int step = SQLITE_ROW;
+    while ((step = sqlite3_step(rewards.get())) == SQLITE_ROW) {
+        std::size_t position = 0;
+        DismantleRewardPolicy reward{};
+        std::uint8_t masterwork = 0;
+        if (!column_count(rewards.get(), 0, candidate.dismantleRewards.size(), position)
+            || position != rewardSeen || rewardSeen >= candidate.dismantleRewardCount
+            || !column_u32(rewards.get(), 1, reward.definitionHash)
+            || !column_i32(rewards.get(), 2, reward.quantity)
+            || !column_u8(rewards.get(), 3, reward.tierMask)
+            || !column_u8(rewards.get(), 4, reward.classMask)
+            || !column_u8(rewards.get(), 5, masterwork)) {
+            return LoadResult::invalid;
+        }
+        reward.masterwork = static_cast<DismantleMasterworkFilter>(masterwork);
+        candidate.dismantleRewards[rewardSeen++] = reward;
+    }
+    if (step != SQLITE_DONE || rewardSeen != candidate.dismantleRewardCount) {
+        return LoadResult::invalid;
+    }
+
+    Statement profiles(database.get(),
+                       "SELECT position, instance_soid, definition_hash, quantity, "
+                       "mutation_serial FROM profile_items WHERE account_id = 1 "
+                       "ORDER BY position;");
+    if (profiles.get() == nullptr) {
+        return LoadResult::invalid;
+    }
+    std::size_t profileSeen = 0;
+    while ((step = sqlite3_step(profiles.get())) == SQLITE_ROW) {
+        std::size_t position = 0;
+        account::inventory::ProfileItem item{};
+        if (!column_count(profiles.get(), 0, candidate.profileItems.size(), position)
+            || position != profileSeen || profileSeen >= candidate.profileItemCount) {
+            return LoadResult::invalid;
+        }
+        item.instanceSoid = unsigned_integer(sqlite3_column_int64(profiles.get(), 1));
+        if (!column_u32(profiles.get(), 2, item.definitionHash)
+            || !column_i32(profiles.get(), 3, item.quantity)
+            || !column_i32(profiles.get(), 4, item.mutationSerial)) {
+            return LoadResult::invalid;
+        }
+        candidate.profileItems[profileSeen++] = item;
+    }
+    if (step != SQLITE_DONE || profileSeen != candidate.profileItemCount) {
+        return LoadResult::invalid;
+    }
+
+    Statement characters(
+        database.get(),
+        "SELECT position, soid, selected, race, gender, character_class, level, accepted, "
+        "preview_available, appearance_value, last_orbited_destination, content_bypass, "
+        "acquired_subclass_ability_mask, inventory_count, next_inventory_serial "
+        "FROM characters WHERE account_id = 1 ORDER BY position;");
+    if (characters.get() == nullptr) {
+        return LoadResult::invalid;
+    }
+    std::array<std::size_t, kCharacterCapacity> inventoryCounts{};
+    std::size_t characterSeen = 0;
+    while ((step = sqlite3_step(characters.get())) == SQLITE_ROW) {
+        std::size_t position = 0;
+        CharacterState character{};
+        std::uint8_t race = 0;
+        std::uint8_t gender = 0;
+        std::uint8_t characterClass = 0;
+        if (!column_count(characters.get(), 0, candidate.characters.size(), position)
+            || position != characterSeen || characterSeen >= candidate.characterCount) {
+            return LoadResult::invalid;
+        }
+        character.soid = unsigned_integer(sqlite3_column_int64(characters.get(), 1));
+        if (!column_bool(characters.get(), 2, character.selected)
+            || !column_u8(characters.get(), 3, race)
+            || !column_u8(characters.get(), 4, gender)
+            || !column_u8(characters.get(), 5, characterClass)
+            || !column_u8(characters.get(), 6, character.level)
+            || !column_bool(characters.get(), 7, character.accepted)
+            || !column_bool(characters.get(), 8, character.previewAvailable)
+            || !column_float(characters.get(), 9, character.appearanceValue)
+            || !column_u32(characters.get(), 10, character.lastOrbitedDestination)
+            || !column_bool(characters.get(), 11, character.contentBypass)
+            || !column_count(characters.get(),
+                             13,
+                             account::inventory::kCharacterItemCapacity,
+                             inventoryCounts[characterSeen])
+            || !column_u32(characters.get(), 14, character.nextInventorySerial)) {
+            return LoadResult::invalid;
+        }
+        character.race = static_cast<CharacterRace>(race);
+        character.gender = static_cast<CharacterGender>(gender);
+        character.characterClass = static_cast<CharacterClass>(characterClass);
+        character.acquiredSubclassAbilityMask =
+            unsigned_integer(sqlite3_column_int64(characters.get(), 12));
+        candidate.characters[characterSeen++] = character;
+    }
+    if (step != SQLITE_DONE || characterSeen != candidate.characterCount) {
+        return LoadResult::invalid;
+    }
+    for (std::size_t index = 0; index < candidate.characterCount; ++index) {
+        if (!load_items(database.get(),
+                        index,
+                        inventoryCounts[index],
+                        candidate.characters[index])) {
+            return LoadResult::invalid;
+        }
+    }
+    if (!account::valid(candidate)) {
+        return LoadResult::invalid;
+    }
+    output = candidate;
+    return LoadResult::loaded;
+}
+
+} // namespace sunrise::state::persistence::sqlite::detail

--- a/Sunrise/src/state/persistence/sqlite/account_save.h
+++ b/Sunrise/src/state/persistence/sqlite/account_save.h
@@ -1,0 +1,230 @@
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+
+#include "../../account/account_state.h"
+#include "database.h"
+#include "settings_codec.h"
+
+namespace sunrise::state::persistence::sqlite::detail {
+/** Inserts one item row and its exact optional plug prefix. */
+[[nodiscard]] inline bool store_item(Statement& itemInsert,
+                                     Statement& plugInsert,
+                                     std::size_t characterPosition,
+                                     int location,
+                                     std::size_t position,
+                                     const account::inventory::Item& item) noexcept {
+    sqlite3_stmt* statement = itemInsert.get();
+    if (statement == nullptr || !bind_count(statement, 1, characterPosition)
+        || sqlite3_bind_int(statement, 2, location) != SQLITE_OK
+        || !bind_count(statement, 3, position) || !bind_u64(statement, 4, item.instanceSoid)
+        || sqlite3_bind_int64(statement, 5, item.definitionHash) != SQLITE_OK
+        || sqlite3_bind_int64(statement, 6, item.level) != SQLITE_OK
+        || sqlite3_bind_int64(statement, 7, item.quantity) != SQLITE_OK
+        || sqlite3_bind_int64(statement, 8, item.mutationSerial) != SQLITE_OK
+        || sqlite3_bind_int64(statement, 9, item.flags) != SQLITE_OK
+        || sqlite3_bind_int(statement, 10, static_cast<int>(item.sockets.policy)) != SQLITE_OK
+        || !bind_count(statement, 11, item.sockets.plugCount)
+        || sqlite3_bind_int(statement, 12, item.movementAbilityEntry) != SQLITE_OK
+        || sqlite3_bind_int(statement, 13, item.grenadeAbilityEntry) != SQLITE_OK
+        || sqlite3_bind_int(statement, 14, item.superAbilityEntry) != SQLITE_OK
+        || sqlite3_bind_int(statement, 15, item.meleeAbilityEntry) != SQLITE_OK
+        || sqlite3_bind_int(statement, 16, item.classAbilityEntry) != SQLITE_OK
+        || sqlite3_step(statement) != SQLITE_DONE || !itemInsert.reset()) {
+        return false;
+    }
+    for (std::size_t plugPosition = 0; plugPosition < item.sockets.plugCount;
+         ++plugPosition) {
+        sqlite3_stmt* plug = plugInsert.get();
+        const std::optional<std::uint32_t>& hash = item.sockets.plugs[plugPosition];
+        if (plug == nullptr || !bind_count(plug, 1, characterPosition)
+            || sqlite3_bind_int(plug, 2, location) != SQLITE_OK
+            || !bind_count(plug, 3, position) || !bind_count(plug, 4, plugPosition)
+            || (hash.has_value()
+                    ? sqlite3_bind_int64(plug, 5, hash.value()) != SQLITE_OK
+                    : sqlite3_bind_null(plug, 5) != SQLITE_OK)
+            || sqlite3_step(plug) != SQLITE_DONE || !plugInsert.reset()) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/** Replaces the complete account snapshot in one durable SQLite transaction. */
+[[nodiscard]] inline bool save_account(void* module, const AccountState& accountState) noexcept {
+    if (module == nullptr) {
+        return true;
+    }
+    if (!account::valid(accountState)) {
+        return false;
+    }
+    Database database;
+    if (open_database(module, database) != OpenResult::opened
+        || !database.configure_supported_schema()
+        || !database.execute("BEGIN IMMEDIATE;")) {
+        return false;
+    }
+    const bool stored = [&]() noexcept {
+        if (!database.execute(
+                "DELETE FROM item_plugs; DELETE FROM character_items; DELETE FROM characters; "
+                "DELETE FROM profile_items; DELETE FROM dismantle_rewards; "
+                "DELETE FROM account_state;")) {
+            return false;
+        }
+        SettingsWriter settings;
+        if (!encode_settings(accountState.settings, settings)) {
+            return false;
+        }
+        Statement root(database.get(),
+                       "INSERT INTO account_state (singleton, format_version, primary_soid, "
+                       "dismantle_reward_count, profile_item_count, character_count, "
+                       "settings_payload, updated_unix_seconds) VALUES (1, ?, ?, ?, ?, ?, ?, ?);");
+        const std::span<const std::byte> payload = settings.bytes();
+        const auto now = std::chrono::duration_cast<std::chrono::seconds>(
+                             std::chrono::system_clock::now().time_since_epoch())
+                             .count();
+        if (root.get() == nullptr
+            || sqlite3_bind_int(root.get(), 1, kAccountFormatVersion) != SQLITE_OK
+            || !bind_u64(root.get(), 2, accountState.primarySoid)
+            || !bind_count(root.get(), 3, accountState.dismantleRewardCount)
+            || !bind_count(root.get(), 4, accountState.profileItemCount)
+            || !bind_count(root.get(), 5, accountState.characterCount)
+            || sqlite3_bind_blob(root.get(),
+                                 6,
+                                 payload.data(),
+                                 static_cast<int>(payload.size()),
+                                 SQLITE_TRANSIENT)
+                   != SQLITE_OK
+            || sqlite3_bind_int64(root.get(), 7, static_cast<sqlite3_int64>(now))
+                   != SQLITE_OK
+            || sqlite3_step(root.get()) != SQLITE_DONE) {
+            return false;
+        }
+
+        Statement rewardInsert(
+            database.get(),
+            "INSERT INTO dismantle_rewards (account_id, position, definition_hash, quantity, "
+            "tier_mask, class_mask, masterwork) VALUES (1, ?, ?, ?, ?, ?, ?);");
+        if (rewardInsert.get() == nullptr) {
+            return false;
+        }
+        for (std::size_t index = 0; index < accountState.dismantleRewardCount; ++index) {
+            const DismantleRewardPolicy& reward = accountState.dismantleRewards[index];
+            sqlite3_stmt* statement = rewardInsert.get();
+            if (!bind_count(statement, 1, index)
+                || sqlite3_bind_int64(statement, 2, reward.definitionHash) != SQLITE_OK
+                || sqlite3_bind_int64(statement, 3, reward.quantity) != SQLITE_OK
+                || sqlite3_bind_int(statement, 4, reward.tierMask) != SQLITE_OK
+                || sqlite3_bind_int(statement, 5, reward.classMask) != SQLITE_OK
+                || sqlite3_bind_int(statement, 6, static_cast<int>(reward.masterwork)) != SQLITE_OK
+                || sqlite3_step(statement) != SQLITE_DONE || !rewardInsert.reset()) {
+                return false;
+            }
+        }
+
+        Statement profileInsert(
+            database.get(),
+            "INSERT INTO profile_items (account_id, position, instance_soid, definition_hash, "
+            "quantity, mutation_serial) VALUES (1, ?, ?, ?, ?, ?);");
+        if (profileInsert.get() == nullptr) {
+            return false;
+        }
+        for (std::size_t index = 0; index < accountState.profileItemCount; ++index) {
+            const account::inventory::ProfileItem& item = accountState.profileItems[index];
+            sqlite3_stmt* statement = profileInsert.get();
+            if (!bind_count(statement, 1, index) || !bind_u64(statement, 2, item.instanceSoid)
+                || sqlite3_bind_int64(statement, 3, item.definitionHash) != SQLITE_OK
+                || sqlite3_bind_int64(statement, 4, item.quantity) != SQLITE_OK
+                || sqlite3_bind_int64(statement, 5, item.mutationSerial) != SQLITE_OK
+                || sqlite3_step(statement) != SQLITE_DONE || !profileInsert.reset()) {
+                return false;
+            }
+        }
+
+        Statement characterInsert(
+            database.get(),
+            "INSERT INTO characters (account_id, position, soid, selected, race, gender, "
+            "character_class, level, accepted, preview_available, appearance_value, "
+            "last_orbited_destination, content_bypass, acquired_subclass_ability_mask, "
+            "inventory_count, next_inventory_serial) "
+            "VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);");
+        Statement itemInsert(
+            database.get(),
+            "INSERT INTO character_items (account_id, character_position, location, position, "
+            "instance_soid, definition_hash, item_level, quantity, mutation_serial, flags, "
+            "socket_policy, plug_count, movement_ability_entry, grenade_ability_entry, "
+            "super_ability_entry, melee_ability_entry, class_ability_entry) "
+            "VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);");
+        Statement plugInsert(
+            database.get(),
+            "INSERT INTO item_plugs (account_id, character_position, location, item_position, "
+            "plug_position, definition_hash) VALUES (1, ?, ?, ?, ?, ?);");
+        if (characterInsert.get() == nullptr || itemInsert.get() == nullptr
+            || plugInsert.get() == nullptr) {
+            return false;
+        }
+        for (std::size_t characterIndex = 0; characterIndex < accountState.characterCount;
+             ++characterIndex) {
+            const CharacterState& character = accountState.characters[characterIndex];
+            sqlite3_stmt* statement = characterInsert.get();
+            if (!bind_count(statement, 1, characterIndex)
+                || !bind_u64(statement, 2, character.soid)
+                || !bind_bool(statement, 3, character.selected)
+                || sqlite3_bind_int(statement, 4, static_cast<int>(character.race)) != SQLITE_OK
+                || sqlite3_bind_int(statement, 5, static_cast<int>(character.gender)) != SQLITE_OK
+                || sqlite3_bind_int(statement, 6, static_cast<int>(character.characterClass))
+                       != SQLITE_OK
+                || sqlite3_bind_int(statement, 7, character.level) != SQLITE_OK
+                || !bind_bool(statement, 8, character.accepted)
+                || !bind_bool(statement, 9, character.previewAvailable)
+                || sqlite3_bind_double(statement, 10, character.appearanceValue) != SQLITE_OK
+                || sqlite3_bind_int64(statement, 11, character.lastOrbitedDestination)
+                       != SQLITE_OK
+                || !bind_bool(statement, 12, character.contentBypass)
+                || !bind_u64(statement, 13, character.acquiredSubclassAbilityMask)
+                || !bind_count(statement, 14, character.inventory.count)
+                || sqlite3_bind_int64(statement, 15, character.nextInventorySerial) != SQLITE_OK
+                || sqlite3_step(statement) != SQLITE_DONE || !characterInsert.reset()) {
+                return false;
+            }
+            for (std::size_t slot = 0; slot < character.equipment.slots.size(); ++slot) {
+                const std::optional<account::inventory::Item>& item =
+                    character.equipment.slots[slot];
+                if (item.has_value()
+                    && !store_item(
+                        itemInsert,
+                        plugInsert,
+                        characterIndex,
+                        kEquipmentItemLocation,
+                        slot,
+                        item.value())) {
+                    return false;
+                }
+            }
+            for (std::size_t index = 0; index < character.inventory.count; ++index) {
+                if (!store_item(itemInsert,
+                                plugInsert,
+                                characterIndex,
+                                kInventoryItemLocation,
+                                index,
+                                character.inventory.values[index])) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }();
+    if (!stored || !database.execute("COMMIT;")) {
+        (void)database.execute("ROLLBACK;");
+        return false;
+    }
+    // Bound sidecar growth on clean shutdown without changing commit success semantics.
+    (void)database.execute("PRAGMA wal_checkpoint(TRUNCATE);");
+    return true;
+}
+
+} // namespace sunrise::state::persistence::sqlite::detail

--- a/Sunrise/src/state/persistence/sqlite/account_snapshot.h
+++ b/Sunrise/src/state/persistence/sqlite/account_snapshot.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#include "account_load.h"
+#include "account_save.h"

--- a/Sunrise/src/state/persistence/sqlite/database.h
+++ b/Sunrise/src/state/persistence/sqlite/database.h
@@ -1,0 +1,375 @@
+#pragma once
+
+#include <Windows.h>
+#include <winsqlite/winsqlite3.h>
+
+#include <bit>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <string_view>
+
+#include "../../../core/filesystem/path.h"
+
+#if defined(_MSC_VER)
+#pragma comment(lib, "winsqlite3.lib")
+#endif
+
+namespace sunrise::state::persistence::sqlite::detail {
+
+/** Version of the relational SQLite schema owned by this implementation. */
+inline constexpr int kSchemaVersion = 1;
+/** Version of the account row contract independent of SQLite table migrations. */
+inline constexpr int kAccountFormatVersion = 1;
+/** Version of the explicit account-settings payload stored in the account row. */
+inline constexpr std::uint32_t kSettingsPayloadVersion = 1;
+/** Fixed payload storage is comfortably above the current settings and binding table. */
+inline constexpr std::size_t kSettingsPayloadCapacity = 1024;
+/** Wait long enough for a prior checkpoint to release the single-writer lock. */
+inline constexpr int kBusyTimeoutMilliseconds = 3'000;
+/** Stable discriminator values stored in character_items.location. */
+inline constexpr int kEquipmentItemLocation = 0;
+inline constexpr int kInventoryItemLocation = 1;
+/** SQLite database stored in Sunrise's generated-artifact directory. */
+inline constexpr std::wstring_view kDatabaseSuffix = L"\\state.sqlite3";
+
+/** Outcome of opening and migrating the database. */
+enum class OpenResult {
+    opened,
+    newer,
+    failed,
+};
+
+/** Owns one prepared SQLite statement. */
+class Statement final {
+public:
+    Statement(sqlite3* database, const char* sql) noexcept {
+        if (database != nullptr && sql != nullptr) {
+            (void)sqlite3_prepare_v2(database, sql, -1, &value_, nullptr);
+        }
+    }
+
+    ~Statement() noexcept {
+        if (value_ != nullptr) {
+            (void)sqlite3_finalize(value_);
+        }
+    }
+
+    Statement(const Statement&) = delete;
+    Statement& operator=(const Statement&) = delete;
+
+    /** @return Prepared statement handle, or null when preparation failed. */
+    [[nodiscard]] sqlite3_stmt* get() const noexcept {
+        return value_;
+    }
+
+    /** Resets one reusable insert and clears every prior binding. */
+    [[nodiscard]] bool reset() noexcept {
+        return value_ != nullptr && sqlite3_reset(value_) == SQLITE_OK
+               && sqlite3_clear_bindings(value_) == SQLITE_OK;
+    }
+
+private:
+    sqlite3_stmt* value_{};
+};
+
+/** Owns one SQLite connection. */
+class Database final {
+public:
+    ~Database() noexcept {
+        if (value_ != nullptr) {
+            (void)sqlite3_close(value_);
+        }
+    }
+
+    Database(const Database&) = delete;
+    Database& operator=(const Database&) = delete;
+    Database() = default;
+
+    /** Opens the database beside Sunrise's other generated artifacts. */
+    [[nodiscard]] bool open(void* module) noexcept {
+        core::path::Buffer path;
+        if (module == nullptr || !core::path::artifact_directory(module, path)
+            || !core::path::append(path, kDatabaseSuffix)) {
+            return false;
+        }
+        if (sqlite3_open16(path.chars.data(), &value_) != SQLITE_OK || value_ == nullptr) {
+            if (value_ != nullptr) {
+                (void)sqlite3_close(value_);
+                value_ = nullptr;
+            }
+            return false;
+        }
+        (void)sqlite3_extended_result_codes(value_, 1);
+        return sqlite3_busy_timeout(value_, kBusyTimeoutMilliseconds) == SQLITE_OK;
+    }
+
+    /** Enables write behavior only after this build accepts the on-disk schema. */
+    [[nodiscard]] bool configure_supported_schema() noexcept {
+        if (!execute("PRAGMA foreign_keys = ON;")
+            || !execute("PRAGMA synchronous = FULL;")) {
+            return false;
+        }
+        // WAL makes later write-through checkpoints practical. The fallback journal remains safe
+        // when the host or filesystem refuses the mode transition.
+        (void)execute("PRAGMA journal_mode = WAL;");
+        return true;
+    }
+
+    /** Executes one or more SQL statements without returning rows. */
+    [[nodiscard]] bool execute(const char* sql) noexcept {
+        return value_ != nullptr && sql != nullptr
+               && sqlite3_exec(value_, sql, nullptr, nullptr, nullptr) == SQLITE_OK;
+    }
+
+    /** @return Borrowed connection handle. */
+    [[nodiscard]] sqlite3* get() const noexcept {
+        return value_;
+    }
+
+private:
+    sqlite3* value_{};
+};
+
+/** Converts every uint64 bit pattern into SQLite's signed integer domain. */
+[[nodiscard]] inline sqlite3_int64 sql_integer(std::uint64_t value) noexcept {
+    return std::bit_cast<std::int64_t>(value);
+}
+
+/** Restores a uint64 bit pattern read from a SQLite signed integer. */
+[[nodiscard]] inline std::uint64_t unsigned_integer(sqlite3_int64 value) noexcept {
+    return std::bit_cast<std::uint64_t>(static_cast<std::int64_t>(value));
+}
+
+/** Binds one bool as canonical integer zero or one. */
+[[nodiscard]] inline bool bind_bool(sqlite3_stmt* statement, int index, bool value) noexcept {
+    return sqlite3_bind_int(statement, index, value ? 1 : 0) == SQLITE_OK;
+}
+
+/** Binds an unsigned 64-bit bit pattern without losing its high bit. */
+[[nodiscard]] inline bool
+bind_u64(sqlite3_stmt* statement, int index, std::uint64_t value) noexcept {
+    return sqlite3_bind_int64(statement, index, sql_integer(value)) == SQLITE_OK;
+}
+
+/** Binds a nonnegative count after proving it fits SQLite's signed range. */
+[[nodiscard]] inline bool
+bind_count(sqlite3_stmt* statement, int index, std::size_t value) noexcept {
+    if (value > static_cast<std::size_t>((std::numeric_limits<sqlite3_int64>::max)())) {
+        return false;
+    }
+    return sqlite3_bind_int64(statement, index, static_cast<sqlite3_int64>(value)) == SQLITE_OK;
+}
+
+/** Reads a canonical SQLite boolean. */
+[[nodiscard]] inline bool column_bool(sqlite3_stmt* statement, int index, bool& output) noexcept {
+    const sqlite3_int64 value = sqlite3_column_int64(statement, index);
+    if (value != 0 && value != 1) {
+        return false;
+    }
+    output = value != 0;
+    return true;
+}
+
+/** Reads a size bounded by one caller-provided capacity. */
+[[nodiscard]] inline bool column_count(sqlite3_stmt* statement,
+                                       int index,
+                                       std::size_t capacity,
+                                       std::size_t& output) noexcept {
+    const sqlite3_int64 value = sqlite3_column_int64(statement, index);
+    if (value < 0 || static_cast<std::uint64_t>(value) > capacity) {
+        return false;
+    }
+    output = static_cast<std::size_t>(value);
+    return true;
+}
+
+/** Reads one uint8 scalar without truncation. */
+[[nodiscard]] inline bool column_u8(sqlite3_stmt* statement,
+                                    int index,
+                                    std::uint8_t& output) noexcept {
+    const sqlite3_int64 value = sqlite3_column_int64(statement, index);
+    if (value < 0 || value > (std::numeric_limits<std::uint8_t>::max)()) {
+        return false;
+    }
+    output = static_cast<std::uint8_t>(value);
+    return true;
+}
+
+/** Reads one uint32 scalar without truncation. */
+[[nodiscard]] inline bool column_u32(sqlite3_stmt* statement,
+                                     int index,
+                                     std::uint32_t& output) noexcept {
+    const sqlite3_int64 value = sqlite3_column_int64(statement, index);
+    if (value < 0
+        || static_cast<std::uint64_t>(value)
+               > (std::numeric_limits<std::uint32_t>::max)()) {
+        return false;
+    }
+    output = static_cast<std::uint32_t>(value);
+    return true;
+}
+
+/** Reads one int32 scalar without truncation. */
+[[nodiscard]] inline bool column_i32(sqlite3_stmt* statement,
+                                     int index,
+                                     std::int32_t& output) noexcept {
+    const sqlite3_int64 value = sqlite3_column_int64(statement, index);
+    if (value < (std::numeric_limits<std::int32_t>::min)()
+        || value > (std::numeric_limits<std::int32_t>::max)()) {
+        return false;
+    }
+    output = static_cast<std::int32_t>(value);
+    return true;
+}
+
+/** Reads one finite float without silently overflowing it. */
+[[nodiscard]] inline bool column_float(sqlite3_stmt* statement,
+                                       int index,
+                                       float& output) noexcept {
+    const double value = sqlite3_column_double(statement, index);
+    if (!std::isfinite(value)
+        || value < static_cast<double>((std::numeric_limits<float>::lowest)())
+        || value > static_cast<double>((std::numeric_limits<float>::max)())) {
+        return false;
+    }
+    output = static_cast<float>(value);
+    return true;
+}
+
+/** Creates the first normalized account schema. */
+[[nodiscard]] inline bool create_schema(Database& database) noexcept {
+    static constexpr const char* kSchema = R"sql(
+CREATE TABLE account_state (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    format_version INTEGER NOT NULL,
+    primary_soid INTEGER NOT NULL,
+    dismantle_reward_count INTEGER NOT NULL CHECK (dismantle_reward_count >= 0),
+    profile_item_count INTEGER NOT NULL CHECK (profile_item_count >= 0),
+    character_count INTEGER NOT NULL CHECK (character_count >= 0),
+    settings_payload BLOB NOT NULL,
+    updated_unix_seconds INTEGER NOT NULL
+);
+CREATE TABLE dismantle_rewards (
+    account_id INTEGER NOT NULL,
+    position INTEGER NOT NULL CHECK (position >= 0),
+    definition_hash INTEGER NOT NULL CHECK (definition_hash >= 0),
+    quantity INTEGER NOT NULL,
+    tier_mask INTEGER NOT NULL CHECK (tier_mask BETWEEN 0 AND 255),
+    class_mask INTEGER NOT NULL CHECK (class_mask BETWEEN 0 AND 255),
+    masterwork INTEGER NOT NULL CHECK (masterwork BETWEEN 0 AND 255),
+    PRIMARY KEY (account_id, position),
+    FOREIGN KEY (account_id) REFERENCES account_state(singleton) ON DELETE CASCADE
+);
+CREATE TABLE profile_items (
+    account_id INTEGER NOT NULL,
+    position INTEGER NOT NULL CHECK (position >= 0),
+    instance_soid INTEGER NOT NULL,
+    definition_hash INTEGER NOT NULL CHECK (definition_hash >= 0),
+    quantity INTEGER NOT NULL,
+    mutation_serial INTEGER NOT NULL,
+    PRIMARY KEY (account_id, position),
+    FOREIGN KEY (account_id) REFERENCES account_state(singleton) ON DELETE CASCADE
+);
+CREATE TABLE characters (
+    account_id INTEGER NOT NULL,
+    position INTEGER NOT NULL CHECK (position >= 0),
+    soid INTEGER NOT NULL,
+    selected INTEGER NOT NULL CHECK (selected IN (0, 1)),
+    race INTEGER NOT NULL CHECK (race BETWEEN 0 AND 255),
+    gender INTEGER NOT NULL CHECK (gender BETWEEN 0 AND 255),
+    character_class INTEGER NOT NULL CHECK (character_class BETWEEN 0 AND 255),
+    level INTEGER NOT NULL CHECK (level BETWEEN 0 AND 255),
+    accepted INTEGER NOT NULL CHECK (accepted IN (0, 1)),
+    preview_available INTEGER NOT NULL CHECK (preview_available IN (0, 1)),
+    appearance_value REAL NOT NULL,
+    last_orbited_destination INTEGER NOT NULL CHECK (last_orbited_destination >= 0),
+    content_bypass INTEGER NOT NULL CHECK (content_bypass IN (0, 1)),
+    acquired_subclass_ability_mask INTEGER NOT NULL,
+    inventory_count INTEGER NOT NULL CHECK (inventory_count >= 0),
+    next_inventory_serial INTEGER NOT NULL CHECK (next_inventory_serial >= 0),
+    PRIMARY KEY (account_id, position),
+    FOREIGN KEY (account_id) REFERENCES account_state(singleton) ON DELETE CASCADE
+);
+CREATE TABLE character_items (
+    account_id INTEGER NOT NULL,
+    character_position INTEGER NOT NULL,
+    location INTEGER NOT NULL CHECK (location IN (0, 1)),
+    position INTEGER NOT NULL CHECK (position >= 0),
+    instance_soid INTEGER NOT NULL,
+    definition_hash INTEGER NOT NULL CHECK (definition_hash >= 0),
+    item_level INTEGER NOT NULL,
+    quantity INTEGER NOT NULL,
+    mutation_serial INTEGER NOT NULL,
+    flags INTEGER NOT NULL CHECK (flags >= 0),
+    socket_policy INTEGER NOT NULL CHECK (socket_policy BETWEEN 0 AND 255),
+    plug_count INTEGER NOT NULL CHECK (plug_count >= 0),
+    movement_ability_entry INTEGER NOT NULL CHECK (movement_ability_entry BETWEEN 0 AND 255),
+    grenade_ability_entry INTEGER NOT NULL CHECK (grenade_ability_entry BETWEEN 0 AND 255),
+    super_ability_entry INTEGER NOT NULL CHECK (super_ability_entry BETWEEN 0 AND 255),
+    melee_ability_entry INTEGER NOT NULL CHECK (melee_ability_entry BETWEEN 0 AND 255),
+    class_ability_entry INTEGER NOT NULL CHECK (class_ability_entry BETWEEN 0 AND 255),
+    PRIMARY KEY (account_id, character_position, location, position),
+    FOREIGN KEY (account_id, character_position)
+        REFERENCES characters(account_id, position) ON DELETE CASCADE
+);
+CREATE TABLE item_plugs (
+    account_id INTEGER NOT NULL,
+    character_position INTEGER NOT NULL,
+    location INTEGER NOT NULL,
+    item_position INTEGER NOT NULL,
+    plug_position INTEGER NOT NULL CHECK (plug_position >= 0),
+    definition_hash INTEGER CHECK (definition_hash >= 0),
+    PRIMARY KEY (
+        account_id,
+        character_position,
+        location,
+        item_position,
+        plug_position
+    ),
+    FOREIGN KEY (account_id, character_position, location, item_position)
+        REFERENCES character_items(account_id, character_position, location, position)
+        ON DELETE CASCADE
+);
+)sql";
+    if (!database.execute("BEGIN IMMEDIATE;")) {
+        return false;
+    }
+    const bool created = database.execute(kSchema)
+                         && database.execute("PRAGMA user_version = 1;")
+                         && database.execute("COMMIT;");
+    if (!created) {
+        (void)database.execute("ROLLBACK;");
+    }
+    return created;
+}
+
+/** Opens a database, creates schema v1 when empty, and rejects every unknown version. */
+[[nodiscard]] inline OpenResult open_database(void* module, Database& database) noexcept {
+    if (!database.open(module)) {
+        return OpenResult::failed;
+    }
+    Statement version(database.get(), "PRAGMA user_version;");
+    if (version.get() == nullptr || sqlite3_step(version.get()) != SQLITE_ROW) {
+        return OpenResult::failed;
+    }
+    const int current = sqlite3_column_int(version.get(), 0);
+    if (sqlite3_step(version.get()) != SQLITE_DONE) {
+        return OpenResult::failed;
+    }
+    if (current == 0) {
+        return database.configure_supported_schema() && create_schema(database)
+                   ? OpenResult::opened
+                   : OpenResult::failed;
+    }
+    if (current > kSchemaVersion) {
+        return OpenResult::newer;
+    }
+    if (current != kSchemaVersion) {
+        return OpenResult::failed;
+    }
+    return OpenResult::opened;
+}
+
+} // namespace sunrise::state::persistence::sqlite::detail

--- a/Sunrise/src/state/persistence/sqlite/settings_codec.h
+++ b/Sunrise/src/state/persistence/sqlite/settings_codec.h
@@ -1,0 +1,328 @@
+#pragma once
+
+#include <array>
+#include <bit>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+
+#include "../../account/account_state.h"
+#include "database.h"
+
+namespace sunrise::state::persistence::sqlite::detail {
+
+/** Result of decoding the independently versioned settings payload. */
+enum class SettingsDecodeResult {
+    decoded,
+    incompatible,
+    invalid,
+};
+
+/** Fixed-capacity little-endian writer for the non-relational settings leaf. */
+class SettingsWriter final {
+public:
+    [[nodiscard]] bool put_u8(std::uint8_t value) noexcept {
+        if (size_ >= bytes_.size()) {
+            return false;
+        }
+        bytes_[size_++] = static_cast<std::byte>(value);
+        return true;
+    }
+
+    [[nodiscard]] bool put_bool(bool value) noexcept {
+        return put_u8(value ? 1U : 0U);
+    }
+
+    [[nodiscard]] bool put_u16(std::uint16_t value) noexcept {
+        return put_u8(static_cast<std::uint8_t>(value & 0xFFU))
+               && put_u8(static_cast<std::uint8_t>((value >> 8U) & 0xFFU));
+    }
+
+    [[nodiscard]] bool put_u32(std::uint32_t value) noexcept {
+        return put_u8(static_cast<std::uint8_t>(value & 0xFFU))
+               && put_u8(static_cast<std::uint8_t>((value >> 8U) & 0xFFU))
+               && put_u8(static_cast<std::uint8_t>((value >> 16U) & 0xFFU))
+               && put_u8(static_cast<std::uint8_t>((value >> 24U) & 0xFFU));
+    }
+
+    [[nodiscard]] bool put_i8(std::int8_t value) noexcept {
+        return put_u8(std::bit_cast<std::uint8_t>(value));
+    }
+
+    [[nodiscard]] bool put_i32(std::int32_t value) noexcept {
+        return put_u32(std::bit_cast<std::uint32_t>(value));
+    }
+
+    [[nodiscard]] bool put_float(float value) noexcept {
+        return put_u32(std::bit_cast<std::uint32_t>(value));
+    }
+
+    [[nodiscard]] bool put_optional_u16(const std::optional<std::uint16_t>& value) noexcept {
+        return put_bool(value.has_value()) && put_u16(value.value_or(0));
+    }
+
+    /** @return Complete encoded byte prefix. */
+    [[nodiscard]] std::span<const std::byte> bytes() const noexcept {
+        return {bytes_.data(), size_};
+    }
+
+private:
+    std::array<std::byte, kSettingsPayloadCapacity> bytes_{};
+    std::size_t size_{};
+};
+
+/** Bounds-checked little-endian reader paired with SettingsWriter. */
+class SettingsReader final {
+public:
+    explicit SettingsReader(std::span<const std::byte> bytes) noexcept : bytes_(bytes) {}
+
+    [[nodiscard]] bool get_u8(std::uint8_t& output) noexcept {
+        if (offset_ >= bytes_.size()) {
+            return false;
+        }
+        output = std::to_integer<std::uint8_t>(bytes_[offset_++]);
+        return true;
+    }
+
+    [[nodiscard]] bool get_bool(bool& output) noexcept {
+        std::uint8_t value = 0;
+        if (!get_u8(value) || value > 1) {
+            return false;
+        }
+        output = value != 0;
+        return true;
+    }
+
+    [[nodiscard]] bool get_u16(std::uint16_t& output) noexcept {
+        std::uint8_t low = 0;
+        std::uint8_t high = 0;
+        if (!get_u8(low) || !get_u8(high)) {
+            return false;
+        }
+        output = static_cast<std::uint16_t>(low)
+                 | static_cast<std::uint16_t>(static_cast<std::uint16_t>(high) << 8U);
+        return true;
+    }
+
+    [[nodiscard]] bool get_u32(std::uint32_t& output) noexcept {
+        std::uint8_t byte0 = 0;
+        std::uint8_t byte1 = 0;
+        std::uint8_t byte2 = 0;
+        std::uint8_t byte3 = 0;
+        if (!get_u8(byte0) || !get_u8(byte1) || !get_u8(byte2) || !get_u8(byte3)) {
+            return false;
+        }
+        output = static_cast<std::uint32_t>(byte0)
+                 | (static_cast<std::uint32_t>(byte1) << 8U)
+                 | (static_cast<std::uint32_t>(byte2) << 16U)
+                 | (static_cast<std::uint32_t>(byte3) << 24U);
+        return true;
+    }
+
+    [[nodiscard]] bool get_i8(std::int8_t& output) noexcept {
+        std::uint8_t value = 0;
+        if (!get_u8(value)) {
+            return false;
+        }
+        output = std::bit_cast<std::int8_t>(value);
+        return true;
+    }
+
+    [[nodiscard]] bool get_i32(std::int32_t& output) noexcept {
+        std::uint32_t value = 0;
+        if (!get_u32(value)) {
+            return false;
+        }
+        output = std::bit_cast<std::int32_t>(value);
+        return true;
+    }
+
+    [[nodiscard]] bool get_float(float& output) noexcept {
+        std::uint32_t value = 0;
+        if (!get_u32(value)) {
+            return false;
+        }
+        output = std::bit_cast<float>(value);
+        return std::isfinite(output);
+    }
+
+    [[nodiscard]] bool get_optional_u16(std::optional<std::uint16_t>& output) noexcept {
+        bool present = false;
+        std::uint16_t value = 0;
+        if (!get_bool(present) || !get_u16(value)) {
+            return false;
+        }
+        output = present ? std::optional<std::uint16_t>(value) : std::nullopt;
+        return true;
+    }
+
+    /** @return True only when every payload byte was consumed. */
+    [[nodiscard]] bool complete() const noexcept {
+        return offset_ == bytes_.size();
+    }
+
+private:
+    std::span<const std::byte> bytes_;
+    std::size_t offset_{};
+};
+
+/** Encodes every account-setting scalar without copying object padding or optional internals. */
+[[nodiscard]] inline bool
+encode_settings(const account::settings::AccountSettings& value, SettingsWriter& writer) noexcept {
+    const auto& controls = value.controls;
+    const auto& audio = value.audio;
+    const auto& display = value.display;
+    const auto& interfaceSettings = value.interface;
+    const auto& social = value.social;
+    if (!writer.put_u32(kSettingsPayloadVersion) || !writer.put_i8(controls.buttonLayout)
+        || !writer.put_i8(controls.movementMode)
+        || !writer.put_i8(controls.controllerLookSensitivity)
+        || !writer.put_bool(controls.controllerInvertVertical)
+        || !writer.put_bool(controls.controllerAutoLookCentering)
+        || !writer.put_bool(controls.controllerVibration)
+        || !writer.put_bool(controls.controllerSwapShoulders)
+        || !writer.put_bool(controls.controllerInvertHorizontal)
+        || !writer.put_i32(controls.mouseLookSensitivity)
+        || !writer.put_bool(controls.mouseInvertVertical)
+        || !writer.put_bool(controls.mouseInvertHorizontal)
+        || !writer.put_bool(controls.unidentifiedToggle)
+        || !writer.put_bool(controls.mouseAimSmoothing)
+        || !writer.put_float(controls.adsSensitivityModifier)
+        || !writer.put_i8(controls.doublePressDelay)
+        || !writer.put_i8(audio.voiceOutputMode) || !writer.put_i8(audio.teamVoiceChannel)
+        || !writer.put_i8(audio.reservedMode) || !writer.put_i8(audio.migrationVersion)
+        || !writer.put_i8(audio.chatVolume) || !writer.put_bool(audio.muteWhenUnfocused)
+        || !writer.put_i8(audio.soundEffectsVolume) || !writer.put_i8(audio.dialogueVolume)
+        || !writer.put_i8(audio.musicVolume) || !writer.put_i8(display.brightness)
+        || !writer.put_bool(display.showFps) || !writer.put_i8(display.hdrMode)
+        || !writer.put_u8(display.verticalSyncInterval)
+        || !writer.put_i32(display.fieldOfView)
+        || !writer.put_float(display.calibrationPrimary)
+        || !writer.put_float(display.calibrationAlpha)
+        || !writer.put_i8(interfaceSettings.subtitlesMode)
+        || !writer.put_i8(interfaceSettings.colorblindMode)
+        || !writer.put_i8(interfaceSettings.helmetMode)
+        || !writer.put_i8(interfaceSettings.hudOpacity)
+        || !writer.put_bool(interfaceSettings.displayHints)
+        || !writer.put_i8(interfaceSettings.backgroundOpacity)
+        || !writer.put_i8(interfaceSettings.reticleLocation)
+        || !writer.put_i8(interfaceSettings.reticleColor)
+        || !writer.put_i8(interfaceSettings.textSize)
+        || !writer.put_i8(interfaceSettings.textColor)
+        || !writer.put_i8(interfaceSettings.textBackgroundStyle)
+        || !writer.put_i8(interfaceSettings.textBackgroundOpacity)
+        || !writer.put_i8(interfaceSettings.reservedTextMode)
+        || !writer.put_i8(interfaceSettings.subtitleOptionsEntry)
+        || !writer.put_bool(social.preferGoodConnection)
+        || !writer.put_i8(social.textChatMode) || !writer.put_bool(social.showRealNames)
+        || !writer.put_bool(social.clanInviteNotifications)
+        || !writer.put_bool(social.profanityFilter)
+        || !writer.put_bool(social.voiceChatEnabled)
+        || !writer.put_i8(social.whisperChatMode)
+        || !writer.put_i8(social.teamChatJoinMode)
+        || !writer.put_i8(social.localChatJoinMode)
+        || !writer.put_i8(social.clanChatJoinMode)
+        || !writer.put_i8(social.chatAutoHideMode)
+        || !writer.put_u8(static_cast<std::uint8_t>(value.keyBindingSource))
+        || !writer.put_bool(value.keyBindings.configured)) {
+        return false;
+    }
+    for (const account::settings::bindings::Binding& binding : value.keyBindings.values) {
+        if (!writer.put_optional_u16(binding.primary)
+            || !writer.put_optional_u16(binding.secondary)) {
+            return false;
+        }
+    }
+    return writer.put_bool(value.configured);
+}
+
+/** Decodes settings only after the whole versioned payload is structurally complete. */
+[[nodiscard]] inline SettingsDecodeResult
+decode_settings(std::span<const std::byte> bytes,
+                 account::settings::AccountSettings& output) noexcept {
+    SettingsReader reader(bytes);
+    account::settings::AccountSettings value{};
+    std::uint32_t version = 0;
+    std::uint8_t keyBindingSource = 0;
+    auto& controls = value.controls;
+    auto& audio = value.audio;
+    auto& display = value.display;
+    auto& interfaceSettings = value.interface;
+    auto& social = value.social;
+    if (!reader.get_u32(version)) {
+        return SettingsDecodeResult::invalid;
+    }
+    if (version > kSettingsPayloadVersion) {
+        return SettingsDecodeResult::incompatible;
+    }
+    if (version != kSettingsPayloadVersion || !reader.get_i8(controls.buttonLayout)
+        || !reader.get_i8(controls.movementMode)
+        || !reader.get_i8(controls.controllerLookSensitivity)
+        || !reader.get_bool(controls.controllerInvertVertical)
+        || !reader.get_bool(controls.controllerAutoLookCentering)
+        || !reader.get_bool(controls.controllerVibration)
+        || !reader.get_bool(controls.controllerSwapShoulders)
+        || !reader.get_bool(controls.controllerInvertHorizontal)
+        || !reader.get_i32(controls.mouseLookSensitivity)
+        || !reader.get_bool(controls.mouseInvertVertical)
+        || !reader.get_bool(controls.mouseInvertHorizontal)
+        || !reader.get_bool(controls.unidentifiedToggle)
+        || !reader.get_bool(controls.mouseAimSmoothing)
+        || !reader.get_float(controls.adsSensitivityModifier)
+        || !reader.get_i8(controls.doublePressDelay)
+        || !reader.get_i8(audio.voiceOutputMode) || !reader.get_i8(audio.teamVoiceChannel)
+        || !reader.get_i8(audio.reservedMode) || !reader.get_i8(audio.migrationVersion)
+        || !reader.get_i8(audio.chatVolume) || !reader.get_bool(audio.muteWhenUnfocused)
+        || !reader.get_i8(audio.soundEffectsVolume) || !reader.get_i8(audio.dialogueVolume)
+        || !reader.get_i8(audio.musicVolume) || !reader.get_i8(display.brightness)
+        || !reader.get_bool(display.showFps) || !reader.get_i8(display.hdrMode)
+        || !reader.get_u8(display.verticalSyncInterval)
+        || !reader.get_i32(display.fieldOfView)
+        || !reader.get_float(display.calibrationPrimary)
+        || !reader.get_float(display.calibrationAlpha)
+        || !reader.get_i8(interfaceSettings.subtitlesMode)
+        || !reader.get_i8(interfaceSettings.colorblindMode)
+        || !reader.get_i8(interfaceSettings.helmetMode)
+        || !reader.get_i8(interfaceSettings.hudOpacity)
+        || !reader.get_bool(interfaceSettings.displayHints)
+        || !reader.get_i8(interfaceSettings.backgroundOpacity)
+        || !reader.get_i8(interfaceSettings.reticleLocation)
+        || !reader.get_i8(interfaceSettings.reticleColor)
+        || !reader.get_i8(interfaceSettings.textSize)
+        || !reader.get_i8(interfaceSettings.textColor)
+        || !reader.get_i8(interfaceSettings.textBackgroundStyle)
+        || !reader.get_i8(interfaceSettings.textBackgroundOpacity)
+        || !reader.get_i8(interfaceSettings.reservedTextMode)
+        || !reader.get_i8(interfaceSettings.subtitleOptionsEntry)
+        || !reader.get_bool(social.preferGoodConnection)
+        || !reader.get_i8(social.textChatMode) || !reader.get_bool(social.showRealNames)
+        || !reader.get_bool(social.clanInviteNotifications)
+        || !reader.get_bool(social.profanityFilter)
+        || !reader.get_bool(social.voiceChatEnabled)
+        || !reader.get_i8(social.whisperChatMode)
+        || !reader.get_i8(social.teamChatJoinMode)
+        || !reader.get_i8(social.localChatJoinMode)
+        || !reader.get_i8(social.clanChatJoinMode)
+        || !reader.get_i8(social.chatAutoHideMode) || !reader.get_u8(keyBindingSource)
+        || keyBindingSource
+               > static_cast<std::uint8_t>(account::settings::KeyBindingSource::computer)
+        || !reader.get_bool(value.keyBindings.configured)) {
+        return SettingsDecodeResult::invalid;
+    }
+    value.keyBindingSource = static_cast<account::settings::KeyBindingSource>(keyBindingSource);
+    for (account::settings::bindings::Binding& binding : value.keyBindings.values) {
+        if (!reader.get_optional_u16(binding.primary)
+            || !reader.get_optional_u16(binding.secondary)) {
+            return SettingsDecodeResult::invalid;
+        }
+    }
+    if (!reader.get_bool(value.configured) || !reader.complete()) {
+        return SettingsDecodeResult::invalid;
+    }
+    output = value;
+    return SettingsDecodeResult::decoded;
+}
+
+} // namespace sunrise::state::persistence::sqlite::detail

--- a/Sunrise/src/state/persistence/sqlite_account_store.h
+++ b/Sunrise/src/state/persistence/sqlite_account_store.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdio>
+#include <string_view>
+
+#include "../../core/logging/log.h"
+#include "../activity/defaults/definition.h"
+#include "../runtime/runtime.h"
+#include "sqlite/account_snapshot.h"
+
+namespace sunrise::state::persistence {
+namespace detail {
+
+/** Active module path used only between a successful initialize and shutdown. */
+inline void* g_module{};
+/** True only after the wrapped State runtime reached a complete initialized image. */
+inline bool g_active{};
+/** False when startup found data written in a format this build must preserve untouched. */
+inline bool g_writable{};
+
+/** Emits one compact persistence lifecycle event through the already-open State log. */
+inline void report(std::string_view stage,
+                   std::string_view result,
+                   std::string_view reason) noexcept {
+    std::array<char, 160> line{};
+    const int written = std::snprintf(line.data(),
+                                      line.size(),
+                                      "ev=account_persistence backend=sqlite stage=%.*s "
+                                      "result=%.*s reason=%.*s",
+                                      static_cast<int>(stage.size()),
+                                      stage.data(),
+                                      static_cast<int>(result.size()),
+                                      result.data(),
+                                      static_cast<int>(reason.size()),
+                                      reason.data());
+    if (written > 0) {
+        const std::size_t length = static_cast<std::size_t>(written) < line.size()
+                                       ? static_cast<std::size_t>(written)
+                                       : line.size() - 1;
+        core::log::write(core::log::Channel::state,
+                         result == "ok" ? core::log::Level::info : core::log::Level::warn,
+                         {line.data(), length});
+    }
+}
+
+} // namespace detail
+
+/**
+ * Restores a valid SQLite snapshot before State initializes, with authored settings as fallback.
+ * @param module Loaded Sunrise module, or null to retain ephemeral test behavior.
+ * @param initialAccount Checked account parsed from settings.json.
+ * @param activityDefaults Immutable activity policy from settings.json.
+ * @return True when State initializes from either the snapshot or authored fallback.
+ */
+[[nodiscard]] inline bool
+initialize(void* module,
+           const AccountState& initialAccount,
+           const activity::defaults::ActivityDefaults& activityDefaults) noexcept {
+    if (detail::g_active) {
+        return true;
+    }
+    AccountState restored{};
+    const sqlite::detail::LoadResult load = sqlite::detail::load_account(module, restored);
+    if (load == sqlite::detail::LoadResult::loaded) {
+        if (::sunrise::state::initialize(module, restored, activityDefaults)) {
+            detail::g_module = module;
+            detail::g_active = true;
+            detail::g_writable = module != nullptr;
+            detail::report("load", "ok", "restored");
+            return true;
+        }
+        // A structurally valid snapshot can still reference data absent from a different installed
+        // build. Unwind that attempt and retain the human-authored recovery path.
+        ::sunrise::state::shutdown();
+        detail::report("load", "fallback", "runtime_rejected");
+    } else if (load == sqlite::detail::LoadResult::schemaNewer) {
+        detail::report("load", "fallback", "schema_newer");
+    } else if (load == sqlite::detail::LoadResult::formatNewer) {
+        detail::report("load", "fallback", "format_newer");
+    } else if (load == sqlite::detail::LoadResult::invalid) {
+        detail::report("load", "fallback", "invalid_database");
+    }
+    if (!::sunrise::state::initialize(module, initialAccount, activityDefaults)) {
+        return false;
+    }
+    detail::g_module = module;
+    detail::g_active = true;
+    detail::g_writable = module != nullptr
+                         && load != sqlite::detail::LoadResult::schemaNewer
+                         && load != sqlite::detail::LoadResult::formatNewer;
+    if (module != nullptr && load == sqlite::detail::LoadResult::missing) {
+        detail::report("load", "ok", "first_run");
+    }
+    return true;
+}
+
+/** Writes the current account snapshot without stopping State. */
+[[nodiscard]] inline bool flush() noexcept {
+    if (!detail::g_active || detail::g_module == nullptr || !detail::g_writable) {
+        return true;
+    }
+    return sqlite::detail::save_account(detail::g_module, ::sunrise::state::account_snapshot());
+}
+
+/** Writes and reports one durable snapshot without stopping State. */
+[[nodiscard]] inline bool checkpoint(std::string_view reason) noexcept {
+    const bool report =
+        detail::g_active && detail::g_module != nullptr && detail::g_writable;
+    const bool saved = flush();
+    if (report) {
+        detail::report("save", saved ? "ok" : "fail", reason);
+    }
+    return saved;
+}
+
+/** Persists one final account image, then securely shuts down the State runtime. */
+inline void shutdown() noexcept {
+    if (detail::g_active) {
+        if (detail::g_module != nullptr) {
+            (void)checkpoint("clean_shutdown");
+        }
+        detail::g_active = false;
+        detail::g_writable = false;
+        detail::g_module = nullptr;
+    }
+    ::sunrise::state::shutdown();
+}
+
+} // namespace sunrise::state::persistence

--- a/docs/sqlite-migration.md
+++ b/docs/sqlite-migration.md
@@ -1,0 +1,147 @@
+# SQLite account persistence
+
+## Status
+
+This change implements a SQLite-backed persistence path for existing Sunrise account state. It does
+not change or remove `settings.json`.
+
+## Feasibility verdict
+
+SQLite is a good fit for mutable account state, but not for every file Sunrise currently owns.
+The recommended architecture is hybrid:
+
+- Keep `settings.json` as human-editable bootstrap and recovery configuration.
+- Keep the generated build-data cache in its current versioned binary format. It is a dense,
+  rebuildable, sequential-read cache and would gain little from relational storage.
+- Store mutable account state in SQLite. Characters, inventory, equipment, sockets, profile
+  stacks, account settings, and key bindings need atomic updates and durable restart behavior.
+
+The existing runtime already validates complete `AccountState` snapshots before publishing them.
+That makes a transactional snapshot boundary practical without changing the game-facing encoders.
+
+## Implemented scope
+
+The branch adds `Sunrise/state.sqlite3` under the existing module-relative artifact directory and
+uses the Windows SDK WinSQLite API (`winsqlite/winsqlite3.h` and `winsqlite3.lib`). No SQLite
+amalgamation or third-party binary is copied into the repository.
+
+Initialization now follows this order:
+
+1. Open or create `state.sqlite3`.
+2. Create or validate schema v1 through `PRAGMA user_version`.
+3. Read a complete account snapshot.
+4. Reconstruct bounded C++ state and run the existing `account::valid` checks.
+5. Initialize State from the restored account.
+6. Fall back to the account in `settings.json` if the database is missing, newer than the code,
+   malformed, or rejected by installed build data.
+
+Shutdown checkpoints the account before Client hook teardown and writes the final account again
+after Client, Server, and Middleware have quiesced. Each save replaces all SQLite rows inside one
+`BEGIN IMMEDIATE` transaction. If hook teardown must be retried, the initial checkpoint remains
+durable; the prior committed snapshot remains intact if any insert or commit fails.
+
+## Schema v1
+
+`account_state`
+: Singleton root, format version, row counts, primary SOID, explicit settings payload, and update
+  timestamp.
+
+`dismantle_rewards`
+: Ordered economy-policy rows.
+
+`profile_items`
+: Ordered account-wide currency, material, and action-source stacks.
+
+`characters`
+: Character identity, selection, presentation values, runtime masks, and inventory generation.
+
+`character_items`
+: Equipment and character-inventory items. `location` distinguishes semantic equipment slots from
+  ordered unequipped inventory rows.
+
+`item_plugs`
+: Ordered optional socket-plug entries for each item.
+
+The account settings leaf is encoded into a small versioned payload because it is a fixed scalar
+record rather than a useful relational query surface. Every field and optional key binding is
+written explicitly in little-endian order; C++ object bytes, padding, and `std::optional` internals
+are never copied to disk.
+
+Unsigned 64-bit identifiers and masks are bit-cast into SQLite's signed 64-bit integer domain and
+bit-cast back on load. This preserves values such as an all-bits-set acquired-ability mask.
+
+## Compatibility and recovery
+
+- `PRAGMA user_version` versions the relational schema.
+- `format_version` versions the account-row contract.
+- The settings payload has an independent format version.
+- A database with a higher `user_version` is inspected before writable pragmas are enabled, then
+  left untouched and ignored by older code.
+- A newer account-row or settings-payload format disables persistence writes for the session,
+  even when its schema version is still recognized.
+- A structurally valid account that cannot initialize against the installed game packages is
+  rejected and the authored `settings.json` account is used instead.
+- `settings.json` remains unchanged, so deleting or renaming `state.sqlite3`, `state.sqlite3-wal`,
+  and `state.sqlite3-shm` restores the previous ephemeral behavior on the next launch.
+
+## Durability behavior
+
+The first implementation writes when Sunrise shutdown begins and again after clean teardown. A
+failed pre-teardown checkpoint cancels shutdown while Client, Server, Middleware, and State remain
+live, allowing a later attempt to retry the durable write. Once that checkpoint succeeds, normal
+restarts remain persistent even when hook teardown needs a retry. WAL mode is requested for future
+write-through support, `synchronous=FULL` is used, and a truncate checkpoint is attempted after a
+successful final commit.
+
+The public persistence wrapper also exposes `flush()`. It can be called by later top-level mutation
+boundaries once the desired write cadence is selected.
+
+## Known limitations
+
+1. A process crash or forced termination can lose changes made after the previous clean shutdown.
+   The previously committed database remains valid.
+2. The existing State initializer deliberately reseeds character item mutation serials at startup.
+   Inventory contents and ordering persist, but those runtime generations are canonicalized again.
+3. WinSQLite follows the SQLite version serviced with Windows. A production release that requires
+   a pinned SQLite version or extension set should vendor the official amalgamation instead.
+4. No automatic SQLite-to-JSON export is included. `settings.json` is recovery/bootstrap input, not
+   a live mirror of runtime inventory.
+5. Live client preference changes are not yet copied back into `AccountState.settings`; SQLite
+   persists the settings State currently owns, while live settings propagation remains separate.
+6. The database is designed for one Sunrise process. Cross-process account sharing is not included.
+
+## Validation performed in the implementation environment
+
+- The complete header was syntax-checked as C++20 with strict Clang warnings using API and project
+  type stubs.
+- The settings payload was round-tripped and re-encoded byte-for-byte; the current payload is 438
+  bytes.
+- A complete two-character snapshot was saved and restored through SQLite, including high-bit SOIDs,
+  profile stacks, equipment, inventory, nullable plugs, settings, and key bindings.
+- Schema v1 was executed against SQLite, all six tables were inspected, and both integrity and
+  foreign-key checks passed. Newer schema and nested payload versions remain untouched, while a
+  deliberately missing plug row is rejected and repaired through the intended fallback path.
+- The repository's 100-column formatting contract was checked.
+
+The branch workflow builds and runs `tests/SQLitePersistenceTests.vcxproj` before the DLL build.
+That test links the production State validators, compiles the persistence path against Windows SDK
+WinSQLite, and repeats complete snapshot, integrity, compatibility, malformed-row, and repair
+checks before the Windows Release x64 DLL build.
+
+## Recommended next steps
+
+1. Add debounced `flush()` calls after successful top-level account mutations so a crash loses at
+   most a short interval rather than the whole session.
+2. Add a build/package fingerprint to the root row and report exactly why a restored snapshot is
+   rejected after an installed-build change.
+3. Add fault-injection tests for interrupted transactions, malformed child rows, a newer
+   `user_version`, and WAL recovery.
+4. Add schema v2 only through an explicit migration transaction; never edit schema v1 in place once
+   users have databases.
+5. Reassess whether to vendor the official SQLite amalgamation before distribution. This is a
+   dependency-policy decision, not a blocker for proving the persistence model.
+
+## Non-goals
+
+This change does not migrate the package-derived build cache, embedded JSON resources, activity
+configuration, or logging output.

--- a/tests/SQLitePersistenceTests.vcxproj
+++ b/tests/SQLitePersistenceTests.vcxproj
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <ProjectGuid>{81B7F973-82D9-492F-B9BE-7855E55F3326}</ProjectGuid>
+    <RootNamespace>SQLitePersistenceTests</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <ProjectName>SQLitePersistenceTests</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v145</PlatformToolset>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <PropertyGroup>
+    <OutDir>$(ProjectDir)build\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(ProjectDir)build\obj\$(Platform)\$(Configuration)\</IntDir>
+    <VcpkgApplocalDeps>false</VcpkgApplocalDeps>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <WarningLevel>Level4</WarningLevel>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <ConformanceMode>true</ConformanceMode>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalIncludeDirectories>
+        $(ProjectDir)..\Sunrise\src;%(AdditionalIncludeDirectories)
+      </AdditionalIncludeDirectories>
+      <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
+      <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
+      <PreprocessorDefinitions>
+        WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;NOMINMAX;%(PreprocessorDefinitions)
+      </PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>winsqlite3.lib;kernel32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\Sunrise\src\state\account\account_state.cpp" />
+    <ClCompile Include="..\Sunrise\src\state\account\inventory\inventory_state.cpp" />
+    <ClCompile Include="..\Sunrise\src\state\account\settings\settings_state.cpp" />
+    <ClCompile Include="sqlite_account_snapshot_test.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/tests/sqlite_account_snapshot_test.cpp
+++ b/tests/sqlite_account_snapshot_test.cpp
@@ -1,0 +1,573 @@
+#include "state/persistence/sqlite_account_store.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <filesystem>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+std::wstring g_artifactDirectory;
+sunrise::state::AccountState g_runtimeAccount;
+
+[[nodiscard]] bool check(bool condition, std::string_view message) noexcept {
+    if (!condition) {
+        std::cerr << "sqlite persistence test failed: " << message << '\n';
+    }
+    return condition;
+}
+
+[[nodiscard]] bool same_settings(
+    const sunrise::state::account::settings::AccountSettings& left,
+    const sunrise::state::account::settings::AccountSettings& right) noexcept {
+    sunrise::state::persistence::sqlite::detail::SettingsWriter encodedLeft;
+    sunrise::state::persistence::sqlite::detail::SettingsWriter encodedRight;
+    return sunrise::state::persistence::sqlite::detail::encode_settings(left, encodedLeft)
+           && sunrise::state::persistence::sqlite::detail::encode_settings(right, encodedRight)
+           && std::equal(encodedLeft.bytes().begin(),
+                         encodedLeft.bytes().end(),
+                         encodedRight.bytes().begin(),
+                         encodedRight.bytes().end());
+}
+
+[[nodiscard]] bool same_item(const sunrise::state::account::inventory::Item& left,
+                             const sunrise::state::account::inventory::Item& right) noexcept {
+    return left.instanceSoid == right.instanceSoid
+           && left.definitionHash == right.definitionHash && left.level == right.level
+           && left.quantity == right.quantity && left.mutationSerial == right.mutationSerial
+           && left.flags == right.flags && left.sockets.policy == right.sockets.policy
+           && left.sockets.plugCount == right.sockets.plugCount
+           && left.sockets.plugs == right.sockets.plugs
+           && left.movementAbilityEntry == right.movementAbilityEntry
+           && left.grenadeAbilityEntry == right.grenadeAbilityEntry
+           && left.superAbilityEntry == right.superAbilityEntry
+           && left.meleeAbilityEntry == right.meleeAbilityEntry
+           && left.classAbilityEntry == right.classAbilityEntry;
+}
+
+[[nodiscard]] bool same_character(const sunrise::state::CharacterState& left,
+                                  const sunrise::state::CharacterState& right) noexcept {
+    if (left.soid != right.soid || left.selected != right.selected || left.race != right.race
+        || left.gender != right.gender || left.characterClass != right.characterClass
+        || left.level != right.level || left.accepted != right.accepted
+        || left.previewAvailable != right.previewAvailable
+        || left.appearanceValue != right.appearanceValue
+        || left.lastOrbitedDestination != right.lastOrbitedDestination
+        || left.contentBypass != right.contentBypass
+        || left.acquiredSubclassAbilityMask != right.acquiredSubclassAbilityMask
+        || left.inventory.count != right.inventory.count
+        || left.nextInventorySerial != right.nextInventorySerial) {
+        return false;
+    }
+    for (std::size_t index = 0; index < left.equipment.slots.size(); ++index) {
+        const auto& leftItem = left.equipment.slots[index];
+        const auto& rightItem = right.equipment.slots[index];
+        if (leftItem.has_value() != rightItem.has_value()
+            || (leftItem.has_value() && !same_item(*leftItem, *rightItem))) {
+            return false;
+        }
+    }
+    for (std::size_t index = 0; index < left.inventory.count; ++index) {
+        if (!same_item(left.inventory.values[index], right.inventory.values[index])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+[[nodiscard]] bool same_account(const sunrise::state::AccountState& left,
+                                const sunrise::state::AccountState& right) noexcept {
+    if (left.primarySoid != right.primarySoid
+        || left.dismantleRewardCount != right.dismantleRewardCount
+        || left.profileItemCount != right.profileItemCount
+        || left.characterCount != right.characterCount
+        || !same_settings(left.settings, right.settings)) {
+        return false;
+    }
+    for (std::size_t index = 0; index < left.dismantleRewardCount; ++index) {
+        const auto& leftReward = left.dismantleRewards[index];
+        const auto& rightReward = right.dismantleRewards[index];
+        if (leftReward.definitionHash != rightReward.definitionHash
+            || leftReward.quantity != rightReward.quantity
+            || leftReward.tierMask != rightReward.tierMask
+            || leftReward.classMask != rightReward.classMask
+            || leftReward.masterwork != rightReward.masterwork) {
+            return false;
+        }
+    }
+    for (std::size_t index = 0; index < left.profileItemCount; ++index) {
+        const auto& leftItem = left.profileItems[index];
+        const auto& rightItem = right.profileItems[index];
+        if (leftItem.instanceSoid != rightItem.instanceSoid
+            || leftItem.definitionHash != rightItem.definitionHash
+            || leftItem.quantity != rightItem.quantity
+            || leftItem.mutationSerial != rightItem.mutationSerial) {
+            return false;
+        }
+    }
+    for (std::size_t index = 0; index < left.characterCount; ++index) {
+        if (!same_character(left.characters[index], right.characters[index])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+[[nodiscard]] bool set_settings_payload_version(sqlite3* database,
+                                                std::uint32_t version,
+                                                std::size_t minimumSize = 0) noexcept {
+    sqlite3_stmt* select = nullptr;
+    if (sqlite3_prepare_v2(database,
+                          "SELECT settings_payload FROM account_state WHERE singleton = 1;",
+                          -1,
+                          &select,
+                          nullptr)
+            != SQLITE_OK
+        || select == nullptr || sqlite3_step(select) != SQLITE_ROW) {
+        (void)sqlite3_finalize(select);
+        return false;
+    }
+    const int size = sqlite3_column_bytes(select, 0);
+    const auto* bytes = static_cast<const std::byte*>(sqlite3_column_blob(select, 0));
+    if (size < static_cast<int>(sizeof(version)) || bytes == nullptr) {
+        (void)sqlite3_finalize(select);
+        return false;
+    }
+    std::vector<std::byte> payload(bytes, bytes + size);
+    if (sqlite3_finalize(select) != SQLITE_OK) {
+        return false;
+    }
+    if (payload.size() < minimumSize) {
+        payload.resize(minimumSize, std::byte{0});
+    }
+    payload[0] = static_cast<std::byte>(version & 0xFFU);
+    payload[1] = static_cast<std::byte>((version >> 8U) & 0xFFU);
+    payload[2] = static_cast<std::byte>((version >> 16U) & 0xFFU);
+    payload[3] = static_cast<std::byte>((version >> 24U) & 0xFFU);
+
+    sqlite3_stmt* update = nullptr;
+    const bool updated =
+        sqlite3_prepare_v2(database,
+                           "UPDATE account_state SET settings_payload = ? WHERE singleton = 1;",
+                           -1,
+                           &update,
+                           nullptr)
+                == SQLITE_OK
+        && update != nullptr
+        && sqlite3_bind_blob(update,
+                             1,
+                             payload.data(),
+                             static_cast<int>(payload.size()),
+                             SQLITE_TRANSIENT)
+               == SQLITE_OK
+        && sqlite3_step(update) == SQLITE_DONE;
+    return sqlite3_finalize(update) == SQLITE_OK && updated;
+}
+
+} // namespace
+
+namespace sunrise::core::path {
+
+bool artifact_directory(void*, Buffer& output) noexcept {
+    if (g_artifactDirectory.size() >= output.chars.size()) {
+        return false;
+    }
+    output = {};
+    std::copy(g_artifactDirectory.cbegin(), g_artifactDirectory.cend(), output.chars.begin());
+    output.length = g_artifactDirectory.size();
+    output.chars[output.length] = L'\0';
+    return true;
+}
+
+bool append(Buffer& output, std::wstring_view suffix) noexcept {
+    if (output.length + suffix.size() >= output.chars.size()) {
+        return false;
+    }
+    std::copy(suffix.cbegin(), suffix.cend(), output.chars.begin() + output.length);
+    output.length += suffix.size();
+    output.chars[output.length] = L'\0';
+    return true;
+}
+
+} // namespace sunrise::core::path
+
+namespace sunrise::core::log {
+
+void write(Channel, Level, std::string_view) noexcept {}
+
+} // namespace sunrise::core::log
+
+namespace sunrise::state {
+
+bool initialize(void*,
+                const AccountState& account,
+                const activity::defaults::ActivityDefaults&) noexcept {
+    g_runtimeAccount = account;
+    return true;
+}
+
+void shutdown() noexcept {
+    g_runtimeAccount = {};
+}
+
+AccountState account_snapshot() noexcept {
+    return g_runtimeAccount;
+}
+
+} // namespace sunrise::state
+
+int main() {
+    namespace persistence = sunrise::state::persistence;
+    using namespace sunrise::state;
+
+    std::error_code error;
+    const std::filesystem::path root =
+        std::filesystem::temp_directory_path(error) / "sunrise-sqlite-persistence-test";
+    if (!check(!error, "resolve temporary directory")) {
+        return 1;
+    }
+    std::filesystem::remove_all(root, error);
+    error.clear();
+    std::filesystem::create_directories(root, error);
+    if (!check(!error, "create temporary directory")) {
+        return 1;
+    }
+    g_artifactDirectory = root.wstring();
+
+    AccountState input{};
+    // These deliberately synthetic values exercise field widths without embedding client data.
+    input.primarySoid = 0xF123456789ABCDEFULL;
+    input.dismantleRewardCount = 1;
+    input.dismantleRewards[0].definitionHash = 0xFEDCBA98U;
+    input.dismantleRewards[0].quantity = 3;
+    input.dismantleRewards[0].tierMask = 0x02;
+    input.dismantleRewards[0].classMask = 0x01;
+    input.dismantleRewards[0].masterwork = DismantleMasterworkFilter::masterworked;
+    input.profileItemCount = 2;
+    input.profileItems[0] = {0x5000000000000001ULL, 0x90000000U, 44, 7};
+    input.profileItems[1] = {0, 0xFFFFFFFFU, 1, 8};
+    input.characterCount = 2;
+
+    CharacterState& first = input.characters[0];
+    first.soid = 0x8123456789ABCDEFULL;
+    first.selected = true;
+    first.race = CharacterRace::exo;
+    first.gender = CharacterGender::female;
+    first.characterClass = CharacterClass::warlock;
+    first.level = 40;
+    first.accepted = true;
+    first.previewAvailable = true;
+    first.appearanceValue = 1.5F;
+    first.lastOrbitedDestination = 0xF0000000U;
+    first.contentBypass = true;
+    first.acquiredSubclassAbilityMask = ~std::uint64_t{0};
+    first.nextInventorySerial = 50;
+
+    account::inventory::Item equipped{};
+    equipped.instanceSoid = 0x9000000000000001ULL;
+    equipped.definitionHash = 0xE0000001U;
+    equipped.level = 1;
+    equipped.quantity = 1;
+    equipped.mutationSerial = 12;
+    equipped.flags = 0xF0000000U;
+    equipped.sockets.policy = account::inventory::SocketPolicy::authored;
+    equipped.sockets.plugCount = 3;
+    equipped.sockets.plugs[0] = 0xFFFFFFFFU;
+    equipped.sockets.plugs[1].reset();
+    equipped.sockets.plugs[2] = 5U;
+    equipped.movementAbilityEntry = 4;
+    equipped.grenadeAbilityEntry = 8;
+    equipped.superAbilityEntry = 10;
+    equipped.meleeAbilityEntry = 12;
+    equipped.classAbilityEntry = 2;
+    first.equipment.slots[11] = equipped;
+
+    account::inventory::Item inventory = equipped;
+    inventory.instanceSoid = 0x9000000000000002ULL;
+    inventory.definitionHash = 0xE0000002U;
+    inventory.sockets.plugs = {};
+    inventory.sockets.plugCount = 1;
+    inventory.sockets.plugs[0].reset();
+    first.inventory.values[0] = inventory;
+    first.inventory.count = 1;
+
+    CharacterState& second = input.characters[1];
+    second.soid = 2;
+    second.level = 20;
+    second.accepted = true;
+    second.previewAvailable = true;
+    second.race = CharacterRace::human;
+    second.gender = CharacterGender::male;
+    second.characterClass = CharacterClass::titan;
+    second.appearanceValue = -2.25F;
+    second.lastOrbitedDestination = 7;
+    second.acquiredSubclassAbilityMask = 0x8000000000000000ULL;
+    second.nextInventorySerial = 3;
+
+    input.settings.controls.buttonLayout = 5;
+    input.settings.controls.movementMode = 3;
+    input.settings.controls.controllerLookSensitivity = 9;
+    input.settings.controls.controllerInvertVertical = true;
+    input.settings.controls.controllerAutoLookCentering = true;
+    input.settings.controls.controllerVibration = true;
+    input.settings.controls.controllerSwapShoulders = true;
+    input.settings.controls.controllerInvertHorizontal = true;
+    input.settings.controls.mouseLookSensitivity = 100;
+    input.settings.controls.mouseInvertVertical = true;
+    input.settings.controls.mouseInvertHorizontal = true;
+    input.settings.controls.unidentifiedToggle = true;
+    input.settings.controls.mouseAimSmoothing = true;
+    input.settings.controls.adsSensitivityModifier = 1.5F;
+    input.settings.controls.doublePressDelay = 4;
+    input.settings.audio.voiceOutputMode = 2;
+    input.settings.audio.teamVoiceChannel = 1;
+    input.settings.audio.reservedMode = 1;
+    input.settings.audio.migrationVersion = 8;
+    input.settings.audio.chatVolume = 8;
+    input.settings.audio.muteWhenUnfocused = true;
+    input.settings.audio.soundEffectsVolume = 10;
+    input.settings.audio.dialogueVolume = 9;
+    input.settings.audio.musicVolume = 8;
+    input.settings.display.brightness = 6;
+    input.settings.display.showFps = true;
+    input.settings.display.hdrMode = 1;
+    input.settings.display.verticalSyncInterval = 4;
+    input.settings.display.fieldOfView = 105;
+    input.settings.display.calibrationPrimary = 10000.0F;
+    input.settings.display.calibrationAlpha = 0.0F;
+    input.settings.interface.subtitlesMode = 2;
+    input.settings.interface.colorblindMode = 3;
+    input.settings.interface.helmetMode = 1;
+    input.settings.interface.hudOpacity = 3;
+    input.settings.interface.displayHints = true;
+    input.settings.interface.backgroundOpacity = 4;
+    input.settings.interface.reticleLocation = 1;
+    input.settings.interface.reticleColor = 6;
+    input.settings.interface.textSize = 4;
+    input.settings.interface.textColor = 3;
+    input.settings.interface.textBackgroundStyle = 3;
+    input.settings.interface.textBackgroundOpacity = 4;
+    input.settings.social.preferGoodConnection = true;
+    input.settings.social.textChatMode = 3;
+    input.settings.social.showRealNames = true;
+    input.settings.social.clanInviteNotifications = true;
+    input.settings.social.profanityFilter = true;
+    input.settings.social.voiceChatEnabled = true;
+    input.settings.social.whisperChatMode = 1;
+    input.settings.social.teamChatJoinMode = 1;
+    input.settings.social.localChatJoinMode = 1;
+    input.settings.social.clanChatJoinMode = 1;
+    input.settings.social.chatAutoHideMode = 1;
+    input.settings.keyBindingSource = account::settings::KeyBindingSource::account;
+    input.settings.keyBindings.configured = true;
+    input.settings.keyBindings.values[0].primary = 0xFFFFU;
+    input.settings.keyBindings.values[0].secondary.reset();
+    input.settings.keyBindings.values.back().primary = 1U;
+    input.settings.keyBindings.values.back().secondary = 2U;
+    input.settings.configured = true;
+
+    int moduleToken = 0;
+    void* module = &moduleToken;
+    if (!check(account::valid(input), "production-valid fixture")
+        || !check(persistence::sqlite::detail::save_account(module, input), "save account")) {
+        return 1;
+    }
+    AccountState output{};
+    if (!check(persistence::sqlite::detail::load_account(module, output)
+                   == persistence::sqlite::detail::LoadResult::loaded,
+               "load account")
+        || !check(same_account(input, output), "complete account round trip")) {
+        return 1;
+    }
+    AccountState invalid = input;
+    invalid.characters[0].equipment.slots[11]->level = -1;
+    if (!check(!account::valid(invalid), "reject invalid fixture")
+        || !check(!persistence::sqlite::detail::save_account(module, invalid),
+                  "reject invalid save")
+        || !check(persistence::sqlite::detail::load_account(module, output)
+                      == persistence::sqlite::detail::LoadResult::loaded,
+                  "load after rejected save")
+        || !check(same_account(input, output), "rejected save preserves snapshot")) {
+        return 1;
+    }
+
+    const std::wstring databasePath = (root / "state.sqlite3").wstring();
+    sqlite3* database = nullptr;
+    if (!check(sqlite3_open16(databasePath.c_str(), &database) == SQLITE_OK,
+               "open database for inspection")) {
+        return 1;
+    }
+    int integrity = 0;
+    int foreignKeyViolations = 0;
+    int deleteJournal = 0;
+    const auto integrityCallback = [](void* value, int columns, char** values, char**) -> int {
+        if (columns == 1 && values != nullptr && values[0] != nullptr
+            && std::string_view(values[0]) == "ok") {
+            *static_cast<int*>(value) = 1;
+        }
+        return 0;
+    };
+    const auto rowCountCallback = [](void* value, int, char**, char**) -> int {
+        ++*static_cast<int*>(value);
+        return 0;
+    };
+    const auto deleteJournalCallback = [](void* value,
+                                          int columns,
+                                          char** values,
+                                          char**) -> int {
+        if (columns == 1 && values != nullptr && values[0] != nullptr
+            && std::string_view(values[0]) == "delete") {
+            *static_cast<int*>(value) = 1;
+        }
+        return 0;
+    };
+    const bool inspected =
+        sqlite3_exec(database,
+                     "PRAGMA integrity_check;",
+                     integrityCallback,
+                     &integrity,
+                     nullptr)
+            == SQLITE_OK
+        && integrity == 1
+        && sqlite3_exec(database,
+                        "PRAGMA foreign_key_check;",
+                        rowCountCallback,
+                        &foreignKeyViolations,
+                        nullptr)
+               == SQLITE_OK
+        && foreignKeyViolations == 0
+        && sqlite3_exec(database,
+                        "PRAGMA journal_mode = DELETE;",
+                        deleteJournalCallback,
+                        &deleteJournal,
+                        nullptr)
+               == SQLITE_OK
+        && deleteJournal == 1
+        && sqlite3_exec(database, "PRAGMA user_version = 2;", nullptr, nullptr, nullptr)
+               == SQLITE_OK
+        && sqlite3_close(database) == SQLITE_OK;
+    database = nullptr;
+    if (!check(inspected, "integrity and schema version setup")) {
+        return 1;
+    }
+    AccountState ignored{};
+    if (!check(persistence::sqlite::detail::load_account(module, ignored)
+                   == persistence::sqlite::detail::LoadResult::schemaNewer,
+               "reject newer schema")) {
+        return 1;
+    }
+
+    if (!check(sqlite3_open16(databasePath.c_str(), &database) == SQLITE_OK,
+               "reopen database")) {
+        return 1;
+    }
+    int preservedJournal = 0;
+    const bool preservedSchema =
+        sqlite3_exec(database,
+                     "PRAGMA journal_mode;",
+                     deleteJournalCallback,
+                     &preservedJournal,
+                     nullptr)
+            == SQLITE_OK
+        && preservedJournal == 1
+        && sqlite3_exec(database, "PRAGMA user_version = 1;", nullptr, nullptr, nullptr)
+               == SQLITE_OK;
+    if (!check(preservedSchema, "newer schema remains in delete journal mode")) {
+        (void)sqlite3_close(database);
+        return 1;
+    }
+    const bool damaged =
+        sqlite3_exec(database,
+                     "DELETE FROM item_plugs WHERE character_position = 0 "
+                     "AND location = 0 AND item_position = 11 AND plug_position = 1;",
+                     nullptr,
+                     nullptr,
+                     nullptr)
+            == SQLITE_OK
+        && sqlite3_close(database) == SQLITE_OK;
+    database = nullptr;
+    if (!check(damaged, "damage child row")) {
+        return 1;
+    }
+    if (!check(persistence::sqlite::detail::load_account(module, ignored)
+                   == persistence::sqlite::detail::LoadResult::invalid,
+               "reject incomplete child rows")
+        || !check(persistence::sqlite::detail::save_account(module, input), "repair snapshot")
+        || !check(persistence::sqlite::detail::load_account(module, ignored)
+                      == persistence::sqlite::detail::LoadResult::loaded,
+                  "load repaired snapshot")) {
+        return 1;
+    }
+
+    if (!check(sqlite3_open16(databasePath.c_str(), &database) == SQLITE_OK,
+               "open account-format database")) {
+        return 1;
+    }
+    const bool newerAccountFormat =
+        sqlite3_exec(database,
+                     "UPDATE account_state SET format_version = 2 WHERE singleton = 1;",
+                     nullptr,
+                     nullptr,
+                     nullptr)
+            == SQLITE_OK
+        && sqlite3_close(database) == SQLITE_OK;
+    database = nullptr;
+    activity::defaults::ActivityDefaults defaults{};
+    if (!check(newerAccountFormat, "set newer account format")
+        || !check(persistence::initialize(module, input, defaults),
+                  "fallback from newer account format")) {
+        return 1;
+    }
+    persistence::shutdown();
+    if (!check(persistence::sqlite::detail::load_account(module, ignored)
+                   == persistence::sqlite::detail::LoadResult::formatNewer,
+               "preserve newer account format")) {
+        return 1;
+    }
+    if (!check(sqlite3_open16(databasePath.c_str(), &database) == SQLITE_OK,
+               "restore account format")) {
+        return 1;
+    }
+    const bool restoredAccountFormat =
+        sqlite3_exec(database,
+                     "UPDATE account_state SET format_version = 1 WHERE singleton = 1;",
+                     nullptr,
+                     nullptr,
+                     nullptr)
+            == SQLITE_OK
+        && set_settings_payload_version(database,
+                                        2,
+                                        persistence::sqlite::detail::kSettingsPayloadCapacity + 1)
+        && sqlite3_close(database) == SQLITE_OK;
+    database = nullptr;
+    if (!check(restoredAccountFormat, "set newer settings format")
+        || !check(persistence::initialize(module, input, defaults),
+                  "fallback from newer settings format")) {
+        return 1;
+    }
+    persistence::shutdown();
+    if (!check(persistence::sqlite::detail::load_account(module, ignored)
+                   == persistence::sqlite::detail::LoadResult::formatNewer,
+               "preserve newer settings format")) {
+        return 1;
+    }
+    if (!check(persistence::sqlite::detail::save_account(module, input),
+               "restore settings format")
+        || !check(persistence::sqlite::detail::load_account(module, output)
+                      == persistence::sqlite::detail::LoadResult::loaded,
+                  "load after compatibility checks")
+        || !check(same_account(input, output), "compatibility checks preserve account")) {
+        return 1;
+    }
+
+    std::filesystem::remove_all(root, error);
+    if (!check(!error, "remove temporary directory")) {
+        return 1;
+    }
+    std::cout << "sqlite-account-snapshot-ok\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Persist the existing account, character, equipment, inventory, socket, profile-item, reward, and settings state in SQLite schema v1.
- Restore a validated snapshot during startup, with `settings.json` retained as bootstrap and recovery input.
- Save the complete account atomically during shutdown using the Windows SDK WinSQLite API.

## Implementation

The database lives at `Sunrise/state.sqlite3` beside the existing generated artifacts. Relational account data is normalized across six tables; the fixed settings leaf uses an explicitly encoded, versioned payload rather than copying C++ object bytes.

Startup validates the schema, account-row format, settings-payload format, bounded row counts, and the reconstructed production `AccountState`. A missing or malformed snapshot falls back to `settings.json`. Newer schema or payload formats also fall back, but disable persistence writes for that session so older code cannot overwrite newer data.

Shutdown writes a durable checkpoint before Client teardown. If that checkpoint fails, shutdown returns false while Client, Server, Middleware, and State remain alive for retry. The final post-teardown save is best-effort because the same account image is already durable.

## Compatibility

- Schema remains version 1.
- No public API or settings-format changes.
- `settings.json` remains unchanged and recoverable.
- Newer schemas are inspected before writable pragmas and left untouched.
- Existing account settings and key-binding source are preserved; live client settings propagation is outside this PR.
- WinSQLite is supplied by the declared Windows SDK; no SQLite binary is vendored.

## Validation

- Clean `Release|x64` rebuild with Visual Studio 2026 Build Tools, toolset `v145`, and Windows SDK `10.0.26100.0`.
- Standalone production-validator integration test: `sqlite-account-snapshot-ok`.
- Complete field-by-field account round trip, including high-bit identifiers and nullable socket plugs.
- `PRAGMA integrity_check` and `foreign_key_check` pass.
- Invalid production state is rejected.
- Newer schema, account-row, and oversized settings-payload formats remain unchanged across initialize/shutdown.
- Newer schema in DELETE journal mode remains in DELETE mode after inspection.
- Branch-wide `git diff --check` and 100-column check pass.
- Manual restart testing covered character selection, equipment changes, socket selection, item lock state, profile acquisition, dismantling rewards, and restored snapshots.

## Known limitation

Persistence currently checkpoints on clean shutdown. A forced termination can lose changes made after the previous clean snapshot, while the last committed database remains valid. Live audio and key-binding mutations are not propagated back into account State by this PR.