### PR TITLE
ci: build the Linux (clang-cl/xwin) cross-compile on every PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,8 +83,9 @@ jobs:
         run: cmake --build build
 
       - name: Upload artifact
+        # CMakeLists routes outputs to build/x64/<CONFIG>, mirroring MSVC.
         uses: actions/upload-artifact@v4
         with:
           name: Sunrise-Release-x64-linux-cross
-          path: build/steam_api64.dll
+          path: build/x64/Release/steam_api64.dll
           if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,12 +45,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install LLVM toolchain and Ninja
-        # The toolchain file invokes the unsuffixed clang-cl / lld-link /
-        # llvm-lib / llvm-rc names, which Ubuntu only ships inside the
-        # versioned /usr/lib/llvm-*/bin directory — put it on PATH.
+        # The MSVC STL that xwin fetches static-asserts on Clang >= 19, and
+        # the project's warning flags need it too, so Ubuntu 24.04's stock
+        # clang-18 is not enough — install LLVM 20 from apt.llvm.org. The
+        # toolchain file invokes the unsuffixed clang-cl / lld-link /
+        # llvm-lib / llvm-rc names, which only exist inside the versioned
+        # /usr/lib/llvm-*/bin directory — put the newest one on PATH.
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends clang lld llvm ninja-build
+          sudo apt-get install -y --no-install-recommends ninja-build
+          curl -sL https://apt.llvm.org/llvm.sh | sudo bash -s -- 20
           LLVM_BIN=$(ls -d /usr/lib/llvm-*/bin | sort -V | tail -1)
           echo "$LLVM_BIN" >> "$GITHUB_PATH"
           "$LLVM_BIN/clang-cl" --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,3 +35,52 @@ jobs:
             build/x64/Release/steam_api64.dll
             build/x64/Release/steam_api64.pdb
           if-no-files-found: error
+
+  linux-cross:
+    name: Linux cross-compile x64
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install LLVM toolchain and Ninja
+        # The toolchain file invokes the unsuffixed clang-cl / lld-link /
+        # llvm-lib / llvm-rc names, which Ubuntu only ships inside the
+        # versioned /usr/lib/llvm-*/bin directory — put it on PATH.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends clang lld llvm ninja-build
+          LLVM_BIN=$(ls -d /usr/lib/llvm-*/bin | sort -V | tail -1)
+          echo "$LLVM_BIN" >> "$GITHUB_PATH"
+          "$LLVM_BIN/clang-cl" --version
+          cmake --version
+
+      - name: Cache the xwin Windows SDK
+        id: xwin-cache
+        uses: actions/cache@v4
+        with:
+          path: .xwin-cache
+          key: xwin-sdk-10.0.26100-splat-v1
+
+      - name: Download Windows SDK via xwin
+        if: steps.xwin-cache.outputs.cache-hit != 'true'
+        run: |
+          curl -sL https://github.com/Jake-Shadle/xwin/releases/download/0.10.0/xwin-0.10.0-x86_64-unknown-linux-musl.tar.gz | tar xz
+          ./xwin-0.10.0-x86_64-unknown-linux-musl/xwin --sdk-version 10.0.26100 --accept-license splat --include-debug-libs --output .xwin-cache
+
+      - name: Configure
+        run: >
+          cmake -B build -G Ninja
+          -DCMAKE_TOOLCHAIN_FILE=$PWD/linux-to-win-toolchain.cmake
+          -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Sunrise-Release-x64-linux-cross
+          path: build/steam_api64.dll
+          if-no-files-found: error


### PR DESCRIPTION
The Linux build path has broken twice since it landed (#40, #61) because CI only exercises MSVC. This adds a second job that runs the README's documented Linux build on `ubuntu-24.04`, so a PR that compiles under MSVC but not the cross toolchain fails checks instead of landing.

Details:
- LLVM 20 from apt.llvm.org — the MSVC STL that xwin fetches static-asserts Clang >= 19 (stock ubuntu-24.04 clang-18 fails), and the project's warning flags need >= 19 as well
- xwin 0.10.0 pinned; the splatted SDK is cached between runs (one-time ~2 min fetch on first run)
- Ninja + the repo's own `linux-to-win-toolchain.cmake`, per README; artifact uploaded from `build/x64/Release/`, mirroring the MSVC job
- Timing on my fork: 5m16s with warm cache — finishes before the MSVC job, so no added wall-clock
- Green run: https://github.com/ProjectUgarte/Sunrise/actions/runs/32770256080

🤖 Generated with [Claude Code](https://claude.com/claude-code)