### PR TITLE
Investement: random rolls - support randomized weapon acquisitions

### DIFF
--- a/Sunrise/Sunrise.vcxproj
+++ b/Sunrise/Sunrise.vcxproj
@@ -145,6 +145,7 @@
     <ClCompile Include="src\state\runtime\state_account_profile_runtime.cpp" />
     <ClCompile Include="src\state\runtime\state_account_socket_runtime.cpp" />
     <ClCompile Include="src\state\runtime\state_rolled_socket_plugs.cpp" />
+    <ClCompile Include="src\state\runtime\state_item_random_roll.cpp" />
     <ClCompile Include="src\state\runtime\state_account_item_action_runtime.cpp" />
     <ClCompile Include="src\core\ui\busy\ui_busy_overlay.cpp" />
     <ClCompile Include="src\core\ui\busy\ui_busy_state.cpp" />
@@ -242,6 +243,8 @@
     <ClCompile Include="src\client\hooks\bitmap\bitmap_hook_lifecycle.cpp" />
     <ClCompile Include="src\client\hooks\membership_probe\membership_probe.cpp" />
     <ClCompile Include="src\client\hooks\bitmap\bitmap_ref_guard.cpp" />
+    <ClCompile Include="src\client\hooks\sockets\socket_masks_hook.cpp" />
+    <ClCompile Include="src\client\hooks\sockets\sockets_lifecycle.cpp" />
     <ClCompile Include="src\client\hooks\external_server\external_server_route.cpp" />
     <ClCompile Include="src\client\hooks\external_server\external_server_setopt_guard.cpp" />
     <ClCompile Include="src\client\hooks\bootflow\bootflow_hook_lifecycle.cpp" />
@@ -1004,6 +1007,7 @@
     <ClInclude Include="src\state\runtime\runtime.h" />
     <ClInclude Include="src\state\runtime\state_account_transaction_helpers.h" />
     <ClInclude Include="src\state\runtime\state_rolled_socket_plugs.h" />
+    <ClInclude Include="src\state\runtime\state_item_random_roll.h" />
     <ClInclude Include="src\state\runtime\state.h" />
     <ClInclude Include="src\state\runtime\storage\internal.h" />
     <ClInclude Include="src\state\activity\definition.h" />
@@ -1239,6 +1243,8 @@
     <ClInclude Include="src\client\hooks\assert_handler\assert_handler_lifecycle.h" />
     <ClInclude Include="src\client\hooks\bitmap\bitmap_ref_guard.h" />
     <ClInclude Include="src\client\hooks\bitmap\bitmap_hook_lifecycle.h" />
+    <ClInclude Include="src\client\hooks\sockets\socket_masks_hook.h" />
+    <ClInclude Include="src\client\hooks\sockets\sockets_lifecycle.h" />
     <ClInclude Include="src\client\hooks\membership_probe\membership_probe.h" />
     <ClInclude Include="src\client\hooks\bootflow\internal.h" />
     <ClInclude Include="src\client\hooks\bootflow\bootflow_hook_lifecycle.h" />

--- a/Sunrise/src/client/content/items/packages/internal.h
+++ b/Sunrise/src/client/content/items/packages/internal.h
@@ -61,10 +61,6 @@ struct Storage {
     std::vector<std::byte> definition{};
     /** Shared reusable/randomized plug-set table read from investment-root slot 51. */
     std::vector<std::byte> plugSetTable{};
-    /** Socket-entry-list table blob (investment-root slot 97), for lane<->entry matching. */
-    std::vector<std::byte> socketEntryTable{};
-    /** One resolved socket-entry-list definition blob while matching a rolled lane to its entry. */
-    std::vector<std::byte> socketEntryList{};
     /** Compact 0..3 special plug-category code of every dense installed item row. */
     std::array<std::uint8_t, state::build_data::items::kDefinitionCapacity> specialPlugCategories{};
     /** Inventory routing rows held until the paired bucket-definition table is resolved. */

--- a/Sunrise/src/client/content/items/packages/internal.h
+++ b/Sunrise/src/client/content/items/packages/internal.h
@@ -61,6 +61,10 @@ struct Storage {
     std::vector<std::byte> definition{};
     /** Shared reusable/randomized plug-set table read from investment-root slot 51. */
     std::vector<std::byte> plugSetTable{};
+    /** Socket-entry-list table blob (investment-root slot 97), for lane<->entry matching. */
+    std::vector<std::byte> socketEntryTable{};
+    /** One resolved socket-entry-list definition blob while matching a rolled lane to its entry. */
+    std::vector<std::byte> socketEntryList{};
     /** Compact 0..3 special plug-category code of every dense installed item row. */
     std::array<std::uint8_t, state::build_data::items::kDefinitionCapacity> specialPlugCategories{};
     /** Inventory routing rows held until the paired bucket-definition table is resolved. */

--- a/Sunrise/src/client/content/items/packages/package_item_rows.cpp
+++ b/Sunrise/src/client/content/items/packages/package_item_rows.cpp
@@ -54,21 +54,6 @@ bool build_item_rows(const reader::Source& source,
     }
     const bool detailStorageReady = !needDetails || storage.details.size() == kDetailCapacity;
     const std::span<const std::byte> container{storage.child};
-    // The socket-entry-list table (investment root slot 97) is resolved once so each rolled
-    // lane can be matched to the socket entry the hover preview reads through.
-    tables::Array socketEntryTable{};
-    std::uint32_t socketTableTag = 0;
-    const bool socketTableReady =
-        !needSocketPlugs
-        || (tables::slot_tag(std::span<const std::byte>{storage.root},
-                             tables::kSocketEntryListTableSlot,
-                             socketTableTag)
-            && socketTableTag != 0
-            && reader::read_tag(source, storage.scratch, socketTableTag, storage.socketEntryTable)
-            && tables::find_array_at(std::span<const std::byte>{storage.socketEntryTable},
-                                     tables::kTableArrayDescriptor,
-                                     socketEntryTable)
-            && socketEntryTable.elementClass == tables::kSocketEntryListTableClass);
     reason = "rows";
     // The detail closure is gathered during this one walk. Collections can name any installed
     // item row, including profile-owned shaders and modifications, so retain every readable row.
@@ -167,54 +152,10 @@ bool build_item_rows(const reader::Source& source,
                 storage.details[builtDetailCount++] = detail;
             }
             if (needSocketPlugs) {
-                // Collect every socket entry's plug-set reference for this item so a rolled lane
-                // can be matched to the exact entry the hover preview resolves. Resolution errors
-                // leave the pool empty, which is the safe no-op (no state is pinned).
-                std::array<std::uint16_t, 64> entryPlugSets{};
-                std::size_t entryPlugCount = 0;
-                if (socketTableReady && item.hasSocketEntryList
-                    && item.socketEntryListIndex < socketEntryTable.count) {
-                    tables::IndexRow listRow{};
-                    if (tables::index_row(std::span<const std::byte>{storage.socketEntryTable},
-                                          socketEntryTable,
-                                          item.socketEntryListIndex,
-                                          listRow)
-                        && listRow.targetTag != 0
-                        && reader::read_tag(
-                            source, storage.scratch, listRow.targetTag, storage.socketEntryList)) {
-                        tables::Array entries{};
-                        if (tables::find_array_at(
-                                std::span<const std::byte>{storage.socketEntryList},
-                                tables::kSocketEntryArrayDescriptor,
-                                entries)
-                            && entries.count <= entryPlugSets.size()) {
-                            for (std::uint64_t e = 0; e < entries.count; ++e) {
-                                const std::size_t base =
-                                    entries.dataOffset
-                                    + static_cast<std::size_t>(e) * tables::kSocketEntrySize;
-                                std::uint16_t plugSet = 0;
-                                // The read sits at the plug-set field, not at the entry's first
-                                // byte, so the whole field has to fit inside the resolved blob.
-                                if (base > storage.socketEntryList.size()
-                                    || tables::kSocketEntryPlugSetIndex + sizeof plugSet
-                                           > storage.socketEntryList.size() - base) {
-                                    break;
-                                }
-                                std::memcpy(&plugSet,
-                                            storage.socketEntryList.data() + base
-                                                + tables::kSocketEntryPlugSetIndex,
-                                            sizeof plugSet);
-                                entryPlugSets[entryPlugCount++] = plugSet;
-                            }
-                        }
-                    }
-                }
-                (void)socketPlugBuild.append(
-                    item,
-                    std::span<const std::byte>{storage.definition},
-                    std::span<const std::byte>{storage.plugSetTable},
-                    std::span<const std::uint16_t>{entryPlugSets}.first(entryPlugCount),
-                    table.count);
+                (void)socketPlugBuild.append(item,
+                                                   std::span<const std::byte>{storage.definition},
+                                                   std::span<const std::byte>{storage.plugSetTable},
+                                                   table.count);
             }
         }
         if (needDetails) {

--- a/Sunrise/src/client/content/items/packages/package_item_rows.cpp
+++ b/Sunrise/src/client/content/items/packages/package_item_rows.cpp
@@ -54,6 +54,21 @@ bool build_item_rows(const reader::Source& source,
     }
     const bool detailStorageReady = !needDetails || storage.details.size() == kDetailCapacity;
     const std::span<const std::byte> container{storage.child};
+    // The socket-entry-list table (investment root slot 97) is resolved once so each rolled
+    // lane can be matched to the socket entry the hover preview reads through.
+    tables::Array socketEntryTable{};
+    std::uint32_t socketTableTag = 0;
+    const bool socketTableReady =
+        !needSocketPlugs
+        || (tables::slot_tag(std::span<const std::byte>{storage.root},
+                             tables::kSocketEntryListTableSlot,
+                             socketTableTag)
+            && socketTableTag != 0
+            && reader::read_tag(source, storage.scratch, socketTableTag, storage.socketEntryTable)
+            && tables::find_array_at(std::span<const std::byte>{storage.socketEntryTable},
+                                     tables::kTableArrayDescriptor,
+                                     socketEntryTable)
+            && socketEntryTable.elementClass == tables::kSocketEntryListTableClass);
     reason = "rows";
     // The detail closure is gathered during this one walk. Collections can name any installed
     // item row, including profile-owned shaders and modifications, so retain every readable row.
@@ -78,6 +93,11 @@ bool build_item_rows(const reader::Source& source,
                                                item)) {
             continue;
         }
+        const auto firstStat =
+            item.statCount != 0 && item.statValues[0] >= 0 && item.statValues[0] <= 255
+                ? static_cast<std::uint8_t>(item.statValues[0])
+                : std::uint8_t{0};
+        const auto firstStatRow = item.statCount != 0 ? item.statRows[0] : std::uint8_t{0xFF};
         storage.rows[rowCount++] =
             state::build_data::items::Definition{item.definitionHash,
                                                  item.definitionIndex,
@@ -87,7 +107,9 @@ bool build_item_rows(const reader::Source& source,
                                                  item.tier,
                                                  item.plugCategoryHash,
                                                  item.rollSetIndex,
-                                                 item.linkedPlugIndex};
+                                                 item.linkedPlugIndex,
+                                                 firstStat,
+                                                 firstStatRow};
         if (needSocketPlugs) {
             storage.specialPlugCategories[item.definitionIndex] =
                 special_plug_category(item.plugCategoryHash);
@@ -145,10 +167,54 @@ bool build_item_rows(const reader::Source& source,
                 storage.details[builtDetailCount++] = detail;
             }
             if (needSocketPlugs) {
-                (void)socketPlugBuild.append(item,
-                                             std::span<const std::byte>{storage.definition},
-                                             std::span<const std::byte>{storage.plugSetTable},
-                                             table.count);
+                // Collect every socket entry's plug-set reference for this item so a rolled lane
+                // can be matched to the exact entry the hover preview resolves. Resolution errors
+                // leave the pool empty, which is the safe no-op (no state is pinned).
+                std::array<std::uint16_t, 64> entryPlugSets{};
+                std::size_t entryPlugCount = 0;
+                if (socketTableReady && item.hasSocketEntryList
+                    && item.socketEntryListIndex < socketEntryTable.count) {
+                    tables::IndexRow listRow{};
+                    if (tables::index_row(std::span<const std::byte>{storage.socketEntryTable},
+                                          socketEntryTable,
+                                          item.socketEntryListIndex,
+                                          listRow)
+                        && listRow.targetTag != 0
+                        && reader::read_tag(
+                            source, storage.scratch, listRow.targetTag, storage.socketEntryList)) {
+                        tables::Array entries{};
+                        if (tables::find_array_at(
+                                std::span<const std::byte>{storage.socketEntryList},
+                                tables::kSocketEntryArrayDescriptor,
+                                entries)
+                            && entries.count <= entryPlugSets.size()) {
+                            for (std::uint64_t e = 0; e < entries.count; ++e) {
+                                const std::size_t base =
+                                    entries.dataOffset
+                                    + static_cast<std::size_t>(e) * tables::kSocketEntrySize;
+                                std::uint16_t plugSet = 0;
+                                // The read sits at the plug-set field, not at the entry's first
+                                // byte, so the whole field has to fit inside the resolved blob.
+                                if (base > storage.socketEntryList.size()
+                                    || tables::kSocketEntryPlugSetIndex + sizeof plugSet
+                                           > storage.socketEntryList.size() - base) {
+                                    break;
+                                }
+                                std::memcpy(&plugSet,
+                                            storage.socketEntryList.data() + base
+                                                + tables::kSocketEntryPlugSetIndex,
+                                            sizeof plugSet);
+                                entryPlugSets[entryPlugCount++] = plugSet;
+                            }
+                        }
+                    }
+                }
+                (void)socketPlugBuild.append(
+                    item,
+                    std::span<const std::byte>{storage.definition},
+                    std::span<const std::byte>{storage.plugSetTable},
+                    std::span<const std::uint16_t>{entryPlugSets}.first(entryPlugCount),
+                    table.count);
             }
         }
         if (needDetails) {

--- a/Sunrise/src/client/content/items/packages/package_socket_plug_build.cpp
+++ b/Sunrise/src/client/content/items/packages/package_socket_plug_build.cpp
@@ -247,7 +247,6 @@ bool SocketPlugBuild::intern_roll(std::uint32_t& rollPoolIndex) noexcept {
 bool SocketPlugBuild::append(const tables::items::Row& item,
                              std::span<const std::byte> itemDefinition,
                              std::span<const std::byte> plugSetTable,
-                             std::span<const std::uint16_t> entryPlugSetIndices,
                              std::size_t itemDefinitionCount) noexcept {
     if (rules_.empty() || item.definitionIndex >= itemDefinitionCount
         || item.socketCount > socket_plugs::kLaneCapacity) {
@@ -291,25 +290,7 @@ bool SocketPlugBuild::append(const tables::items::Row& item,
             rollPoolIndex = socket_plugs::kEmptyRollPoolIndex;
             complete = false;
         }
-        // A rolled lane's perk is resolved by the hover preview through the socket entry whose
-        // roll pool is this lane's roll pool. Match the lane's randomized-set index against each
-        // entry's plug-set reference so state can be pinned on the exact entry (and never on a
-        // wrong lane position). A lane with no matching entry stays kNoSocketEntry and simply
-        // never pins, which is the safe no-op.
-        std::uint8_t socketEntryIndex = socket_plugs::kNoSocketEntry;
-        std::uint16_t laneSetIndex = tables::items::kUnavailablePlug;
-        if (tables::items::read_roll_set_index(itemDefinition, lane, laneSetIndex)
-            && laneSetIndex != tables::items::kUnavailablePlug) {
-            const std::uint16_t laneMask = static_cast<std::uint16_t>(laneSetIndex & 0x1FFFu);
-            for (std::size_t entry = 0; entry < entryPlugSetIndices.size(); ++entry) {
-                if ((entryPlugSetIndices[entry] & 0x1FFFu) == laneMask) {
-                    socketEntryIndex = static_cast<std::uint8_t>(entry);
-                    break;
-                }
-            }
-        }
-        rules_[ruleCount_++] = {
-            item.definitionIndex, lane, socketEntryIndex, poolIndex, rollPoolIndex};
+        rules_[ruleCount_++] = {item.definitionIndex, lane, 0, poolIndex, rollPoolIndex};
     }
     return complete;
 }

--- a/Sunrise/src/client/content/items/packages/package_socket_plug_build.cpp
+++ b/Sunrise/src/client/content/items/packages/package_socket_plug_build.cpp
@@ -39,6 +39,13 @@ struct VisitorContext {
            && context.build->add(itemDefinitionIndex, context.itemDefinitionCount);
 }
 
+/** @return Whether the package-provided roll member was accepted into bounded roll scratch. */
+[[nodiscard]] bool visit_roll_member(void* opaque, std::uint32_t itemDefinitionIndex) noexcept {
+    auto& context = *static_cast<VisitorContext*>(opaque);
+    return context.build != nullptr
+           && context.build->add_roll(itemDefinitionIndex, context.itemDefinitionCount);
+}
+
 } // namespace
 
 /** Returns the compact 1-based code of one native category-expansion family. */
@@ -64,10 +71,16 @@ bool SocketPlugBuild::prepare(
     pools_.assign(socket_plugs::kPoolCapacity, {});
     members_.assign(socket_plugs::kMemberCapacity, {});
     candidates_.assign(state::build_data::items::kDefinitionCapacity, {});
+    rollPools_.assign(socket_plugs::kRollPoolCapacity, {});
+    rollMembers_.assign(socket_plugs::kRollMemberCapacity, {});
+    rollCandidates_.assign(state::build_data::items::kDefinitionCapacity, {});
     categoryMembers_.assign(kCategoryCount * state::build_data::items::kDefinitionCapacity, {});
     lookup_.assign(kLookupCapacity, {});
+    rollLookup_.assign(kLookupCapacity, {});
     pools_[socket_plugs::kEmptyPoolIndex] = {};
     poolCount_ = 1;
+    rollPools_[socket_plugs::kEmptyRollPoolIndex] = {};
+    rollPoolCount_ = 1;
     for (std::size_t item = 0; item < itemDefinitions.size(); ++item) {
         const std::uint8_t category = specialCategories[item];
         if (category != 0 && category <= kCategoryCount) {
@@ -98,6 +111,17 @@ bool SocketPlugBuild::add(std::uint32_t itemDefinitionIndex,
         return false;
     }
     candidates_[candidateCount_++] = static_cast<std::uint16_t>(itemDefinitionIndex);
+    return true;
+}
+
+bool SocketPlugBuild::add_roll(std::uint32_t itemDefinitionIndex,
+                               std::size_t itemDefinitionCount) noexcept {
+    if (rollCandidates_.empty() || itemDefinitionIndex >= itemDefinitionCount
+        || itemDefinitionIndex >= state::build_data::items::kDefinitionCapacity
+        || rollCandidateCount_ >= state::build_data::items::kDefinitionCapacity) {
+        return false;
+    }
+    rollCandidates_[rollCandidateCount_++] = static_cast<std::uint16_t>(itemDefinitionIndex);
     return true;
 }
 
@@ -139,43 +163,57 @@ bool SocketPlugBuild::intern(std::uint32_t& poolIndex) noexcept {
     if (candidateCount_ == 0) {
         return true;
     }
+    return intern_into(Bank{pools_,
+                            members_,
+                            lookup_,
+                            poolCount_,
+                            memberCount_,
+                            socket_plugs::kPoolCapacity,
+                            socket_plugs::kMemberCapacity},
+                       {candidates_.data(), candidateCount_},
+                       poolIndex);
+}
 
+/** Finds the pool an identical sequence already occupies, or appends one for it. */
+bool SocketPlugBuild::intern_into(Bank bank,
+                                  std::span<const socket_plugs::Member> candidates,
+                                  std::uint32_t& poolIndex) noexcept {
     std::uint64_t fingerprint = kHashOffsetBasis;
-    for (std::size_t member = 0; member < candidateCount_; ++member) {
-        std::uint16_t value = candidates_[member];
+    for (const socket_plugs::Member member : candidates) {
+        std::uint16_t value = member;
         for (std::size_t byte = 0; byte < sizeof value; ++byte) {
             fingerprint ^= static_cast<std::uint8_t>(value);
             fingerprint *= kHashPrime;
             value >>= 8U;
         }
     }
-    fingerprint ^= candidateCount_;
+    fingerprint ^= candidates.size();
     fingerprint *= kHashPrime;
     static_assert((kLookupCapacity & (kLookupCapacity - 1)) == 0);
     const std::size_t start = static_cast<std::size_t>(fingerprint) & (kLookupCapacity - 1);
     for (std::size_t probe = 0; probe < kLookupCapacity; ++probe) {
-        PoolLookup& slot = lookup_[(start + probe) & (kLookupCapacity - 1)];
+        PoolLookup& slot = bank.lookup[(start + probe) & (kLookupCapacity - 1)];
         if (slot.poolIndex == UINT32_MAX) {
-            if (poolCount_ >= socket_plugs::kPoolCapacity
-                || candidateCount_ > socket_plugs::kMemberCapacity - memberCount_) {
+            if (bank.poolCount >= bank.poolCapacity
+                || candidates.size() > bank.memberCapacity - bank.memberCount) {
                 return false;
             }
-            poolIndex = static_cast<std::uint32_t>(poolCount_);
-            pools_[poolCount_++] = {static_cast<std::uint32_t>(memberCount_),
-                                    static_cast<std::uint32_t>(candidateCount_)};
-            std::copy_n(candidates_.data(), candidateCount_, members_.data() + memberCount_);
-            memberCount_ += candidateCount_;
+            poolIndex = static_cast<std::uint32_t>(bank.poolCount);
+            bank.pools[bank.poolCount++] = {static_cast<std::uint32_t>(bank.memberCount),
+                                            static_cast<std::uint32_t>(candidates.size())};
+            std::copy_n(
+                candidates.data(), candidates.size(), bank.members.data() + bank.memberCount);
+            bank.memberCount += candidates.size();
             slot = {fingerprint, poolIndex};
             return true;
         }
-        if (slot.fingerprint != fingerprint || slot.poolIndex >= poolCount_) {
+        if (slot.fingerprint != fingerprint || slot.poolIndex >= bank.poolCount) {
             continue;
         }
-        const socket_plugs::Pool& pool = pools_[slot.poolIndex];
-        if (pool.memberCount == candidateCount_
-            && std::equal(candidates_.data(),
-                          candidates_.data() + candidateCount_,
-                          members_.data() + pool.memberOffset)) {
+        const socket_plugs::Pool& pool = bank.pools[slot.poolIndex];
+        if (pool.memberCount == candidates.size()
+            && std::equal(
+                candidates.begin(), candidates.end(), bank.members.data() + pool.memberOffset)) {
             poolIndex = slot.poolIndex;
             return true;
         }
@@ -183,10 +221,33 @@ bool SocketPlugBuild::intern(std::uint32_t& poolIndex) noexcept {
     return false;
 }
 
+/** Interns the current native-order roll candidate as one shared roll pool. */
+bool SocketPlugBuild::intern_roll(std::uint32_t& rollPoolIndex) noexcept {
+    rollPoolIndex = socket_plugs::kEmptyRollPoolIndex;
+    if (rollCandidateCount_ == 0 || rollPools_.empty() || rollMembers_.empty()
+        || rollLookup_.empty()) {
+        return true;
+    }
+    // Row order is this bank's identity: the row a plug sits on is what the rolled instance
+    // stores, so the sequence is interned exactly as the package published it, never sorted or
+    // deduplicated the way a curated pool is. Whole weapon families share one randomized set, so
+    // reusing the matching pool is what keeps the member bank off its ceiling.
+    return intern_into(Bank{rollPools_,
+                            rollMembers_,
+                            rollLookup_,
+                            rollPoolCount_,
+                            rollMemberCount_,
+                            socket_plugs::kRollPoolCapacity,
+                            socket_plugs::kRollMemberCapacity},
+                       {rollCandidates_.data(), rollCandidateCount_},
+                       rollPoolIndex);
+}
+
 /** Extracts every exact ordinary socket pool of one installed item definition. */
 bool SocketPlugBuild::append(const tables::items::Row& item,
                              std::span<const std::byte> itemDefinition,
                              std::span<const std::byte> plugSetTable,
+                             std::span<const std::uint16_t> entryPlugSetIndices,
                              std::size_t itemDefinitionCount) noexcept {
     if (rules_.empty() || item.definitionIndex >= itemDefinitionCount
         || item.socketCount > socket_plugs::kLaneCapacity) {
@@ -196,8 +257,10 @@ bool SocketPlugBuild::append(const tables::items::Row& item,
     for (std::uint8_t lane = 0; lane < item.socketCount; ++lane) {
         candidateCount_ = 0;
         VisitorContext visitor{this, itemDefinitionCount};
+        // The allowed pool is the curated offer set (embedded + reusable + initial), never
+        // the randomized roll set, which is separately interned as the lane's roll pool.
         bool laneValid = tables::items::visit_allowed_plugs(
-            itemDefinition, plugSetTable, lane, visit_member, &visitor);
+            itemDefinition, plugSetTable, lane, visit_member, &visitor, false);
         if (laneValid && item.initialPlugs[lane] != tables::items::kUnavailablePlug) {
             laneValid = add(item.initialPlugs[lane], itemDefinitionCount);
         }
@@ -213,18 +276,53 @@ bool SocketPlugBuild::append(const tables::items::Row& item,
             complete = false;
             continue;
         }
-        rules_[ruleCount_++] = {item.definitionIndex, lane, 0, poolIndex};
+
+        // The roll pool is an addition to the lane, not a condition on it. A lane whose randomized
+        // set cannot be read, or whose members no longer fit the roll bank, keeps its curated rule
+        // against the empty roll pool: dropping the rule instead would take the lane's allowed
+        // pool with it and stop ordinary socket insertion working on that lane at all.
+        std::uint32_t rollPoolIndex = socket_plugs::kEmptyRollPoolIndex;
+        rollCandidateCount_ = 0;
+        VisitorContext rollVisitor{this, itemDefinitionCount};
+        if (!tables::items::visit_roll_plugs(
+                itemDefinition, plugSetTable, lane, visit_roll_member, &rollVisitor)
+            || !intern_roll(rollPoolIndex)) {
+            rollCandidateCount_ = 0;
+            rollPoolIndex = socket_plugs::kEmptyRollPoolIndex;
+            complete = false;
+        }
+        // A rolled lane's perk is resolved by the hover preview through the socket entry whose
+        // roll pool is this lane's roll pool. Match the lane's randomized-set index against each
+        // entry's plug-set reference so state can be pinned on the exact entry (and never on a
+        // wrong lane position). A lane with no matching entry stays kNoSocketEntry and simply
+        // never pins, which is the safe no-op.
+        std::uint8_t socketEntryIndex = socket_plugs::kNoSocketEntry;
+        std::uint16_t laneSetIndex = tables::items::kUnavailablePlug;
+        if (tables::items::read_roll_set_index(itemDefinition, lane, laneSetIndex)
+            && laneSetIndex != tables::items::kUnavailablePlug) {
+            const std::uint16_t laneMask = static_cast<std::uint16_t>(laneSetIndex & 0x1FFFu);
+            for (std::size_t entry = 0; entry < entryPlugSetIndices.size(); ++entry) {
+                if ((entryPlugSetIndices[entry] & 0x1FFFu) == laneMask) {
+                    socketEntryIndex = static_cast<std::uint8_t>(entry);
+                    break;
+                }
+            }
+        }
+        rules_[ruleCount_++] = {
+            item.definitionIndex, lane, socketEntryIndex, poolIndex, rollPoolIndex};
     }
     return complete;
 }
 
 /** Publishes the bounded relation and releases all transient interning memory. */
 bool SocketPlugBuild::publish() noexcept {
-    const bool published =
-        !rules_.empty() && !pools_.empty() && !members_.empty()
-        && state::build_data::publish_socket_plug_rules(std::span(rules_.data(), ruleCount_),
-                                                        std::span(pools_.data(), poolCount_),
-                                                        std::span(members_.data(), memberCount_));
+    const bool published = !rules_.empty() && !pools_.empty() && !members_.empty()
+                           && state::build_data::publish_socket_plug_rules(
+                               std::span(rules_.data(), ruleCount_),
+                               std::span(pools_.data(), poolCount_),
+                               std::span(members_.data(), memberCount_),
+                               std::span(rollPools_.data(), rollPoolCount_),
+                               std::span(rollMembers_.data(), rollMemberCount_));
     release();
     return published;
 }
@@ -256,10 +354,18 @@ void SocketPlugBuild::release() noexcept {
     members_.shrink_to_fit();
     candidates_.clear();
     candidates_.shrink_to_fit();
+    rollPools_.clear();
+    rollPools_.shrink_to_fit();
+    rollMembers_.clear();
+    rollMembers_.shrink_to_fit();
+    rollCandidates_.clear();
+    rollCandidates_.shrink_to_fit();
     categoryMembers_.clear();
     categoryMembers_.shrink_to_fit();
     lookup_.clear();
     lookup_.shrink_to_fit();
+    rollLookup_.clear();
+    rollLookup_.shrink_to_fit();
     categoryCounts_ = {};
     trackerMembers_ = {};
     trackerCount_ = 0;
@@ -267,6 +373,9 @@ void SocketPlugBuild::release() noexcept {
     poolCount_ = 0;
     memberCount_ = 0;
     candidateCount_ = 0;
+    rollPoolCount_ = 0;
+    rollMemberCount_ = 0;
+    rollCandidateCount_ = 0;
     skipped_ = 0;
 }
 

--- a/Sunrise/src/client/content/items/packages/package_socket_plug_build.h
+++ b/Sunrise/src/client/content/items/packages/package_socket_plug_build.h
@@ -32,6 +32,7 @@ public:
     [[nodiscard]] bool append(const tables::items::Row& item,
                               std::span<const std::byte> itemDefinition,
                               std::span<const std::byte> plugSetTable,
+                              std::span<const std::uint16_t> entryPlugSetIndices,
                               std::size_t itemDefinitionCount) noexcept;
 
     /** Publishes the completed exact relation, then releases its transient scratch. */
@@ -47,10 +48,29 @@ public:
     [[nodiscard]] bool add(std::uint32_t itemDefinitionIndex,
                            std::size_t itemDefinitionCount) noexcept;
 
+    /** Roll-set visitor entry point; accepts only an in-range bounded native index. */
+    [[nodiscard]] bool add_roll(std::uint32_t itemDefinitionIndex,
+                                std::size_t itemDefinitionCount) noexcept;
+
 private:
     struct PoolLookup {
         std::uint64_t fingerprint{};
         std::uint32_t poolIndex{UINT32_MAX};
+    };
+
+    /**
+     * One interned pool bank: its contiguous ranges, the flat member array they cut up, and the
+     * open-addressed fingerprint index that finds an identical existing range. The curated and
+     * the native-order roll relations are two banks of the same shape.
+     */
+    struct Bank {
+        std::vector<socket_plugs::Pool>& pools;
+        std::vector<socket_plugs::Member>& members;
+        std::vector<PoolLookup>& lookup;
+        std::size_t& poolCount;
+        std::size_t& memberCount;
+        std::size_t poolCapacity;
+        std::size_t memberCapacity;
     };
 
     /** A plug set names three categories: reusable, randomized, and the socket's own default. */
@@ -62,8 +82,12 @@ private:
     std::vector<socket_plugs::Pool> pools_{};
     std::vector<socket_plugs::Member> members_{};
     std::vector<socket_plugs::Member> candidates_{};
+    std::vector<socket_plugs::Pool> rollPools_{};
+    std::vector<socket_plugs::Member> rollMembers_{};
+    std::vector<socket_plugs::Member> rollCandidates_{};
     std::vector<socket_plugs::Member> categoryMembers_{};
     std::vector<PoolLookup> lookup_{};
+    std::vector<PoolLookup> rollLookup_{};
     std::array<std::size_t, kCategoryCount> categoryCounts_{};
     std::array<socket_plugs::Member, 3> trackerMembers_{};
     std::size_t trackerCount_{};
@@ -71,10 +95,27 @@ private:
     std::size_t poolCount_{};
     std::size_t memberCount_{};
     std::size_t candidateCount_{};
+    std::size_t rollPoolCount_{};
+    std::size_t rollMemberCount_{};
+    std::size_t rollCandidateCount_{};
     std::size_t skipped_{};
 
+    /**
+     * Interns one exact ordered member sequence into one bank, reusing the pool an identical
+     * sequence already occupies. The sequence is taken as given: any canonical order the bank
+     * wants is the caller's to establish first.
+     * @param bank Destination ranges, members, index, and their capacities.
+     * @param candidates Non-empty member sequence to intern.
+     * @param poolIndex Receives the reused or newly appended pool.
+     * @return True when the sequence resolved to a pool, false when the bank is full.
+     */
+    [[nodiscard]] static bool intern_into(Bank bank,
+                                          std::span<const socket_plugs::Member> candidates,
+                                          std::uint32_t& poolIndex) noexcept;
     /** Expands native category families, canonicalizes, and interns the current candidate. */
     [[nodiscard]] bool intern(std::uint32_t& poolIndex) noexcept;
+    /** Interns the current native-order roll candidate as one shared roll pool. */
+    [[nodiscard]] bool intern_roll(std::uint32_t& rollPoolIndex) noexcept;
     /** Releases every transient allocation and count. */
     void release() noexcept;
 };

--- a/Sunrise/src/client/content/items/packages/package_socket_plug_build.h
+++ b/Sunrise/src/client/content/items/packages/package_socket_plug_build.h
@@ -32,7 +32,6 @@ public:
     [[nodiscard]] bool append(const tables::items::Row& item,
                               std::span<const std::byte> itemDefinition,
                               std::span<const std::byte> plugSetTable,
-                              std::span<const std::uint16_t> entryPlugSetIndices,
                               std::size_t itemDefinitionCount) noexcept;
 
     /** Publishes the completed exact relation, then releases its transient scratch. */

--- a/Sunrise/src/client/hooks/sockets/socket_masks_hook.cpp
+++ b/Sunrise/src/client/hooks/sockets/socket_masks_hook.cpp
@@ -1,0 +1,162 @@
+/**
+ * Hook on the native ordinary-socket mask rebuild function.
+ *
+ * Inside destiny2.exe, whenever an item's inventory state, equipped state, or socket state is
+ * evaluated, the engine calls item_ordinary_socket_masks_rebuild to compute activeMask (+164),
+ * definitionUnlockMask (+168), blockedMask (+172), and expressionUnlockMask (+176).
+ *
+ * In the engine's hover tooltip builder (sub_7FF7B7D087B0), socket cells are evaluated in two
+ * passes:
+ * - Pass 1 evaluates definition-declared initial plugs (kind 1) gated by Filter 1
+ *   (sub_7FF7B6E06D10). Filter 1 checks `!_bittest(&expressionUnlockMask, lane)`. If bit `lane` is
+ *   clear (0), Filter 1 accepts the definition initial plug (the curated/default perk), adding it
+ *   to the tooltip.
+ * - Pass 2 evaluates the instance's own ordinary sockets (kind 0, ordinarySockets.sockets[lane])
+ *   gated by Filter 1 and Filter 2 (sub_7FF7B6E06BD0).
+ *
+ * Because native weapon perks carry no unlock expressions, the engine's mask rebuilder clears
+ * expressionUnlockMask (+176) to 0. This causes the hover tooltip to always accept the definition's
+ * default curated perks during Pass 1, filling up the 6-perk tooltip buffer and hiding the
+ * instance's dynamic rolled perks. Meanwhile, the Inspect screen (item_socket_cell_widget_update at
+ * 0x7FF7B7DFE180) directly reads ordinarySockets.sockets[lane].plugDefinitionIndex, creating a
+ * divergence between the hover preview and the inspect screen.
+ *
+ * This hook detours item_ordinary_socket_masks_rebuild. After the native function computes the base
+ * masks, for every dynamic lane (lane >= 1) where ordinarySockets.sockets[lane] contains an
+ * assigned plug, it clears bit `lane` in definitionUnlockMask (+168) and sets bit `lane` in
+ * expressionUnlockMask (+176). This ensures that Filter 1 suppresses the definition's curated plug
+ * during Pass 1, allowing Pass 2 to emit the instance's rolled plug into the hover tooltip so that
+ * the hover preview and the inspect screen display the exact same perks.
+ */
+
+#include "socket_masks_hook.h"
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+
+#include "../../../core/logging/log.h"
+#include "../../hooking/detour.h"
+#include "../../patterns/image_scan.h"
+
+namespace sunrise::client::hooks::sockets {
+namespace {
+
+using patterns::scan_main_image_unique;
+using patterns::signature;
+using patterns::signature_length;
+
+/**
+ * Signature for item_ordinary_socket_masks_rebuild.
+ * Unique in the main image.
+ */
+constexpr std::string_view kMasksRebuildSignatureText =
+    "4C 89 44 24 ? 48 89 4C 24 ? 53 56 57 41 54 41 55 41 57 48 83 EC 58 33 C0 4C 89 74 24 ? "
+    "4C 8B B4 24 ? ? ? ? 32 DB 48 89 82 ? ? ? ? 4D 8B F9 4D 8B E8";
+
+constexpr auto kMasksRebuildSignature =
+    signature<signature_length(kMasksRebuildSignatureText)>(kMasksRebuildSignatureText);
+
+/** Function signature of native item_ordinary_socket_masks_rebuild. */
+using MasksRebuildFn = __int64(__fastcall*)(void* itemDef,
+                                            void* itemObject,
+                                            void* socketBlock,
+                                            void* invContext,
+                                            void* profileContext) noexcept;
+
+hooking::detour::Handle g_handle{};
+std::atomic<MasksRebuildFn> g_original{nullptr};
+
+/** Byte offset of OrdinarySocketBlock within native item-instance object. */
+constexpr std::size_t kOrdinarySocketsOffset = 20;
+/** Stride of one native OrdinarySocket lane (plugDefinitionIndex + reserved + auxiliary hashes). */
+constexpr std::size_t kOrdinarySocketStride = 12;
+/** Maximum ordinary socket capacity on one item instance. */
+constexpr std::size_t kMaxOrdinarySockets = 12;
+/** Byte offset of definitionUnlockMask within native item-instance object. */
+constexpr std::size_t kDefinitionUnlockMaskOffset = 168;
+/** Byte offset of expressionUnlockMask within native item-instance object. */
+constexpr std::size_t kExpressionUnlockMaskOffset = 176;
+/** Sentinel plug index indicating an empty/unpopulated socket lane. */
+constexpr std::uint16_t kEmptyPlugIndex = 0xFFFF;
+
+/**
+ * Detoured mask rebuild: calls original, then enforces suppression of definition default plugs
+ * for all dynamic lanes that carry an instance ordinary socket plug.
+ */
+__int64 __fastcall detour_masks_rebuild(void* itemDef,
+                                        void* itemObject,
+                                        void* socketBlock,
+                                        void* invContext,
+                                        void* profileContext) noexcept {
+    const MasksRebuildFn original = g_original.load(std::memory_order_acquire);
+    if (original == nullptr) {
+        return 0;
+    }
+
+    const __int64 result = original(itemDef, itemObject, socketBlock, invContext, profileContext);
+
+    if (itemObject != nullptr) {
+        auto* const bytes = static_cast<std::byte*>(itemObject);
+        auto* const defMask = reinterpret_cast<std::uint32_t*>(bytes + kDefinitionUnlockMaskOffset);
+        auto* const exprMask =
+            reinterpret_cast<std::uint32_t*>(bytes + kExpressionUnlockMaskOffset);
+
+        // Lane 0 is the intrinsic weapon frame / archetype. Lanes 1..11 are dynamic perk,
+        // magazine, sight, mod, or cosmetic sockets.
+        for (std::size_t lane = 1; lane < kMaxOrdinarySockets; ++lane) {
+            const auto plug = *reinterpret_cast<const std::uint16_t*>(
+                bytes + kOrdinarySocketsOffset + (lane * kOrdinarySocketStride));
+            if (plug != kEmptyPlugIndex) {
+                *defMask &= ~(1U << lane);
+                *exprMask |= (1U << lane);
+            }
+        }
+    }
+
+    return result;
+}
+
+} // namespace
+
+bool install_socket_masks_hook() noexcept {
+    if (g_handle.attached) {
+        return true;
+    }
+
+    std::byte* const target =
+        scan_main_image_unique(kMasksRebuildSignature, "item_ordinary_socket_masks_rebuild");
+    if (target == nullptr) {
+        core::log::write(core::log::Channel::client,
+                         core::log::Level::warn,
+                         "ev=hook stage=install group=sockets name=masks_rebuild result=fail "
+                         "reason=target");
+        return false;
+    }
+
+    const hooking::detour::Spec spec{target, reinterpret_cast<void*>(&detour_masks_rebuild)};
+    if (!hooking::detour::install(spec, g_handle)) {
+        core::log::write(core::log::Channel::client,
+                         core::log::Level::warn,
+                         "ev=hook stage=install group=sockets name=masks_rebuild result=fail "
+                         "reason=attach");
+        return false;
+    }
+
+    g_original.store(reinterpret_cast<MasksRebuildFn>(g_handle.original),
+                     std::memory_order_release);
+    core::log::write(core::log::Channel::client,
+                     core::log::Level::info,
+                     "ev=hook stage=install group=sockets name=masks_rebuild result=ok");
+    return true;
+}
+
+void uninstall_socket_masks_hook() noexcept {
+    if (g_handle.attached) {
+        (void)hooking::detour::uninstall(g_handle);
+    }
+    g_original.store(nullptr, std::memory_order_release);
+}
+
+} // namespace sunrise::client::hooks::sockets

--- a/Sunrise/src/client/hooks/sockets/socket_masks_hook.h
+++ b/Sunrise/src/client/hooks/sockets/socket_masks_hook.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace sunrise::client::hooks::sockets {
+
+/**
+ * Installs the detour on the native item ordinary-socket mask rebuild function.
+ * @return True when the hook is installed or already attached.
+ */
+[[nodiscard]] bool install_socket_masks_hook() noexcept;
+
+/** Detaches the mask rebuild hook and drops its trampoline. */
+void uninstall_socket_masks_hook() noexcept;
+
+} // namespace sunrise::client::hooks::sockets

--- a/Sunrise/src/client/hooks/sockets/sockets_lifecycle.cpp
+++ b/Sunrise/src/client/hooks/sockets/sockets_lifecycle.cpp
@@ -1,0 +1,29 @@
+#include "sockets_lifecycle.h"
+
+#include <atomic>
+
+#include "socket_masks_hook.h"
+
+namespace sunrise::client::hooks::sockets {
+namespace {
+
+std::atomic_bool g_installed{false};
+
+} // namespace
+
+bool install() noexcept {
+    const bool masksHook = install_socket_masks_hook();
+    g_installed.store(masksHook, std::memory_order_release);
+    return masksHook;
+}
+
+void uninstall() noexcept {
+    uninstall_socket_masks_hook();
+    g_installed.store(false, std::memory_order_release);
+}
+
+bool is_installed() noexcept {
+    return g_installed.load(std::memory_order_acquire);
+}
+
+} // namespace sunrise::client::hooks::sockets

--- a/Sunrise/src/client/hooks/sockets/sockets_lifecycle.h
+++ b/Sunrise/src/client/hooks/sockets/sockets_lifecycle.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace sunrise::client::hooks::sockets {
+
+/** Attaches the socket hooks. */
+[[nodiscard]] bool install() noexcept;
+
+/** Detaches every socket hook. */
+void uninstall() noexcept;
+
+/** @return True while the socket hooks are attached. */
+[[nodiscard]] bool is_installed() noexcept;
+
+} // namespace sunrise::client::hooks::sockets

--- a/Sunrise/src/client/runtime/client_hook_activation.cpp
+++ b/Sunrise/src/client/runtime/client_hook_activation.cpp
@@ -27,6 +27,7 @@
 #include "../hooks/polled_input/runtime.h"
 #include "../hooks/queuez/queuez_hook_lifecycle.h"
 #include "../hooks/retail_log/retail_log_lifecycle.h"
+#include "../hooks/sockets/sockets_lifecycle.h"
 #include "../hooks/teleport/runtime.h"
 #include "../patterns/registry.h"
 #include "../targets/game.h"
@@ -181,6 +182,9 @@ void clear_game_targets() noexcept {
     // The bitmap reference guard puts the none sentinel in place of a reference outside tag
     // space. Without it the widget's stored-reference reader faults.
     (void)hooks::bitmap::install();
+    // Enforces definition plug suppression in ordinary socket mask rebuild so the hover preview
+    // tooltip displays the instance's rolled perks matching the inspect screen.
+    (void)hooks::sockets::install();
     // Read-only. It reports the status word the activity msg 12 handler writes, which is the one
     // thing that separates "the client never saw our membership body" from "it saw it and the
     // world container still did not bind".

--- a/Sunrise/src/client/runtime/client_runtime_lifecycle.cpp
+++ b/Sunrise/src/client/runtime/client_runtime_lifecycle.cpp
@@ -14,6 +14,7 @@
 #include "../hooks/polled_input/runtime.h"
 #include "../hooks/queuez/queuez_hook_lifecycle.h"
 #include "../hooks/retail_log/retail_log_lifecycle.h"
+#include "../hooks/sockets/sockets_lifecycle.h"
 #include "../hooks/teleport/runtime.h"
 #include "../inactivity/inactivity_settings_store.h"
 #include "../movement/movement_settings_store.h"
@@ -63,6 +64,7 @@ bool shutdown() noexcept {
         return false;
     }
     hooks::bitmap::uninstall();
+    hooks::sockets::uninstall();
     hooks::bootflow::uninstall();
     hooks::infinite_ammo::uninstall();
     hooks::inactivity::uninstall();

--- a/Sunrise/src/middleware/content/packages/tables/definition_index_table.h
+++ b/Sunrise/src/middleware/content/packages/tables/definition_index_table.h
@@ -202,8 +202,6 @@ inline constexpr std::size_t kSocketEntryPlugSource = 8;
 inline constexpr std::size_t kSocketEntryGroup = 12;
 /** Entry kind. Kind 34 is the super lane, which is active despite carrying no plug source. */
 inline constexpr std::size_t kSocketEntryKind = 13;
-/** Plug-set reference this socket entry rolls from, matched against a lane's randomized set. */
-inline constexpr std::size_t kSocketEntryPlugSetIndex = 56;
 /** The absent plug source. */
 inline constexpr std::uint32_t kNoPlugSource = 0x811C9DC5U;
 /** The bucket table declares its descriptor count here. */

--- a/Sunrise/src/middleware/content/packages/tables/definition_index_table.h
+++ b/Sunrise/src/middleware/content/packages/tables/definition_index_table.h
@@ -202,6 +202,8 @@ inline constexpr std::size_t kSocketEntryPlugSource = 8;
 inline constexpr std::size_t kSocketEntryGroup = 12;
 /** Entry kind. Kind 34 is the super lane, which is active despite carrying no plug source. */
 inline constexpr std::size_t kSocketEntryKind = 13;
+/** Plug-set reference this socket entry rolls from, matched against a lane's randomized set. */
+inline constexpr std::size_t kSocketEntryPlugSetIndex = 56;
 /** The absent plug source. */
 inline constexpr std::uint32_t kNoPlugSource = 0x811C9DC5U;
 /** The bucket table declares its descriptor count here. */

--- a/Sunrise/src/middleware/content/packages/tables/item_definition_reader.cpp
+++ b/Sunrise/src/middleware/content/packages/tables/item_definition_reader.cpp
@@ -365,7 +365,8 @@ bool visit_allowed_plugs(std::span<const std::byte> definition,
                          std::span<const std::byte> plugSetTable,
                          std::uint8_t lane,
                          AllowedPlugVisitor visitor,
-                         void* context) noexcept {
+                         void* context,
+                         bool includeRandomizedSet) noexcept {
     if (visitor == nullptr || lane >= kSocketCapacity) {
         return false;
     }
@@ -399,20 +400,98 @@ bool visit_allowed_plugs(std::span<const std::byte> definition,
                 || !visit_plug_array(definition, embedded, visitor, context)))) {
         return false;
     }
-    return visit_shared_plug_set(definition,
-                                 socketEntry,
-                                 kReusablePlugSetIndexOffset,
-                                 plugSetTable,
-                                 sets,
-                                 visitor,
-                                 context)
-           && visit_shared_plug_set(definition,
+    if (!visit_shared_plug_set(definition,
+                               socketEntry,
+                               kReusablePlugSetIndexOffset,
+                               plugSetTable,
+                               sets,
+                               visitor,
+                               context)) {
+        return false;
+    }
+    return !includeRandomizedSet
+           || visit_shared_plug_set(definition,
                                     socketEntry,
                                     kRandomizedPlugSetIndexOffset,
                                     plugSetTable,
                                     sets,
                                     visitor,
                                     context);
+}
+
+/**
+ * Visits exactly the randomized draw pool one ordinary socket lane declares.
+ *
+ * The Client resolves a randomized roll by `randomRoll[selectorByte] % count` against this one
+ * set (and never offers its members for insertion), so Sunrise authors the instance plug straight
+ * out of the native row order kept here.
+ * @return True when the lane's randomized set is structurally valid and fully visited.
+ */
+bool visit_roll_plugs(std::span<const std::byte> definition,
+                      std::span<const std::byte> plugSetTable,
+                      std::uint8_t lane,
+                      AllowedPlugVisitor visitor,
+                      void* context) noexcept {
+    if (visitor == nullptr || lane >= kSocketCapacity) {
+        return false;
+    }
+    std::int64_t socketBlockRelative = 0;
+    if (!read(definition, kSocketBlockOffset, socketBlockRelative) || socketBlockRelative == 0) {
+        return false;
+    }
+    const std::int64_t socketBlock =
+        static_cast<std::int64_t>(kSocketBlockOffset) + socketBlockRelative;
+    if (socketBlock < 0 || static_cast<std::uint64_t>(socketBlock) >= definition.size()) {
+        return false;
+    }
+    Array sockets{};
+    if (!find_array_at(definition, static_cast<std::size_t>(socketBlock), sockets)
+        || sockets.elementClass != kOrdinarySocketClass || lane >= sockets.count
+        || sockets.dataOffset > definition.size()
+        || sockets.count > (definition.size() - sockets.dataOffset) / kSocketEntryStride) {
+        return false;
+    }
+    Array sets{};
+    if (!find_array_at(plugSetTable, kTableArrayDescriptor, sets)) {
+        return false;
+    }
+    const std::size_t socketEntry =
+        sockets.dataOffset + static_cast<std::size_t>(lane) * kSocketEntryStride;
+    return visit_shared_plug_set(definition,
+                                 socketEntry,
+                                 kRandomizedPlugSetIndexOffset,
+                                 plugSetTable,
+                                 sets,
+                                 visitor,
+                                 context);
+}
+
+bool read_roll_set_index(std::span<const std::byte> definition,
+                         std::uint8_t lane,
+                         std::uint16_t& setIndex) noexcept {
+    setIndex = kUnavailablePlug;
+    if (lane >= kSocketCapacity) {
+        return false;
+    }
+    std::int64_t socketBlockRelative = 0;
+    if (!read(definition, kSocketBlockOffset, socketBlockRelative) || socketBlockRelative == 0) {
+        return false;
+    }
+    const std::int64_t socketBlock =
+        static_cast<std::int64_t>(kSocketBlockOffset) + socketBlockRelative;
+    if (socketBlock < 0 || static_cast<std::uint64_t>(socketBlock) >= definition.size()) {
+        return false;
+    }
+    Array sockets{};
+    if (!find_array_at(definition, static_cast<std::size_t>(socketBlock), sockets)
+        || sockets.elementClass != kOrdinarySocketClass || lane >= sockets.count
+        || sockets.dataOffset > definition.size()
+        || sockets.count > (definition.size() - sockets.dataOffset) / kSocketEntryStride) {
+        return false;
+    }
+    const std::size_t socketEntry =
+        sockets.dataOffset + static_cast<std::size_t>(lane) * kSocketEntryStride;
+    return read(definition, socketEntry + kRandomizedPlugSetIndexOffset, setIndex);
 }
 
 } // namespace sunrise::middleware::content::packages::tables::items

--- a/Sunrise/src/middleware/content/packages/tables/item_definition_reader.cpp
+++ b/Sunrise/src/middleware/content/packages/tables/item_definition_reader.cpp
@@ -466,32 +466,4 @@ bool visit_roll_plugs(std::span<const std::byte> definition,
                                  context);
 }
 
-bool read_roll_set_index(std::span<const std::byte> definition,
-                         std::uint8_t lane,
-                         std::uint16_t& setIndex) noexcept {
-    setIndex = kUnavailablePlug;
-    if (lane >= kSocketCapacity) {
-        return false;
-    }
-    std::int64_t socketBlockRelative = 0;
-    if (!read(definition, kSocketBlockOffset, socketBlockRelative) || socketBlockRelative == 0) {
-        return false;
-    }
-    const std::int64_t socketBlock =
-        static_cast<std::int64_t>(kSocketBlockOffset) + socketBlockRelative;
-    if (socketBlock < 0 || static_cast<std::uint64_t>(socketBlock) >= definition.size()) {
-        return false;
-    }
-    Array sockets{};
-    if (!find_array_at(definition, static_cast<std::size_t>(socketBlock), sockets)
-        || sockets.elementClass != kOrdinarySocketClass || lane >= sockets.count
-        || sockets.dataOffset > definition.size()
-        || sockets.count > (definition.size() - sockets.dataOffset) / kSocketEntryStride) {
-        return false;
-    }
-    const std::size_t socketEntry =
-        sockets.dataOffset + static_cast<std::size_t>(lane) * kSocketEntryStride;
-    return read(definition, socketEntry + kRandomizedPlugSetIndexOffset, setIndex);
-}
-
 } // namespace sunrise::middleware::content::packages::tables::items

--- a/Sunrise/src/middleware/content/packages/tables/items.h
+++ b/Sunrise/src/middleware/content/packages/tables/items.h
@@ -106,12 +106,41 @@ using AllowedPlugVisitor = bool (*)(void* context, std::uint32_t itemDefinitionI
  * @param lane Ordinary socket lane to inspect.
  * @param visitor Required bounded consumer.
  * @param context Opaque consumer state.
+ * @param includeRandomizedSet Whether the socket's randomized draw pool joins the walk. A socket
+ * offers its embedded and reusable plugs for insertion; the randomized set is what a roll is
+ * drawn from and is never offered, so a plug taken from it can be socketed but never selected
+ * again once something else replaces it.
  * @return True when every referenced array is structurally valid and accepted by the visitor.
  */
 [[nodiscard]] bool visit_allowed_plugs(std::span<const std::byte> definition,
                                        std::span<const std::byte> plugSetTable,
                                        std::uint8_t lane,
                                        AllowedPlugVisitor visitor,
-                                       void* context) noexcept;
+                                       void* context,
+                                       bool includeRandomizedSet = true) noexcept;
+
+/**
+ * Visits exactly the randomized draw pool one ordinary socket lane declares.
+ *
+ * Sunrise authors a random-rolled instance plug straight out of this set's native row order,
+ * matching `randomRoll[selectorByte] % count` against the same rows the Client resolves.
+ * @return True when the lane's randomized set is structurally valid and fully visited.
+ */
+[[nodiscard]] bool visit_roll_plugs(std::span<const std::byte> definition,
+                                    std::span<const std::byte> plugSetTable,
+                                    std::uint8_t lane,
+                                    AllowedPlugVisitor visitor,
+                                    void* context) noexcept;
+
+/**
+ * Reads the native randomized-set index one ordinary socket lane declares.
+ * This is the same set a socket entry with an equal plug-set reference rolls from, which is how
+ * a rolled lane is matched to the socket entry the hover preview resolves through.
+ * @param setIndex Receives the lane's randomized-set index, or kUnavailablePlug when absent.
+ * @return True when the lane shares the socket block and carries a randomized set.
+ */
+[[nodiscard]] bool read_roll_set_index(std::span<const std::byte> definition,
+                                       std::uint8_t lane,
+                                       std::uint16_t& setIndex) noexcept;
 
 } // namespace sunrise::middleware::content::packages::tables::items

--- a/Sunrise/src/middleware/content/packages/tables/items.h
+++ b/Sunrise/src/middleware/content/packages/tables/items.h
@@ -108,8 +108,8 @@ using AllowedPlugVisitor = bool (*)(void* context, std::uint32_t itemDefinitionI
  * @param context Opaque consumer state.
  * @param includeRandomizedSet Whether the socket's randomized draw pool joins the walk. A socket
  * offers its embedded and reusable plugs for insertion; the randomized set is what a roll is
- * drawn from and is never offered, so a plug taken from it can be socketed but never selected
- * again once something else replaces it.
+ * drawn from and is not part of this curated relation. A rolled instance separately publishes its
+ * owned randomized rows, which is what keeps its selected plug reachable after a curated swap.
  * @return True when every referenced array is structurally valid and accepted by the visitor.
  */
 [[nodiscard]] bool visit_allowed_plugs(std::span<const std::byte> definition,
@@ -131,16 +131,5 @@ using AllowedPlugVisitor = bool (*)(void* context, std::uint32_t itemDefinitionI
                                     std::uint8_t lane,
                                     AllowedPlugVisitor visitor,
                                     void* context) noexcept;
-
-/**
- * Reads the native randomized-set index one ordinary socket lane declares.
- * This is the same set a socket entry with an equal plug-set reference rolls from, which is how
- * a rolled lane is matched to the socket entry the hover preview resolves through.
- * @param setIndex Receives the lane's randomized-set index, or kUnavailablePlug when absent.
- * @return True when the lane shares the socket block and carries a randomized set.
- */
-[[nodiscard]] bool read_roll_set_index(std::span<const std::byte> definition,
-                                       std::uint8_t lane,
-                                       std::uint16_t& setIndex) noexcept;
 
 } // namespace sunrise::middleware::content::packages::tables::items

--- a/Sunrise/src/middleware/datagen/family4/instance/instance_encoder.cpp
+++ b/Sunrise/src/middleware/datagen/family4/instance/instance_encoder.cpp
@@ -68,10 +68,8 @@ namespace {
 
     for (std::size_t index = 0; index < input.socketEntryStates.size(); ++index) {
         const SocketEntryState state = input.socketEntryStates[index];
-        // Absent (0), the subclass sentinels (16/17/18) and any nonzero 1-based roll row (1..63)
-        // are all legal. The Client resolves a roll row directly, so these keep index within the
-        // entry count to stay safe.
-        if (static_cast<std::uint8_t>(state) > 63) {
+        if (state != SocketEntryState::absent && state != SocketEntryState::ready
+            && state != SocketEntryState::acquired && state != SocketEntryState::active) {
             return false;
         }
         if (index >= input.socketEntryCount && state != SocketEntryState::absent) {

--- a/Sunrise/src/middleware/datagen/family4/instance/instance_encoder.cpp
+++ b/Sunrise/src/middleware/datagen/family4/instance/instance_encoder.cpp
@@ -1,8 +1,11 @@
 #include "instance_encoder.h"
 
 #include <algorithm>
+#include <array>
+#include <cstdio>
 #include <cstring>
 
+#include "../../../../core/logging/log.h"
 #include "abi.h"
 #include "layout.h"
 
@@ -65,8 +68,10 @@ namespace {
 
     for (std::size_t index = 0; index < input.socketEntryStates.size(); ++index) {
         const SocketEntryState state = input.socketEntryStates[index];
-        if (state != SocketEntryState::absent && state != SocketEntryState::ready
-            && state != SocketEntryState::acquired && state != SocketEntryState::active) {
+        // Absent (0), the subclass sentinels (16/17/18) and any nonzero 1-based roll row (1..63)
+        // are all legal. The Client resolves a roll row directly, so these keep index within the
+        // entry count to stay safe.
+        if (static_cast<std::uint8_t>(state) > 63) {
             return false;
         }
         if (index >= input.socketEntryCount && state != SocketEntryState::absent) {
@@ -140,19 +145,40 @@ bool encode(const ResolvedInstance& input, std::span<std::byte> output) noexcept
     object.ordinarySockets.gateMask = layout::kAllSocketBits;
     object.roll.progress = layout::kInitialInstanceProgress;
     object.roll.socketEntryListIndex = input.socketEntryListIndex;
+    object.roll.randomRoll = input.randomRoll;
 
     if (input.ordinarySockets.state == OrdinarySocketBlockState::present) {
-        // Both permit masks are filled. The plug walk reads the definition's declared plugs as
-        // well as this instance's lanes, and skips whichever source its mask leaves unset.
+        // Both permit masks govern whether the UI socket walk reads the definition's declared plugs
+        // or this instance's dynamic ordinary sockets.
+        // Under filter 1 (sub_7FF7B6E06D10), bit test on expressionUnlockMask rejects kind 1 when
+        // set. Under filter 2 (sub_7FF7B6E06BD0), bit test on definitionUnlockMask passes kind 1
+        // when set. Lane 0 (intrinsic/embedded) keeps expressionUnlockMask cleared and
+        // definitionUnlockMask set, so the intrinsic is emitted in pass 1 and skipped in pass 2
+        // (embeddedCount > 0). Dynamic perk lanes (index > 0) clear definitionUnlockMask and set
+        // expressionUnlockMask, suppressing definition default plugs in pass 1 so pass 2 yields the
+        // rolled instance plugs.
         object.ordinarySockets.activeMask = layout::kAllSocketBits;
         object.ordinarySockets.definitionUnlockMask = layout::kAllSocketBits;
+        object.ordinarySockets.expressionUnlockMask = 0;
         for (std::size_t index = 0; index < input.ordinarySockets.plugs.size(); ++index) {
             const std::optional<std::uint16_t>& plug = input.ordinarySockets.plugs[index];
             if (plug.has_value()) {
                 object.ordinarySockets.sockets[index].plugDefinitionIndex = *plug;
+                if (index > 0) {
+                    object.ordinarySockets.definitionUnlockMask &= ~(1U << index);
+                    object.ordinarySockets.expressionUnlockMask |= (1U << index);
+                }
             }
+            // The two lanes the native record calls auxiliary hashes are one 64-bit mask of the
+            // randomized plug-set rows this instance owns, low half first.
+            const std::uint64_t rows = input.ordinarySockets.availablePlugRows[index];
+            object.ordinarySockets.sockets[index].auxiliaryHashes[0] =
+                static_cast<std::uint32_t>(rows & 0xFFFFFFFFULL);
+            object.ordinarySockets.sockets[index].auxiliaryHashes[1] =
+                static_cast<std::uint32_t>(rows >> 32U);
         }
     }
+
     std::transform(input.socketEntryStates.begin(),
                    input.socketEntryStates.end(),
                    object.roll.socketEntryStates.begin(),
@@ -170,6 +196,21 @@ bool encode(const ResolvedInstance& input, std::span<std::byte> output) noexcept
     // Commit only after validation so a rejected mapping leaves caller-owned storage unchanged.
     std::fill(output.begin(), output.end(), std::byte{});
     std::memcpy(output.data(), &object, sizeof object);
+
+    std::array<char, core::log::kLineCapacity> line{};
+    const int count = std::snprintf(line.data(),
+                                    line.size(),
+                                    "ev=encode_instance soid=0x%llX base_def=%u def_mask=0x%08X "
+                                    "expr_mask=0x%08X",
+                                    static_cast<unsigned long long>(input.instanceSoid),
+                                    input.baseDefinitionIndex,
+                                    object.ordinarySockets.definitionUnlockMask,
+                                    object.ordinarySockets.expressionUnlockMask);
+    if (count > 0) {
+        core::log::write(core::log::Channel::server,
+                         core::log::Level::debug,
+                         {line.data(), static_cast<std::size_t>(count)});
+    }
     return true;
 }
 

--- a/Sunrise/src/middleware/datagen/family4/instance/instance_encoder.h
+++ b/Sunrise/src/middleware/datagen/family4/instance/instance_encoder.h
@@ -43,6 +43,12 @@ enum class OrdinarySocketBlockState : std::uint8_t {
 struct OrdinarySockets {
     OrdinarySocketBlockState state{OrdinarySocketBlockState::unresolved};
     std::array<std::optional<std::uint16_t>, layout::kOrdinarySocketCapacity> plugs{};
+    /**
+     * Per-lane mask of the rows of that socket's randomized plug set this instance owns, one bit
+     * per row. The Client walks the set bits before it falls back to the definition's own plugs,
+     * so a lane that leaves this zero can only ever offer the definition's curated choices.
+     */
+    std::array<std::uint64_t, layout::kOrdinarySocketCapacity> availablePlugRows{};
 };
 
 /** Runtime table bounds required to prove every supplied native index is valid. */
@@ -65,6 +71,11 @@ struct ResolvedInstance {
     std::uint8_t socketEntryCount{};
     bool socketEntryContentsResolved{};
     OrdinarySockets ordinarySockets{};
+    /**
+     * Per-instance entropy the Client reduces to pick a plug for each randomized socket. Left
+     * all-zero, every randomized socket resolves to its plug set's first row.
+     */
+    std::array<std::uint8_t, layout::kRandomRollByteCount> randomRoll{};
     std::array<SocketEntryState, layout::kSocketEntryStateCapacity> socketEntryStates{};
     /** Selector lane per semantic ability bucket, empty for an item with no selection. */
     std::array<SocketSelector, layout::kSelectorCapacity> socketSelectors{};

--- a/Sunrise/src/middleware/datagen/family4/loadout/loadout_item_resolver.cpp
+++ b/Sunrise/src/middleware/datagen/family4/loadout/loadout_item_resolver.cpp
@@ -185,24 +185,6 @@ bool resolve_item(const authored_inventory::Item& authored,
                           character.acquiredSubclassAbilityMask,
                           candidate.item.instance.socketEntryStates,
                           candidate.item.instance.socketSelectors);
-    // Fold a rolled weapon's per-lane roll rows onto the socket entries that back them. The hover
-    // preview reads these states directly (a nonzero N is the 1-based roll row of the entry's
-    // plug set), so this pins the exact rolled perk the inspection grid already reads. Lanes with
-    // no matching entry keep their absent state -- the safe no-op.
-    for (std::size_t lane = 0; lane < authored.rollRowByLane.size(); ++lane) {
-        const std::uint8_t row = authored.rollRowByLane[lane];
-        if (row == 0) {
-            continue;
-        }
-        const std::uint8_t entry = state::build_data::socket_entry_index(
-            itemDefinition.definitionIndex, static_cast<std::uint8_t>(lane));
-        if (entry == state::build_data::items::socket_plugs::kNoSocketEntry
-            || entry >= candidate.item.instance.socketEntryStates.size()) {
-            continue;
-        }
-        candidate.item.instance.socketEntryStates[entry] =
-            static_cast<instance::SocketEntryState>(row);
-    }
     output = candidate;
     return true;
 }

--- a/Sunrise/src/middleware/datagen/family4/loadout/loadout_item_resolver.cpp
+++ b/Sunrise/src/middleware/datagen/family4/loadout/loadout_item_resolver.cpp
@@ -172,6 +172,10 @@ bool resolve_item(const authored_inventory::Item& authored,
     candidate.item.instance.level = authored.level;
     candidate.item.instance.curveSelector = instance::layout::kInitialLevelCurveX;
     candidate.item.instance.capSelector = instance::layout::kInitialLevelCapRow;
+    candidate.item.instance.randomRoll = authored.randomRoll;
+    // The owned-row masks are instance state, not definition data; carry them so the encoded
+    // record tells the Client which randomized-set rows this instance owns.
+    candidate.item.instance.ordinarySockets.availablePlugRows = authored.availablePlugRows;
     candidate.item.instance.socketEntryListIndex = socketList.definitionIndex;
     candidate.item.instance.socketEntryCount = socketList.entryCount;
     candidate.item.instance.socketEntryContentsResolved = true;
@@ -181,6 +185,24 @@ bool resolve_item(const authored_inventory::Item& authored,
                           character.acquiredSubclassAbilityMask,
                           candidate.item.instance.socketEntryStates,
                           candidate.item.instance.socketSelectors);
+    // Fold a rolled weapon's per-lane roll rows onto the socket entries that back them. The hover
+    // preview reads these states directly (a nonzero N is the 1-based roll row of the entry's
+    // plug set), so this pins the exact rolled perk the inspection grid already reads. Lanes with
+    // no matching entry keep their absent state -- the safe no-op.
+    for (std::size_t lane = 0; lane < authored.rollRowByLane.size(); ++lane) {
+        const std::uint8_t row = authored.rollRowByLane[lane];
+        if (row == 0) {
+            continue;
+        }
+        const std::uint8_t entry = state::build_data::socket_entry_index(
+            itemDefinition.definitionIndex, static_cast<std::uint8_t>(lane));
+        if (entry == state::build_data::items::socket_plugs::kNoSocketEntry
+            || entry >= candidate.item.instance.socketEntryStates.size()) {
+            continue;
+        }
+        candidate.item.instance.socketEntryStates[entry] =
+            static_cast<instance::SocketEntryState>(row);
+    }
     output = candidate;
     return true;
 }

--- a/Sunrise/src/state/account/inventory/inventory_state.h
+++ b/Sunrise/src/state/account/inventory/inventory_state.h
@@ -33,6 +33,8 @@ enum class EquipmentSlot : std::uint8_t {
 inline constexpr std::size_t kEquipmentSlotCount = static_cast<std::size_t>(EquipmentSlot::count);
 /** An authored item can pick at most 12 ordinary socket lanes. */
 inline constexpr std::size_t kPlugCapacity = 12;
+/** An item instance carries 8 native random-roll bytes. */
+inline constexpr std::size_t kRandomRollCapacity = 8;
 /** The engine no-definition hash cannot identify an authored item or plug. */
 inline constexpr std::uint32_t kNoDefinitionHash = 0x811C9DC5U;
 
@@ -92,6 +94,36 @@ struct Item {
     /** Native accumulated item-state bits such as the finisher favorite marker. */
     std::uint32_t flags{};
     Sockets sockets;
+    /**
+     * Per-instance entropy the Client reduces to pick a plug for every socket whose plug set is
+     * randomized: it takes one of these bytes, chosen by the socket entry's own selector byte,
+     * modulo the plug set's row count. All-zero therefore pins every randomized socket to its
+     * first plug, which is what a curated Collections pull wants.
+     */
+    std::array<std::uint8_t, kRandomRollCapacity> randomRoll{};
+    /**
+     * Bit per ordinary socket lane this instance had rolled rather than authored from its
+     * definition. A rolled plug is drawn from the socket's randomized set, which the definition's
+     * allowed pool never carries, so the socket route offers a rolled lane the rows named by
+     * availablePlugRows on top of that pool. That is what lets a rolled lane be swapped to a
+     * curated choice and back to the rolled plug, matching what the inspection grid offers.
+     */
+    std::uint16_t rolledLaneMask{};
+    /**
+     * Per-lane bitmask of the rows of that socket's randomized plug set this instance owns, one
+     * bit per row in the lane's published pool order. A rolled lane sets the single bit naming
+     * the pool row it carries; a lane left zero only ever shows its definition's curated choice.
+     * The Client walks these bits before it falls back to the definition's own plugs, so this is
+     * what keeps the hover preview on the same perk the inspection screen reads.
+     */
+    std::array<std::uint64_t, kPlugCapacity> availablePlugRows{};
+    /**
+     * Per-lane 1-based randomized-set row this instance pinned onto the socket entry that backs
+     * the lane (matched by roll-pool reference). Zero means the lane did not pin a state. Keeping
+     * the row on the item lets the loadout fold it into the instance's socket-entry states, which
+     * is what makes the hover preview resolve the exact rolled perk the inspection screen shows.
+     */
+    std::array<std::uint8_t, kPlugCapacity> rollRowByLane{};
     /**
      * Selected ability-node socket entries. Only meaningful on a subclass. Kept on the item, not
      * the character, so each owned subclass remembers its own picks. Defaults match

--- a/Sunrise/src/state/account/inventory/inventory_state.h
+++ b/Sunrise/src/state/account/inventory/inventory_state.h
@@ -118,13 +118,6 @@ struct Item {
      */
     std::array<std::uint64_t, kPlugCapacity> availablePlugRows{};
     /**
-     * Per-lane 1-based randomized-set row this instance pinned onto the socket entry that backs
-     * the lane (matched by roll-pool reference). Zero means the lane did not pin a state. Keeping
-     * the row on the item lets the loadout fold it into the instance's socket-entry states, which
-     * is what makes the hover preview resolve the exact rolled perk the inspection screen shows.
-     */
-    std::array<std::uint8_t, kPlugCapacity> rollRowByLane{};
-    /**
      * Selected ability-node socket entries. Only meaningful on a subclass. Kept on the item, not
      * the character, so each owned subclass remembers its own picks. Defaults match
      * state::kDefault*AbilityEntry, literal here to avoid a circular include.

--- a/Sunrise/src/state/build_data/build_data_runtime.cpp
+++ b/Sunrise/src/state/build_data/build_data_runtime.cpp
@@ -104,8 +104,11 @@ bool initialize(void* module, std::uint64_t configuredEquipmentHash) noexcept {
         // The per-entry tables are what the subclass selection reads. Without them a cache hit
         // makes the lists ready, the package build skips itself, and no ability is picked.
         || !socket_entry_lists::replace_entry_tables(domains.socketEntryTables) || !detailsReplaced
-        || !items::socket_plugs::replace(
-            domains.socketPlugRules, domains.socketPlugPools, domains.socketPlugMembers)
+        || !items::socket_plugs::replace(domains.socketPlugRules,
+                                         domains.socketPlugPools,
+                                         domains.socketPlugMembers,
+                                         domains.socketPlugRollPools,
+                                         domains.socketPlugRollMembers)
         || !abilities::replace(domains.abilityBuckets)
         || !progressions::replace(domains.progressions)
         // The layouts are what activity message 1 reads. Without them a cache hit makes the

--- a/Sunrise/src/state/build_data/cache/read/cache_file_reader.cpp
+++ b/Sunrise/src/state/build_data/cache/read/cache_file_reader.cpp
@@ -27,6 +27,8 @@ namespace {
            && counts.socketPlugRules <= output.socketPlugRules.size()
            && counts.socketPlugPools <= output.socketPlugPools.size()
            && counts.socketPlugMembers <= output.socketPlugMembers.size()
+           && counts.socketPlugRollPools <= output.socketPlugRollPools.size()
+           && counts.socketPlugRollMembers <= output.socketPlugRollMembers.size()
            && counts.inventoryBuckets <= output.inventoryBuckets.size()
            && counts.socketEntryLists <= output.socketEntryLists.size()
            && counts.socketEntryTables <= output.socketEntryTables.size()
@@ -55,6 +57,8 @@ namespace {
         header.socketPlugRuleCount,
         header.socketPlugPoolCount,
         header.socketPlugMemberCount,
+        header.socketPlugRollPoolCount,
+        header.socketPlugRollMemberCount,
         header.inventoryBucketCount,
         header.socketEntryListCount,
         header.socketEntryTableCount,

--- a/Sunrise/src/state/build_data/cache/read/cache_payload_reader.cpp
+++ b/Sunrise/src/state/build_data/cache/read/cache_payload_reader.cpp
@@ -74,6 +74,12 @@ void clear(records::MutableDomains output) noexcept {
     std::fill(output.socketPlugMembers.begin(),
               output.socketPlugMembers.end(),
               items::socket_plugs::Member{});
+    std::fill(output.socketPlugRollPools.begin(),
+              output.socketPlugRollPools.end(),
+              items::socket_plugs::Pool{});
+    std::fill(output.socketPlugRollMembers.begin(),
+              output.socketPlugRollMembers.end(),
+              items::socket_plugs::Member{});
     std::fill(output.inventoryBuckets.begin(),
               output.inventoryBuckets.end(),
               inventory::buckets::Descriptor{});
@@ -112,6 +118,10 @@ bool expected_size(const records::DomainCounts& counts, std::uint64_t& size) noe
            && add_records(counts.socketPlugRules, sizeof(records::SocketPlugRuleRecord), size)
            && add_records(counts.socketPlugPools, sizeof(records::SocketPlugPoolRecord), size)
            && add_records(counts.socketPlugMembers, sizeof(records::SocketPlugMemberRecord), size)
+           && add_records(
+               counts.socketPlugRollPools, sizeof(records::SocketPlugRollPoolRecord), size)
+           && add_records(
+               counts.socketPlugRollMembers, sizeof(records::SocketPlugRollMemberRecord), size)
            && add_records(counts.inventoryBuckets, sizeof(records::InventoryBucketRecord), size)
            && add_records(counts.socketEntryLists, sizeof(records::SocketEntryListRecord), size)
            && add_records(counts.socketEntryTables, sizeof(records::SocketEntryTableRecord), size)
@@ -160,6 +170,12 @@ bool read_payload(HANDLE file,
     valid = valid
             && read_domain<records::SocketPlugMemberRecord>(
                 file, output.socketPlugMembers.first(counts.socketPlugMembers), checksum);
+    valid = valid
+            && read_domain<records::SocketPlugRollPoolRecord>(
+                file, output.socketPlugRollPools.first(counts.socketPlugRollPools), checksum);
+    valid = valid
+            && read_domain<records::SocketPlugRollMemberRecord>(
+                file, output.socketPlugRollMembers.first(counts.socketPlugRollMembers), checksum);
     valid = valid
             && read_domain<records::InventoryBucketRecord>(
                 file, output.inventoryBuckets.first(counts.inventoryBuckets), checksum);
@@ -218,6 +234,8 @@ bool read_payload(HANDLE file,
         output.socketPlugRules.first(counts.socketPlugRules),
         output.socketPlugPools.first(counts.socketPlugPools),
         output.socketPlugMembers.first(counts.socketPlugMembers),
+        output.socketPlugRollPools.first(counts.socketPlugRollPools),
+        output.socketPlugRollMembers.first(counts.socketPlugRollMembers),
         output.inventoryBuckets.first(counts.inventoryBuckets),
         output.socketEntryLists.first(counts.socketEntryLists),
         output.socketEntryTables.first(counts.socketEntryTables),

--- a/Sunrise/src/state/build_data/cache/records/cache_detail_links.cpp
+++ b/Sunrise/src/state/build_data/cache/records/cache_detail_links.cpp
@@ -82,10 +82,12 @@ bool valid_item_detail_links(
 bool valid_socket_plug_links(std::span<const items::socket_plugs::Rule> rules,
                              std::span<const items::socket_plugs::Pool> pools,
                              std::span<const items::socket_plugs::Member> members,
+                             std::span<const items::socket_plugs::Pool> rollPools,
+                             std::span<const items::socket_plugs::Member> rollMembers,
                              std::span<const items::Definition> itemDefinitions,
                              std::span<const items::details::Definition> details) noexcept {
     if (itemDefinitions.empty() || details.empty()
-        || !items::socket_plugs::valid(rules, pools, members)) {
+        || !items::socket_plugs::valid(rules, pools, members, rollPools, rollMembers)) {
         return false;
     }
     for (const items::socket_plugs::Rule& rule : rules) {
@@ -104,9 +106,14 @@ bool valid_socket_plug_links(std::span<const items::socket_plugs::Rule> rules,
             return false;
         }
     }
-    return std::all_of(members.begin(), members.end(), [&itemDefinitions](const auto member) {
-        return member < itemDefinitions.size();
-    });
+    return std::all_of(
+               members.begin(),
+               members.end(),
+               [&itemDefinitions](const auto member) { return member < itemDefinitions.size(); })
+           && std::all_of(
+               rollMembers.begin(), rollMembers.end(), [&itemDefinitions](const auto member) {
+                   return member < itemDefinitions.size();
+               });
 }
 
 } // namespace sunrise::state::build_data::cache::records

--- a/Sunrise/src/state/build_data/cache/records/cache_domain_validation.cpp
+++ b/Sunrise/src/state/build_data/cache/records/cache_domain_validation.cpp
@@ -140,6 +140,8 @@ template <typename Value, typename Less>
            && counts.socketPlugRules <= domains.socketPlugRules.size()
            && counts.socketPlugPools <= domains.socketPlugPools.size()
            && counts.socketPlugMembers <= domains.socketPlugMembers.size()
+           && counts.socketPlugRollPools <= domains.socketPlugRollPools.size()
+           && counts.socketPlugRollMembers <= domains.socketPlugRollMembers.size()
            && counts.inventoryBuckets <= domains.inventoryBuckets.size()
            && counts.socketEntryLists <= domains.socketEntryLists.size()
            && counts.socketEntryTables <= domains.socketEntryTables.size()
@@ -212,8 +214,11 @@ bool valid_domains(Domains domains) noexcept {
         || !socket_entry_lists::valid(domains.socketEntryLists)
         || !socket_entry_lists::valid_entry_tables(domains.socketEntryTables)
         || !strictly_ordered(domains.itemDetails, detail_less)
-        || !items::socket_plugs::valid(
-            domains.socketPlugRules, domains.socketPlugPools, domains.socketPlugMembers)
+        || !items::socket_plugs::valid(domains.socketPlugRules,
+                                       domains.socketPlugPools,
+                                       domains.socketPlugMembers,
+                                       domains.socketPlugRollPools,
+                                       domains.socketPlugRollMembers)
         || !abilities::valid(domains.abilityBuckets)
         || !strictly_ordered(domains.abilityBuckets, ability_less)
         || !progressions::valid(domains.progressions)
@@ -263,6 +268,8 @@ bool valid_domains(Domains domains) noexcept {
            && valid_socket_plug_links(domains.socketPlugRules,
                                       domains.socketPlugPools,
                                       domains.socketPlugMembers,
+                                      domains.socketPlugRollPools,
+                                      domains.socketPlugRollMembers,
                                       domains.items,
                                       domains.itemDetails);
 }

--- a/Sunrise/src/state/build_data/cache/records/cache_record_codec.cpp
+++ b/Sunrise/src/state/build_data/cache/records/cache_record_codec.cpp
@@ -65,12 +65,18 @@ bool encode(const items::Definition& value, ItemRecord& record) noexcept {
         value.plugCategoryHash,
         value.rollSetIndex,
         value.linkedPlugIndex,
+        value.actionStatValue,
+        value.actionStatRow,
+        0,
     };
     return true;
 }
 
-/** Decodes one installed-build item mapping. */
+/** Decodes one installed-build item mapping after checking its reserved byte. */
 bool decode(const ItemRecord& record, items::Definition& value) noexcept {
+    if (record.reserved != kReservedFieldValue) {
+        return false;
+    }
     value = {record.definitionHash,
              record.definitionIndex,
              record.bucketId,
@@ -79,7 +85,9 @@ bool decode(const ItemRecord& record, items::Definition& value) noexcept {
              record.tier,
              record.plugCategoryHash,
              record.rollSetIndex,
-             record.linkedPlugIndex};
+             record.linkedPlugIndex,
+             record.actionStatValue,
+             record.actionStatRow};
     return true;
 }
 

--- a/Sunrise/src/state/build_data/cache/records/cache_socket_plug_record_codec.cpp
+++ b/Sunrise/src/state/build_data/cache/records/cache_socket_plug_record_codec.cpp
@@ -2,23 +2,27 @@
 
 namespace sunrise::state::build_data::cache::records {
 
-/** Encodes one exact item/lane rule. The old padding byte now carries the socket-entry index. */
+/** Encodes one exact item/lane rule only when its canonical padding is zero. */
 bool encode(const items::socket_plugs::Rule& value, SocketPlugRuleRecord& record) noexcept {
     record = {};
+    if (value.reserved != 0) {
+        return false;
+    }
     record.itemDefinitionIndex = value.itemDefinitionIndex;
     record.lane = value.lane;
-    record.socketEntryIndex = value.socketEntryIndex;
     record.poolIndex = value.poolIndex;
     record.rollPoolIndex = value.rollPoolIndex;
     return true;
 }
 
-/** Decodes one exact item/lane rule. Every byte is meaningful, so there is nothing to check. */
+/** Decodes one exact item/lane rule after checking its reserved byte. */
 bool decode(const SocketPlugRuleRecord& record, items::socket_plugs::Rule& value) noexcept {
     value = {};
+    if (record.reserved != 0) {
+        return false;
+    }
     value.itemDefinitionIndex = record.itemDefinitionIndex;
     value.lane = record.lane;
-    value.socketEntryIndex = record.socketEntryIndex;
     value.poolIndex = record.poolIndex;
     value.rollPoolIndex = record.rollPoolIndex;
     return true;

--- a/Sunrise/src/state/build_data/cache/records/cache_socket_plug_record_codec.cpp
+++ b/Sunrise/src/state/build_data/cache/records/cache_socket_plug_record_codec.cpp
@@ -2,27 +2,25 @@
 
 namespace sunrise::state::build_data::cache::records {
 
-/** Encodes one exact item/lane rule only when its canonical padding is zero. */
+/** Encodes one exact item/lane rule. The old padding byte now carries the socket-entry index. */
 bool encode(const items::socket_plugs::Rule& value, SocketPlugRuleRecord& record) noexcept {
     record = {};
-    if (value.reserved != 0) {
-        return false;
-    }
     record.itemDefinitionIndex = value.itemDefinitionIndex;
     record.lane = value.lane;
+    record.socketEntryIndex = value.socketEntryIndex;
     record.poolIndex = value.poolIndex;
+    record.rollPoolIndex = value.rollPoolIndex;
     return true;
 }
 
-/** Decodes one exact item/lane rule after checking its reserved byte. */
+/** Decodes one exact item/lane rule. Every byte is meaningful, so there is nothing to check. */
 bool decode(const SocketPlugRuleRecord& record, items::socket_plugs::Rule& value) noexcept {
     value = {};
-    if (record.reserved != 0) {
-        return false;
-    }
     value.itemDefinitionIndex = record.itemDefinitionIndex;
     value.lane = record.lane;
+    value.socketEntryIndex = record.socketEntryIndex;
     value.poolIndex = record.poolIndex;
+    value.rollPoolIndex = record.rollPoolIndex;
     return true;
 }
 
@@ -46,6 +44,26 @@ bool encode(items::socket_plugs::Member value, SocketPlugMemberRecord& record) n
 
 /** Decodes one native plug-definition index. */
 bool decode(const SocketPlugMemberRecord& record, items::socket_plugs::Member& value) noexcept {
+    value = record.itemDefinitionIndex;
+    return true;
+}
+
+bool encode(items::socket_plugs::Pool value, SocketPlugRollPoolRecord& record) noexcept {
+    record = {value.memberOffset, value.memberCount};
+    return true;
+}
+
+bool decode(const SocketPlugRollPoolRecord& record, items::socket_plugs::Pool& value) noexcept {
+    value = {record.memberOffset, record.memberCount};
+    return true;
+}
+
+bool encode(items::socket_plugs::Member value, SocketPlugRollMemberRecord& record) noexcept {
+    record = {value};
+    return true;
+}
+
+bool decode(const SocketPlugRollMemberRecord& record, items::socket_plugs::Member& value) noexcept {
     value = record.itemDefinitionIndex;
     return true;
 }

--- a/Sunrise/src/state/build_data/cache/records/codec.h
+++ b/Sunrise/src/state/build_data/cache/records/codec.h
@@ -138,6 +138,36 @@ namespace sunrise::state::build_data::cache::records {
                           items::socket_plugs::Member& value) noexcept;
 
 /**
+ * Native-order randomized roll-set range codec.
+ * @param value Runtime row to pack. @param record Receives the packed disk row. @return Always
+ * true.
+ */
+[[nodiscard]] bool encode(items::socket_plugs::Pool value,
+                          SocketPlugRollPoolRecord& record) noexcept;
+
+/**
+ * Native-order randomized roll-set range codec. Cross-row contiguity is checked at the domain.
+ * @param record Packed disk row. @param value Receives the runtime row. @return Always true.
+ */
+[[nodiscard]] bool decode(const SocketPlugRollPoolRecord& record,
+                          items::socket_plugs::Pool& value) noexcept;
+
+/**
+ * Flat native-order roll-member codec.
+ * @param value Runtime row to pack. @param record Receives the packed disk row. @return Always
+ * true.
+ */
+[[nodiscard]] bool encode(items::socket_plugs::Member value,
+                          SocketPlugRollMemberRecord& record) noexcept;
+
+/**
+ * Flat native-order roll-member codec.
+ * @param record Packed disk row. @param value Receives the runtime row. @return Always true.
+ */
+[[nodiscard]] bool decode(const SocketPlugRollMemberRecord& record,
+                          items::socket_plugs::Member& value) noexcept;
+
+/**
  * @param value Runtime row to pack.
  * @param record Receives the packed disk row.
  * @return Always true.

--- a/Sunrise/src/state/build_data/cache/records/domains.h
+++ b/Sunrise/src/state/build_data/cache/records/domains.h
@@ -31,6 +31,8 @@ struct DomainCounts {
     std::size_t socketPlugRules{};
     std::size_t socketPlugPools{};
     std::size_t socketPlugMembers{};
+    std::size_t socketPlugRollPools{};
+    std::size_t socketPlugRollMembers{};
     std::size_t inventoryBuckets{};
     std::size_t socketEntryLists{};
     std::size_t socketEntryTables{};
@@ -60,6 +62,8 @@ struct MutableDomains {
     std::span<items::socket_plugs::Rule> socketPlugRules;
     std::span<items::socket_plugs::Pool> socketPlugPools;
     std::span<items::socket_plugs::Member> socketPlugMembers;
+    std::span<items::socket_plugs::Pool> socketPlugRollPools;
+    std::span<items::socket_plugs::Member> socketPlugRollMembers;
     std::span<inventory::buckets::Descriptor> inventoryBuckets;
     std::span<socket_entry_lists::Definition> socketEntryLists;
     std::span<socket_entry_lists::EntryTable> socketEntryTables;
@@ -88,6 +92,8 @@ struct Domains {
     std::span<const items::socket_plugs::Rule> socketPlugRules;
     std::span<const items::socket_plugs::Pool> socketPlugPools;
     std::span<const items::socket_plugs::Member> socketPlugMembers;
+    std::span<const items::socket_plugs::Pool> socketPlugRollPools;
+    std::span<const items::socket_plugs::Member> socketPlugRollMembers;
     std::span<const inventory::buckets::Descriptor> inventoryBuckets;
     std::span<const socket_entry_lists::Definition> socketEntryLists;
     std::span<const socket_entry_lists::EntryTable> socketEntryTables;

--- a/Sunrise/src/state/build_data/cache/records/format.h
+++ b/Sunrise/src/state/build_data/cache/records/format.h
@@ -29,7 +29,7 @@ inline constexpr std::array<char, 8> kCacheMagic{'S', 'U', 'N', 'R', 'I', 'S', '
  * Bump it when a stored shape changes, and when the extraction filling it changes what it writes.
  * A cached row survives a code change, so a corrected walk keeps publishing the old rows.
  */
-inline constexpr std::uint32_t kCacheFormatVersion = 49;
+inline constexpr std::uint32_t kCacheFormatVersion = 50;
 /** Signed -1 on disk means there is no equipment slot. */
 inline constexpr std::int8_t kAbsentEquipmentSlot = -1;
 /** The standard 64-bit FNV-1a offset basis starts the payload checksum. */
@@ -194,8 +194,8 @@ struct ItemDetailRecord {
 struct SocketPlugRuleRecord {
     std::uint16_t itemDefinitionIndex{};
     std::uint8_t lane{};
-    /** Socket-entry index, or 0xFF when the lane has no matching socket entry. */
-    std::uint8_t socketEntryIndex{};
+    /** Must be zero so all unused bytes have one canonical value. */
+    std::uint8_t reserved{};
     std::uint32_t poolIndex{};
     std::uint32_t rollPoolIndex{};
 };

--- a/Sunrise/src/state/build_data/cache/records/format.h
+++ b/Sunrise/src/state/build_data/cache/records/format.h
@@ -29,7 +29,7 @@ inline constexpr std::array<char, 8> kCacheMagic{'S', 'U', 'N', 'R', 'I', 'S', '
  * Bump it when a stored shape changes, and when the extraction filling it changes what it writes.
  * A cached row survives a code change, so a corrected walk keeps publishing the old rows.
  */
-inline constexpr std::uint32_t kCacheFormatVersion = 44;
+inline constexpr std::uint32_t kCacheFormatVersion = 49;
 /** Signed -1 on disk means there is no equipment slot. */
 inline constexpr std::int8_t kAbsentEquipmentSlot = -1;
 /** The standard 64-bit FNV-1a offset basis starts the payload checksum. */
@@ -73,6 +73,8 @@ struct Header {
     std::uint32_t socketPlugRuleCount{};
     std::uint32_t socketPlugPoolCount{};
     std::uint32_t socketPlugMemberCount{};
+    std::uint32_t socketPlugRollPoolCount{};
+    std::uint32_t socketPlugRollMemberCount{};
     std::uint32_t inventoryBucketCount{};
     std::uint32_t socketEntryListCount{};
     std::uint32_t socketEntryTableCount{};
@@ -116,6 +118,12 @@ struct ItemRecord {
     std::uint32_t plugCategoryHash{};
     std::uint16_t rollSetIndex{};
     std::uint16_t linkedPlugIndex{items::kUnavailableLinkedPlugIndex};
+    /** First investment-stat value (the tier of a masterwork stat plug), clamped into a byte. */
+    std::uint8_t actionStatValue{};
+    /** Stat table row of the first investment stat (the stat a masterwork plug boosts). */
+    std::uint8_t actionStatRow{};
+    /** Must be zero, so every unused disk byte always matches. */
+    std::uint8_t reserved{};
 };
 
 /** Disk form of one material charged by a native Collections acquisition. */
@@ -186,9 +194,10 @@ struct ItemDetailRecord {
 struct SocketPlugRuleRecord {
     std::uint16_t itemDefinitionIndex{};
     std::uint8_t lane{};
-    /** Must be zero so all unused bytes have one canonical value. */
-    std::uint8_t reserved{};
+    /** Socket-entry index, or 0xFF when the lane has no matching socket entry. */
+    std::uint8_t socketEntryIndex{};
     std::uint32_t poolIndex{};
+    std::uint32_t rollPoolIndex{};
 };
 
 /** Disk form of one contiguous range in the flat allowed-plug member bank. */
@@ -199,6 +208,17 @@ struct SocketPlugPoolRecord {
 
 /** Disk form of one native item-definition index allowed as a plug. */
 struct SocketPlugMemberRecord {
+    std::uint16_t itemDefinitionIndex{};
+};
+
+/** Disk form of one contiguous range in the flat native-order roll-member bank. */
+struct SocketPlugRollPoolRecord {
+    std::uint32_t memberOffset{};
+    std::uint32_t memberCount{};
+};
+
+/** Disk form of one native item-definition index in a native-order roll pool. */
+struct SocketPlugRollMemberRecord {
     std::uint16_t itemDefinitionIndex{};
 };
 
@@ -422,7 +442,7 @@ static_assert(sizeof(Prefix) == kCacheMagic.size() + sizeof(std::uint32_t));
 static_assert(sizeof(InvestmentConstants)
               == constants::kCharacterStatRowCount + 2 * sizeof(std::uint8_t));
 static_assert(sizeof(Header)
-              == kCacheMagic.size() + 26 * sizeof(std::uint32_t) + 2 * sizeof(std::uint64_t)
+              == kCacheMagic.size() + 28 * sizeof(std::uint32_t) + 2 * sizeof(std::uint64_t)
                      + sizeof(InvestmentConstants));
 static_assert(sizeof(SpawnPointRecord)
               == spawn_sets::kPositionComponents * sizeof(float) + sizeof(std::uint32_t)
@@ -469,7 +489,7 @@ static_assert(sizeof(NamedRecord)
               == content::kDefinitionNameCapacity + 2 * sizeof(std::uint16_t)
                      + 2 * sizeof(std::uint32_t));
 static_assert(sizeof(ItemRecord)
-              == 2 * sizeof(std::uint32_t) + 5 * sizeof(std::uint16_t) + 2 * sizeof(std::uint8_t));
+              == 2 * sizeof(std::uint32_t) + 5 * sizeof(std::uint16_t) + 5 * sizeof(std::uint8_t));
 static_assert(sizeof(MaterialRequirementRecord)
               == sizeof(std::uint32_t) + 2 * sizeof(std::uint16_t) + 2 * sizeof(std::uint8_t));
 static_assert(sizeof(CollectibleRecord)
@@ -489,9 +509,11 @@ static_assert(sizeof(ItemDetailRecord)
                      + items::details::kRenderOverrideCapacity
                            * (2 * sizeof(std::uint8_t) + sizeof(std::uint16_t)));
 static_assert(sizeof(SocketPlugRuleRecord)
-              == sizeof(std::uint16_t) + 2 * sizeof(std::uint8_t) + sizeof(std::uint32_t));
+              == sizeof(std::uint16_t) + 2 * sizeof(std::uint8_t) + 2 * sizeof(std::uint32_t));
 static_assert(sizeof(SocketPlugPoolRecord) == 2 * sizeof(std::uint32_t));
 static_assert(sizeof(SocketPlugMemberRecord) == sizeof(std::uint16_t));
+static_assert(sizeof(SocketPlugRollPoolRecord) == 2 * sizeof(std::uint32_t));
+static_assert(sizeof(SocketPlugRollMemberRecord) == sizeof(std::uint16_t));
 static_assert(sizeof(InventoryBucketRecord)
               == 4 * sizeof(std::uint8_t) + 2 * sizeof(std::uint16_t));
 static_assert(sizeof(SocketEntryListRecord)

--- a/Sunrise/src/state/build_data/cache/records/validation.h
+++ b/Sunrise/src/state/build_data/cache/records/validation.h
@@ -35,6 +35,8 @@ valid_item_detail_links(std::span<const items::details::Definition> details,
 valid_socket_plug_links(std::span<const items::socket_plugs::Rule> rules,
                         std::span<const items::socket_plugs::Pool> pools,
                         std::span<const items::socket_plugs::Member> members,
+                        std::span<const items::socket_plugs::Pool> rollPools,
+                        std::span<const items::socket_plugs::Member> rollMembers,
                         std::span<const items::Definition> itemDefinitions,
                         std::span<const items::details::Definition> details) noexcept;
 

--- a/Sunrise/src/state/build_data/cache/write/cache_payload_writer.cpp
+++ b/Sunrise/src/state/build_data/cache/write/cache_payload_writer.cpp
@@ -72,6 +72,10 @@ bool payload_checksum(records::Domains domains, std::uint64_t& checksum) noexcep
            && checksum_domain<records::SocketPlugRuleRecord>(domains.socketPlugRules, checksum)
            && checksum_domain<records::SocketPlugPoolRecord>(domains.socketPlugPools, checksum)
            && checksum_domain<records::SocketPlugMemberRecord>(domains.socketPlugMembers, checksum)
+           && checksum_domain<records::SocketPlugRollPoolRecord>(domains.socketPlugRollPools,
+                                                                 checksum)
+           && checksum_domain<records::SocketPlugRollMemberRecord>(domains.socketPlugRollMembers,
+                                                                   checksum)
            && checksum_domain<records::InventoryBucketRecord>(domains.inventoryBuckets, checksum)
            && checksum_domain<records::SocketEntryListRecord>(domains.socketEntryLists, checksum)
            && checksum_domain<records::SocketEntryTableRecord>(domains.socketEntryTables, checksum)
@@ -101,6 +105,8 @@ bool write_payload(HANDLE file, records::Domains domains) noexcept {
            && write_domain<records::SocketPlugRuleRecord>(file, domains.socketPlugRules)
            && write_domain<records::SocketPlugPoolRecord>(file, domains.socketPlugPools)
            && write_domain<records::SocketPlugMemberRecord>(file, domains.socketPlugMembers)
+           && write_domain<records::SocketPlugRollPoolRecord>(file, domains.socketPlugRollPools)
+           && write_domain<records::SocketPlugRollMemberRecord>(file, domains.socketPlugRollMembers)
            && write_domain<records::InventoryBucketRecord>(file, domains.inventoryBuckets)
            && write_domain<records::SocketEntryListRecord>(file, domains.socketEntryLists)
            && write_domain<records::SocketEntryTableRecord>(file, domains.socketEntryTables)

--- a/Sunrise/src/state/build_data/cache/write/temporary/temporary_cache_file.cpp
+++ b/Sunrise/src/state/build_data/cache/write/temporary/temporary_cache_file.cpp
@@ -114,6 +114,8 @@ enum class WriteStatus {
         static_cast<std::uint32_t>(domains.socketPlugRules.size()),
         static_cast<std::uint32_t>(domains.socketPlugPools.size()),
         static_cast<std::uint32_t>(domains.socketPlugMembers.size()),
+        static_cast<std::uint32_t>(domains.socketPlugRollPools.size()),
+        static_cast<std::uint32_t>(domains.socketPlugRollMembers.size()),
         static_cast<std::uint32_t>(domains.inventoryBuckets.size()),
         static_cast<std::uint32_t>(domains.socketEntryLists.size()),
         static_cast<std::uint32_t>(domains.socketEntryTables.size()),

--- a/Sunrise/src/state/build_data/items/item_catalog.h
+++ b/Sunrise/src/state/build_data/items/item_catalog.h
@@ -35,6 +35,18 @@ struct Definition {
     /** Item index of the plug this one stands for, or kUnavailableLinkedPlugIndex when it stands
      * alone. */
     std::uint16_t linkedPlugIndex{kUnavailableLinkedPlugIndex};
+    /**
+     * The definition's first investment-stat value, clamped into a byte. A masterwork stat plug
+     * declares its tier here (1..10); other plugs carry whatever their first stat says, which the
+     * roll only reads to detect a Tier-1 masterwork. Zero when the definition declares no stat.
+     */
+    std::uint8_t actionStatValue{};
+    /**
+     * Stat table row of the first investment stat, naming the stat the definition contributes
+     * to. A masterwork stat plug carries the stat it boosts here; a definition with no stat
+     * carries no row, which never matches a weapon stat.
+     */
+    std::uint8_t actionStatRow{};
 };
 
 /** Roll-set ordinals outside the rolled ladder. */

--- a/Sunrise/src/state/build_data/items/socket_plugs/definition.h
+++ b/Sunrise/src/state/build_data/items/socket_plugs/definition.h
@@ -24,14 +24,12 @@ inline constexpr std::size_t kRollPoolCapacity = kRuleCapacity + 1;
 /** Four million 16-bit roll members bound the native-order relation. */
 inline constexpr std::size_t kRollMemberCapacity = 1U << 22U;
 
-/** Canonically marks a lane with no matching socket entry (the common intrinsic case). */
-inline constexpr std::uint8_t kNoSocketEntry = 0xFF;
 /** One installed item socket and the exact deduplicated plug pool it accepts. */
 struct Rule {
     std::uint16_t itemDefinitionIndex{};
     std::uint8_t lane{};
-    /** Socket-entry index whose roll pool is this lane's roll pool, or kNoSocketEntry. */
-    std::uint8_t socketEntryIndex{};
+    /** Must remain zero so the runtime and packed forms are deterministic. */
+    std::uint8_t reserved{};
     std::uint32_t poolIndex{};
     /** Native-order randomized roll-set pool for the lane, or kEmptyRollPoolIndex. */
     std::uint32_t rollPoolIndex{};

--- a/Sunrise/src/state/build_data/items/socket_plugs/definition.h
+++ b/Sunrise/src/state/build_data/items/socket_plugs/definition.h
@@ -17,14 +17,24 @@ inline constexpr std::size_t kPoolCapacity = kRuleCapacity + 1;
 inline constexpr std::size_t kMemberCapacity = 1U << 22U;
 /** Pool zero is always the canonical empty pool. */
 inline constexpr std::uint32_t kEmptyPoolIndex = 0;
+/** Roll-pool zero is the canonical empty native-order roll pool. */
+inline constexpr std::uint32_t kEmptyRollPoolIndex = 0;
+/** At most one native-order roll pool is retained per installed rule. */
+inline constexpr std::size_t kRollPoolCapacity = kRuleCapacity + 1;
+/** Four million 16-bit roll members bound the native-order relation. */
+inline constexpr std::size_t kRollMemberCapacity = 1U << 22U;
 
+/** Canonically marks a lane with no matching socket entry (the common intrinsic case). */
+inline constexpr std::uint8_t kNoSocketEntry = 0xFF;
 /** One installed item socket and the exact deduplicated plug pool it accepts. */
 struct Rule {
     std::uint16_t itemDefinitionIndex{};
     std::uint8_t lane{};
-    /** Must remain zero so the runtime and packed forms are deterministic. */
-    std::uint8_t reserved{};
+    /** Socket-entry index whose roll pool is this lane's roll pool, or kNoSocketEntry. */
+    std::uint8_t socketEntryIndex{};
     std::uint32_t poolIndex{};
+    /** Native-order randomized roll-set pool for the lane, or kEmptyRollPoolIndex. */
+    std::uint32_t rollPoolIndex{};
 };
 
 /** One contiguous range in the flat, sorted plug-definition index bank. */

--- a/Sunrise/src/state/build_data/items/socket_plugs/socket_plug_build_data_runtime.cpp
+++ b/Sunrise/src/state/build_data/items/socket_plugs/socket_plug_build_data_runtime.cpp
@@ -17,9 +17,11 @@ constexpr std::uint8_t kShaderBucketId = 14;
 [[nodiscard]] bool
 valid_socket_plug_publication(std::span<const items::socket_plugs::Rule> rules,
                               std::span<const items::socket_plugs::Pool> pools,
-                              std::span<const items::socket_plugs::Member> members) noexcept {
-    if (!items::socket_plugs::valid(rules, pools, members) || items::count() == 0
-        || !configured_item_details_ready()) {
+                              std::span<const items::socket_plugs::Member> members,
+                              std::span<const items::socket_plugs::Pool> rollPools,
+                              std::span<const items::socket_plugs::Member> rollMembers) noexcept {
+    if (!items::socket_plugs::valid(rules, pools, members, rollPools, rollMembers)
+        || items::count() == 0 || !configured_item_details_ready()) {
         return false;
     }
     for (const items::socket_plugs::Rule& rule : rules) {
@@ -31,6 +33,11 @@ valid_socket_plug_publication(std::span<const items::socket_plugs::Rule> rules,
         }
     }
     for (const items::socket_plugs::Member member : members) {
+        if (member >= items::count()) {
+            return false;
+        }
+    }
+    for (const items::socket_plugs::Member member : rollMembers) {
         if (member >= items::count()) {
             return false;
         }
@@ -48,13 +55,17 @@ bool socket_plug_rules_ready() noexcept {
 /** Publishes the complete exact socket relation in one persistence transaction. */
 bool publish_socket_plug_rules(std::span<const items::socket_plugs::Rule> rules,
                                std::span<const items::socket_plugs::Pool> pools,
-                               std::span<const items::socket_plugs::Member> members) noexcept {
+                               std::span<const items::socket_plugs::Member> members,
+                               std::span<const items::socket_plugs::Pool> rollPools,
+                               std::span<const items::socket_plugs::Member> rollMembers) noexcept {
     runtime::persistence::Transaction transaction;
-    if (!transaction.active() || !valid_socket_plug_publication(rules, pools, members)) {
+    if (!transaction.active()
+        || !valid_socket_plug_publication(rules, pools, members, rollPools, rollMembers)) {
         return false;
     }
-    return transaction.finish(items::socket_plugs::replace(rules, pools, members),
-                              items::socket_plugs::clear);
+    return transaction.finish(
+        items::socket_plugs::replace(rules, pools, members, rollPools, rollMembers),
+        items::socket_plugs::clear);
 }
 
 /** Answers one exact installed item/lane/plug compatibility query. */
@@ -72,6 +83,20 @@ bool visit_socket_plug_pool(std::uint16_t itemDefinitionIndex,
                             void* context) noexcept {
     return socket_plug_rules_ready()
            && items::socket_plugs::visit_pool(itemDefinitionIndex, lane, visitor, context);
+}
+
+/** Names the socket entry a rolled lane resolves through, or kNoSocketEntry when it has none. */
+std::uint8_t socket_entry_index(std::uint16_t itemDefinitionIndex, std::uint8_t lane) noexcept {
+    return items::socket_plugs::socket_entry_index(itemDefinitionIndex, lane);
+}
+
+/** Walks one lane's native-order randomized roll pool once the whole relation is in State. */
+bool visit_socket_roll_pool(std::uint16_t itemDefinitionIndex,
+                            std::uint8_t lane,
+                            items::socket_plugs::MemberVisitor visitor,
+                            void* context) noexcept {
+    return socket_plug_rules_ready()
+           && items::socket_plugs::visit_roll_pool(itemDefinitionIndex, lane, visitor, context);
 }
 
 /** Answers pool membership anywhere in the installed relation. */

--- a/Sunrise/src/state/build_data/items/socket_plugs/socket_plug_build_data_runtime.cpp
+++ b/Sunrise/src/state/build_data/items/socket_plugs/socket_plug_build_data_runtime.cpp
@@ -85,11 +85,6 @@ bool visit_socket_plug_pool(std::uint16_t itemDefinitionIndex,
            && items::socket_plugs::visit_pool(itemDefinitionIndex, lane, visitor, context);
 }
 
-/** Names the socket entry a rolled lane resolves through, or kNoSocketEntry when it has none. */
-std::uint8_t socket_entry_index(std::uint16_t itemDefinitionIndex, std::uint8_t lane) noexcept {
-    return items::socket_plugs::socket_entry_index(itemDefinitionIndex, lane);
-}
-
 /** Walks one lane's native-order randomized roll pool once the whole relation is in State. */
 bool visit_socket_roll_pool(std::uint16_t itemDefinitionIndex,
                             std::uint8_t lane,

--- a/Sunrise/src/state/build_data/items/socket_plugs/socket_plug_catalog.cpp
+++ b/Sunrise/src/state/build_data/items/socket_plugs/socket_plug_catalog.cpp
@@ -50,8 +50,7 @@ bool valid(std::span<const Rule> rules,
     }
     for (std::size_t index = 0; index < rules.size(); ++index) {
         const Rule& rule = rules[index];
-        if ((rule.socketEntryIndex != kNoSocketEntry && rule.socketEntryIndex >= 64)
-            || rule.lane >= kLaneCapacity || rule.poolIndex >= pools.size()
+        if (rule.reserved != 0 || rule.lane >= kLaneCapacity || rule.poolIndex >= pools.size()
             || rule.rollPoolIndex >= rollPools.size()
             || (index != 0 && !rule_less(rules[index - 1], rule))) {
             return false;
@@ -209,22 +208,6 @@ bool visit_roll_pool(std::uint16_t itemDefinitionIndex,
         }
     }
     return true;
-}
-
-/** Returns the socket-entry index a rolled lane resolves through, or kNoSocketEntry. */
-std::uint8_t socket_entry_index(std::uint16_t itemDefinitionIndex, std::uint8_t lane) noexcept {
-    if (lane >= kLaneCapacity) {
-        return kNoSocketEntry;
-    }
-    const Lock::Shared guard(g_lock);
-    const auto rules = g_rules.rows();
-    const Rule key{itemDefinitionIndex, lane, 0, 0, 0};
-    const auto found = std::lower_bound(rules.begin(), rules.end(), key, rule_less);
-    if (found == rules.end() || found->itemDefinitionIndex != itemDefinitionIndex
-        || found->lane != lane) {
-        return kNoSocketEntry;
-    }
-    return found->socketEntryIndex;
 }
 
 /** Answers whether one definition occurs in any installed ordinary-socket plug pool. */

--- a/Sunrise/src/state/build_data/items/socket_plugs/socket_plug_catalog.cpp
+++ b/Sunrise/src/state/build_data/items/socket_plugs/socket_plug_catalog.cpp
@@ -12,6 +12,8 @@ Lock g_lock;
 Table<Rule, kRuleCapacity> g_rules;
 Table<Pool, kPoolCapacity> g_pools;
 Table<Member, kMemberCapacity> g_members;
+Table<Pool, kRollPoolCapacity> g_rollPools;
+Table<Member, kRollMemberCapacity> g_rollMembers;
 std::bitset<details::kDefinitionCapacity> g_membership;
 
 /** @return True when the first rule's item/lane key is strictly before the second. */
@@ -28,21 +30,29 @@ void clear() noexcept {
     g_rules.clear();
     g_pools.clear();
     g_members.clear();
+    g_rollPools.clear();
+    g_rollMembers.clear();
     g_membership.reset();
 }
 
 /** Checks counts, strict rule order, contiguous pools, and sorted unique pool members. */
 bool valid(std::span<const Rule> rules,
            std::span<const Pool> pools,
-           std::span<const Member> members) noexcept {
+           std::span<const Member> members,
+           std::span<const Pool> rollPools,
+           std::span<const Member> rollMembers) noexcept {
     if (rules.empty() || rules.size() > kRuleCapacity || pools.empty()
         || pools.size() > kPoolCapacity || members.size() > kMemberCapacity
-        || pools.front().memberOffset != 0 || pools.front().memberCount != 0) {
+        || pools.front().memberOffset != 0 || pools.front().memberCount != 0 || rollPools.empty()
+        || rollPools.size() > kRollPoolCapacity || rollMembers.size() > kRollMemberCapacity
+        || rollPools.front().memberOffset != 0 || rollPools.front().memberCount != 0) {
         return false;
     }
     for (std::size_t index = 0; index < rules.size(); ++index) {
         const Rule& rule = rules[index];
-        if (rule.reserved != 0 || rule.lane >= kLaneCapacity || rule.poolIndex >= pools.size()
+        if ((rule.socketEntryIndex != kNoSocketEntry && rule.socketEntryIndex >= 64)
+            || rule.lane >= kLaneCapacity || rule.poolIndex >= pools.size()
+            || rule.rollPoolIndex >= rollPools.size()
             || (index != 0 && !rule_less(rules[index - 1], rule))) {
             return false;
         }
@@ -64,22 +74,49 @@ bool valid(std::span<const Rule> rules,
         }
         expectedOffset += pool.memberCount;
     }
-    return expectedOffset == members.size();
-}
-
-/** Replaces all three arrays while no reader can observe a partial relation. */
-bool replace(std::span<const Rule> rules,
-             std::span<const Pool> pools,
-             std::span<const Member> members) noexcept {
-    if (!valid(rules, pools, members)) {
+    if (expectedOffset != members.size()) {
         return false;
     }
+    expectedOffset = 0;
+    for (std::size_t index = 0; index < rollPools.size(); ++index) {
+        const Pool& pool = rollPools[index];
+        if (pool.memberOffset != expectedOffset || (index != 0 && pool.memberCount == 0)
+            || pool.memberCount > rollMembers.size() - expectedOffset) {
+            return false;
+        }
+        const auto range = rollMembers.subspan(expectedOffset, pool.memberCount);
+        if (std::any_of(range.begin(), range.end(), [](Member member) {
+                return member >= details::kDefinitionCapacity;
+            })) {
+            return false;
+        }
+        expectedOffset += pool.memberCount;
+    }
+    return expectedOffset == rollMembers.size();
+}
+
+/** Replaces all arrays while no reader can observe a partial relation. */
+bool replace(std::span<const Rule> rules,
+             std::span<const Pool> pools,
+             std::span<const Member> members,
+             std::span<const Pool> rollPools,
+             std::span<const Member> rollMembers) noexcept {
+    if (!valid(rules, pools, members, rollPools, rollMembers)) {
+        return false;
+    }
+    // Membership answers "does this definition occur in any ordinary socket at all", so it spans
+    // both banks. The curated pool alone would leave a perk that only ever appears in a randomized
+    // set looking unpooled, and the rolled-result search treats an unpooled plug as a roll result.
     std::bitset<details::kDefinitionCapacity> membership;
     for (const Member member : members) {
         membership.set(member);
     }
+    for (const Member member : rollMembers) {
+        membership.set(member);
+    }
     const Lock::Exclusive guard(g_lock);
-    if (!g_rules.replace(rules) || !g_pools.replace(pools) || !g_members.replace(members)) {
+    if (!g_rules.replace(rules) || !g_pools.replace(pools) || !g_members.replace(members)
+        || !g_rollPools.replace(rollPools) || !g_rollMembers.replace(rollMembers)) {
         return false;
     }
     g_membership = membership;
@@ -97,7 +134,7 @@ bool allowed(std::uint16_t itemDefinitionIndex,
     const auto rules = g_rules.rows();
     const auto pools = g_pools.rows();
     const auto members = g_members.rows();
-    const Rule key{itemDefinitionIndex, lane, 0, 0};
+    const Rule key{itemDefinitionIndex, lane, 0, 0, 0};
     const auto found = std::lower_bound(rules.begin(), rules.end(), key, rule_less);
     if (found == rules.end() || found->itemDefinitionIndex != itemDefinitionIndex
         || found->lane != lane || found->poolIndex >= pools.size()) {
@@ -124,7 +161,7 @@ bool visit_pool(std::uint16_t itemDefinitionIndex,
     const auto rules = g_rules.rows();
     const auto pools = g_pools.rows();
     const auto members = g_members.rows();
-    const Rule key{itemDefinitionIndex, lane, 0, 0};
+    const Rule key{itemDefinitionIndex, lane, 0, 0, 0};
     const auto found = std::lower_bound(rules.begin(), rules.end(), key, rule_less);
     if (found == rules.end() || found->itemDefinitionIndex != itemDefinitionIndex
         || found->lane != lane || found->poolIndex >= pools.size()) {
@@ -143,25 +180,80 @@ bool visit_pool(std::uint16_t itemDefinitionIndex,
     return true;
 }
 
+/** Walks one lane's native-order randomized roll pool under a shared hold. */
+bool visit_roll_pool(std::uint16_t itemDefinitionIndex,
+                     std::uint8_t lane,
+                     MemberVisitor visitor,
+                     void* context) noexcept {
+    if (lane >= kLaneCapacity || visitor == nullptr) {
+        return false;
+    }
+    const Lock::Shared guard(g_lock);
+    const auto rules = g_rules.rows();
+    const auto rollPools = g_rollPools.rows();
+    const auto rollMembers = g_rollMembers.rows();
+    const Rule key{itemDefinitionIndex, lane, 0, 0, 0};
+    const auto found = std::lower_bound(rules.begin(), rules.end(), key, rule_less);
+    if (found == rules.end() || found->itemDefinitionIndex != itemDefinitionIndex
+        || found->lane != lane || found->rollPoolIndex >= rollPools.size()) {
+        return false;
+    }
+    const Pool& pool = rollPools[found->rollPoolIndex];
+    if (pool.memberOffset > rollMembers.size()
+        || pool.memberCount > rollMembers.size() - pool.memberOffset) {
+        return false;
+    }
+    for (const Member member : rollMembers.subspan(pool.memberOffset, pool.memberCount)) {
+        if (!visitor(context, member)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/** Returns the socket-entry index a rolled lane resolves through, or kNoSocketEntry. */
+std::uint8_t socket_entry_index(std::uint16_t itemDefinitionIndex, std::uint8_t lane) noexcept {
+    if (lane >= kLaneCapacity) {
+        return kNoSocketEntry;
+    }
+    const Lock::Shared guard(g_lock);
+    const auto rules = g_rules.rows();
+    const Rule key{itemDefinitionIndex, lane, 0, 0, 0};
+    const auto found = std::lower_bound(rules.begin(), rules.end(), key, rule_less);
+    if (found == rules.end() || found->itemDefinitionIndex != itemDefinitionIndex
+        || found->lane != lane) {
+        return kNoSocketEntry;
+    }
+    return found->socketEntryIndex;
+}
+
 /** Answers whether one definition occurs in any installed ordinary-socket plug pool. */
 bool contains(Member plugDefinitionIndex) noexcept {
     const Lock::Shared guard(g_lock);
     return plugDefinitionIndex < g_membership.size() && g_membership.test(plugDefinitionIndex);
 }
 
-/** Copies the three related arrays under the same shared hold. */
+/** Copies the related arrays under the same shared hold. */
 bool snapshot(std::span<Rule> rules,
               std::size_t& ruleCount,
               std::span<Pool> pools,
               std::size_t& poolCount,
               std::span<Member> members,
-              std::size_t& memberCount) noexcept {
+              std::size_t& memberCount,
+              std::span<Pool> rollPools,
+              std::size_t& rollPoolCount,
+              std::span<Member> rollMembers,
+              std::size_t& rollMemberCount) noexcept {
     ruleCount = 0;
     poolCount = 0;
     memberCount = 0;
+    rollPoolCount = 0;
+    rollMemberCount = 0;
     const Lock::Shared guard(g_lock);
     return g_rules.snapshot(rules, ruleCount) && g_pools.snapshot(pools, poolCount)
-           && g_members.snapshot(members, memberCount);
+           && g_members.snapshot(members, memberCount)
+           && g_rollPools.snapshot(rollPools, rollPoolCount)
+           && g_rollMembers.snapshot(rollMembers, rollMemberCount);
 }
 
 /** Reports the published rule count under the catalog lock. */

--- a/Sunrise/src/state/build_data/items/socket_plugs/socket_plug_catalog.h
+++ b/Sunrise/src/state/build_data/items/socket_plugs/socket_plug_catalog.h
@@ -16,16 +16,22 @@ void clear() noexcept;
  * @param rules Strictly item/lane-ordered socket rules.
  * @param pools Contiguous member ranges, beginning with the canonical empty pool.
  * @param members Sorted unique members inside each pool range.
+ * @param rollPools Contiguous native-order ranges, beginning with the empty roll pool.
+ * @param rollMembers Native-order members inside each roll pool range.
  * @return True when every count, key, range, and pool reference is canonical.
  */
 [[nodiscard]] bool valid(std::span<const Rule> rules,
                          std::span<const Pool> pools,
-                         std::span<const Member> members) noexcept;
+                         std::span<const Member> members,
+                         std::span<const Pool> rollPools,
+                         std::span<const Member> rollMembers) noexcept;
 
-/** Replaces the complete relation atomically after validating all three arrays. */
+/** Replaces the complete relation atomically after validating all arrays. */
 [[nodiscard]] bool replace(std::span<const Rule> rules,
                            std::span<const Pool> pools,
-                           std::span<const Member> members) noexcept;
+                           std::span<const Member> members,
+                           std::span<const Pool> rollPools,
+                           std::span<const Member> rollMembers) noexcept;
 
 /**
  * Answers whether one exact plug is allowed in one installed item's ordinary socket lane.
@@ -50,13 +56,33 @@ void clear() noexcept;
                               MemberVisitor visitor,
                               void* context) noexcept;
 
+/**
+ * Walks one lane's native-order randomized roll pool.
+ * @return True when the lane has a roll pool and the visitor saw every member.
+ */
+[[nodiscard]] bool visit_roll_pool(std::uint16_t itemDefinitionIndex,
+                                   std::uint8_t lane,
+                                   MemberVisitor visitor,
+                                   void* context) noexcept;
+
+/**
+ * @return The socket-entry index a rolled lane resolves through, or kNoSocketEntry when the lane
+ * has no matching entry. A missing rule lane also returns kNoSocketEntry (safe no-op).
+ */
+[[nodiscard]] std::uint8_t socket_entry_index(std::uint16_t itemDefinitionIndex,
+                                              std::uint8_t lane) noexcept;
+
 /** Copies the complete relation while holding its single shared lock. */
 [[nodiscard]] bool snapshot(std::span<Rule> rules,
                             std::size_t& ruleCount,
                             std::span<Pool> pools,
                             std::size_t& poolCount,
                             std::span<Member> members,
-                            std::size_t& memberCount) noexcept;
+                            std::size_t& memberCount,
+                            std::span<Pool> rollPools,
+                            std::size_t& rollPoolCount,
+                            std::span<Member> rollMembers,
+                            std::size_t& rollMemberCount) noexcept;
 
 /** @return Published socket-rule row count. */
 [[nodiscard]] std::size_t rule_count() noexcept;

--- a/Sunrise/src/state/build_data/items/socket_plugs/socket_plug_catalog.h
+++ b/Sunrise/src/state/build_data/items/socket_plugs/socket_plug_catalog.h
@@ -65,13 +65,6 @@ void clear() noexcept;
                                    MemberVisitor visitor,
                                    void* context) noexcept;
 
-/**
- * @return The socket-entry index a rolled lane resolves through, or kNoSocketEntry when the lane
- * has no matching entry. A missing rule lane also returns kNoSocketEntry (safe no-op).
- */
-[[nodiscard]] std::uint8_t socket_entry_index(std::uint16_t itemDefinitionIndex,
-                                              std::uint8_t lane) noexcept;
-
 /** Copies the complete relation while holding its single shared lock. */
 [[nodiscard]] bool snapshot(std::span<Rule> rules,
                             std::size_t& ruleCount,

--- a/Sunrise/src/state/build_data/runtime.h
+++ b/Sunrise/src/state/build_data/runtime.h
@@ -191,13 +191,6 @@ publish_socket_plug_rules(std::span<const items::socket_plugs::Rule> rules,
                                           void* context) noexcept;
 
 /**
- * @return The socket-entry index a rolled lane resolves through, or
- * items::socket_plugs::kNoSocketEntry when the lane has no matching entry or no installed rule.
- */
-[[nodiscard]] std::uint8_t socket_entry_index(std::uint16_t itemDefinitionIndex,
-                                              std::uint8_t lane) noexcept;
-
-/**
  * Walks one lane's native-order randomized roll pool. Missing relations fail closed.
  * @return True when the lane has a roll pool and the visitor saw every member.
  */

--- a/Sunrise/src/state/build_data/runtime.h
+++ b/Sunrise/src/state/build_data/runtime.h
@@ -162,12 +162,16 @@ publish_configured_item_details(std::span<const items::details::Definition> defi
  * @param rules Strictly item/lane-ordered rules.
  * @param pools Deduplicated contiguous pool ranges, beginning with the empty pool.
  * @param members Flat sorted plug-definition indices.
+ * @param rollPools Contiguous native-order roll ranges, beginning with the empty roll pool.
+ * @param rollMembers Flat native-order roll plug-definition indices.
  * @return True when the relation and its item/detail links validate and any cache write succeeds.
  */
 [[nodiscard]] bool
 publish_socket_plug_rules(std::span<const items::socket_plugs::Rule> rules,
                           std::span<const items::socket_plugs::Pool> pools,
-                          std::span<const items::socket_plugs::Member> members) noexcept;
+                          std::span<const items::socket_plugs::Member> members,
+                          std::span<const items::socket_plugs::Pool> rollPools,
+                          std::span<const items::socket_plugs::Member> rollMembers) noexcept;
 
 /**
  * Answers whether one installed plug definition is valid for one exact ordinary socket lane.
@@ -182,6 +186,22 @@ publish_socket_plug_rules(std::span<const items::socket_plugs::Rule> rules,
  * @return True when the lane has a pool and the visitor saw every member.
  */
 [[nodiscard]] bool visit_socket_plug_pool(std::uint16_t itemDefinitionIndex,
+                                          std::uint8_t lane,
+                                          items::socket_plugs::MemberVisitor visitor,
+                                          void* context) noexcept;
+
+/**
+ * @return The socket-entry index a rolled lane resolves through, or
+ * items::socket_plugs::kNoSocketEntry when the lane has no matching entry or no installed rule.
+ */
+[[nodiscard]] std::uint8_t socket_entry_index(std::uint16_t itemDefinitionIndex,
+                                              std::uint8_t lane) noexcept;
+
+/**
+ * Walks one lane's native-order randomized roll pool. Missing relations fail closed.
+ * @return True when the lane has a roll pool and the visitor saw every member.
+ */
+[[nodiscard]] bool visit_socket_roll_pool(std::uint16_t itemDefinitionIndex,
                                           std::uint8_t lane,
                                           items::socket_plugs::MemberVisitor visitor,
                                           void* context) noexcept;

--- a/Sunrise/src/state/build_data/runtime/persistence/build_data_persistence.cpp
+++ b/Sunrise/src/state/build_data/runtime/persistence/build_data_persistence.cpp
@@ -74,7 +74,11 @@ to_record(const constants::InvestmentConstants& value) noexcept {
                                             scratch.socketPlugPools,
                                             counts.socketPlugPools,
                                             scratch.socketPlugMembers,
-                                            counts.socketPlugMembers)
+                                            counts.socketPlugMembers,
+                                            scratch.socketPlugRollPools,
+                                            counts.socketPlugRollPools,
+                                            scratch.socketPlugRollMembers,
+                                            counts.socketPlugRollMembers)
            && inventory::buckets::snapshot(scratch.inventoryBuckets, counts.inventoryBuckets)
            && socket_entry_lists::snapshot(scratch.socketEntryLists, counts.socketEntryLists)
            && socket_entry_lists::snapshot_entry_tables(scratch.socketEntryTables,
@@ -138,6 +142,14 @@ cache::records::MutableDomains scratch_domains(Context& state) noexcept {
     const auto socketPlugMembers = ensure_scratch<build_data::items::socket_plugs::Member,
                                                   build_data::items::socket_plugs::kMemberCapacity>(
         state.socketPlugMemberScratch);
+    const auto socketPlugRollPools =
+        ensure_scratch<build_data::items::socket_plugs::Pool,
+                       build_data::items::socket_plugs::kRollPoolCapacity>(
+            state.socketPlugRollPoolScratch);
+    const auto socketPlugRollMembers =
+        ensure_scratch<build_data::items::socket_plugs::Member,
+                       build_data::items::socket_plugs::kRollMemberCapacity>(
+            state.socketPlugRollMemberScratch);
     const auto inventoryBuckets =
         ensure_scratch<inventory::buckets::Descriptor, inventory::buckets::kDescriptorCapacity>(
             state.inventoryBucketScratch);
@@ -187,6 +199,8 @@ cache::records::MutableDomains scratch_domains(Context& state) noexcept {
         socketPlugRules,
         socketPlugPools,
         socketPlugMembers,
+        socketPlugRollPools,
+        socketPlugRollMembers,
         inventoryBuckets,
         socketEntryLists,
         socketEntryTables,
@@ -224,6 +238,8 @@ void release_scratch_locked(Context& state) noexcept {
     release_bank(state.socketPlugRuleScratch);
     release_bank(state.socketPlugPoolScratch);
     release_bank(state.socketPlugMemberScratch);
+    release_bank(state.socketPlugRollPoolScratch);
+    release_bank(state.socketPlugRollMemberScratch);
     release_bank(state.inventoryBucketScratch);
     release_bank(state.socketEntryListScratch);
     release_bank(state.socketEntryTableScratch);
@@ -264,6 +280,10 @@ cache::records::Domains occupied_domains(Context& state,
         state.socketPlugPoolScratch.data(), counts.socketPlugPools};
     const std::span<const items::socket_plugs::Member> socketPlugMembers{
         state.socketPlugMemberScratch.data(), counts.socketPlugMembers};
+    const std::span<const items::socket_plugs::Pool> socketPlugRollPools{
+        state.socketPlugRollPoolScratch.data(), counts.socketPlugRollPools};
+    const std::span<const items::socket_plugs::Member> socketPlugRollMembers{
+        state.socketPlugRollMemberScratch.data(), counts.socketPlugRollMembers};
     return {
         state.constantsScratch,
         std::span<const content::Definition>{state.namedScratch.data(), counts.named},
@@ -276,6 +296,8 @@ cache::records::Domains occupied_domains(Context& state,
         socketPlugRules,
         socketPlugPools,
         socketPlugMembers,
+        socketPlugRollPools,
+        socketPlugRollMembers,
         std::span<const inventory::buckets::Descriptor>{state.inventoryBucketScratch.data(),
                                                         counts.inventoryBuckets},
         std::span<const socket_entry_lists::Definition>{state.socketEntryListScratch.data(),

--- a/Sunrise/src/state/build_data/runtime/persistence/build_data_persistence.h
+++ b/Sunrise/src/state/build_data/runtime/persistence/build_data_persistence.h
@@ -37,6 +37,8 @@ struct Context {
     std::vector<items::socket_plugs::Rule> socketPlugRuleScratch{};
     std::vector<items::socket_plugs::Pool> socketPlugPoolScratch{};
     std::vector<items::socket_plugs::Member> socketPlugMemberScratch{};
+    std::vector<items::socket_plugs::Pool> socketPlugRollPoolScratch{};
+    std::vector<items::socket_plugs::Member> socketPlugRollMemberScratch{};
     std::vector<inventory::buckets::Descriptor> inventoryBucketScratch{};
     std::vector<socket_entry_lists::Definition> socketEntryListScratch{};
     std::vector<socket_entry_lists::EntryTable> socketEntryTableScratch{};

--- a/Sunrise/src/state/runtime/runtime.h
+++ b/Sunrise/src/state/runtime/runtime.h
@@ -324,11 +324,16 @@ void shutdown() noexcept;
  * @param collectibleIndex Collections row the Client pulled from.
  * @param definitionHash Installed item definition requested by the Client.
  * @param mutation Gets a checked after-image without changing account State.
+ * @param allowRandomRoll Rolls the ordinary socket lanes of an acquired character weapon instead
+ * of keeping the curated initial plugs. Only a weapon ever rolls; armour, cosmetics and every
+ * profile-owned row keep their definition's plugs whatever this says. Pass false to hand out one
+ * exact curated roll.
  * @return True when the item and every existing loadout row resolve with one free native row.
  */
 [[nodiscard]] bool prepare_item_acquisition(std::uint16_t collectibleIndex,
                                             std::uint32_t definitionHash,
-                                            PendingItemAcquisition& mutation) noexcept;
+                                            PendingItemAcquisition& mutation,
+                                            bool allowRandomRoll = true) noexcept;
 
 /** Builds the exact full-account after-image while a prepared item pull remains current. */
 [[nodiscard]] bool preview_item_acquisition(const PendingItemAcquisition& mutation,

--- a/Sunrise/src/state/runtime/state_account_acquisition_runtime.cpp
+++ b/Sunrise/src/state/runtime/state_account_acquisition_runtime.cpp
@@ -10,6 +10,7 @@
 #include "../build_data/runtime.h"
 #include "runtime.h"
 #include "state_account_transaction_helpers.h"
+#include "state_item_random_roll.h"
 #include "storage/internal.h"
 
 namespace sunrise::state {
@@ -23,7 +24,8 @@ namespace family4_loadout = middleware::datagen::family4::loadout;
 /** Prepares one native-row-checked selected-character inventory insertion. */
 bool prepare_item_acquisition(std::uint16_t collectibleIndex,
                               std::uint32_t definitionHash,
-                              PendingItemAcquisition& mutation) noexcept {
+                              PendingItemAcquisition& mutation,
+                              bool allowRandomRoll) noexcept {
     mutation = {};
     const AccountState account = account_snapshot();
     build_data::collectibles::Definition collectible{};
@@ -100,6 +102,19 @@ bool prepare_item_acquisition(std::uint16_t collectibleIndex,
     acquired.quantity = 1;
     acquired.mutationSerial = static_cast<std::int32_t>(after.nextInventorySerial++);
     acquired.sockets.policy = authored_inventory::SocketPolicy::nativeDefaults;
+
+    if (allowRandomRoll) {
+        item_details::Definition detail{};
+        if (build_data::find_configured_item_detail(grantedDefinition.definitionIndex, detail)) {
+            // The instance is the roll's own key and is folded in by the roll itself, so the seed
+            // carries only what the instance cannot supply: when the pull happened and which pull
+            // it was on this character.
+            const std::uint64_t seed = (static_cast<std::uint64_t>(GetTickCount64()) << 8U)
+                                       ^ static_cast<std::uint64_t>(after.nextInventorySerial);
+            (void)roll_random_bytes(acquired, grantedDefinition, detail, seed);
+        }
+    }
+
     after.inventory.values[inventoryIndex] = acquired;
     ++after.inventory.count;
 

--- a/Sunrise/src/state/runtime/state_account_equipment_runtime.cpp
+++ b/Sunrise/src/state/runtime/state_account_equipment_runtime.cpp
@@ -290,7 +290,10 @@ finalize_equipment_transition(const AccountState& account,
            && left.level == right.level && left.quantity == right.quantity
            && left.flags == right.flags && left.sockets.policy == right.sockets.policy
            && left.sockets.plugCount == right.sockets.plugCount
-           && left.sockets.plugs == right.sockets.plugs
+           && left.sockets.plugs == right.sockets.plugs && left.randomRoll == right.randomRoll
+           && left.rolledLaneMask == right.rolledLaneMask
+           && left.availablePlugRows == right.availablePlugRows
+           && left.rollRowByLane == right.rollRowByLane
            && left.movementAbilityEntry == right.movementAbilityEntry
            && left.grenadeAbilityEntry == right.grenadeAbilityEntry
            && left.superAbilityEntry == right.superAbilityEntry

--- a/Sunrise/src/state/runtime/state_account_equipment_runtime.cpp
+++ b/Sunrise/src/state/runtime/state_account_equipment_runtime.cpp
@@ -293,7 +293,6 @@ finalize_equipment_transition(const AccountState& account,
            && left.sockets.plugs == right.sockets.plugs && left.randomRoll == right.randomRoll
            && left.rolledLaneMask == right.rolledLaneMask
            && left.availablePlugRows == right.availablePlugRows
-           && left.rollRowByLane == right.rollRowByLane
            && left.movementAbilityEntry == right.movementAbilityEntry
            && left.grenadeAbilityEntry == right.grenadeAbilityEntry
            && left.superAbilityEntry == right.superAbilityEntry

--- a/Sunrise/src/state/runtime/state_account_item_action_runtime.cpp
+++ b/Sunrise/src/state/runtime/state_account_item_action_runtime.cpp
@@ -140,15 +140,31 @@ bool prepare_character_selector_socket_plug(std::uint64_t instanceIdentityToken,
         // Most action kinds are the physical ordinary-socket lane. Prefer that exact lane when
         // its pool accepts the plug, which disambiguates armour with two mod sockets on one pool.
         // Some kinds are semantic instead (shaders), so keep the unique-compatible-lane fallback.
+        // The lane test is the instance's offer rule, not the definition's pool alone: a rolled
+        // lane also offers the randomized-set rows the instance owns. Testing the pool alone
+        // resolves no lane for the plug a rolled lane started with, so the roll could be swapped
+        // away and never chosen again.
+        CharacterItemLocation targetLocation{};
+        const authored_inventory::Item* targetItem =
+            find_character_item_location(snapshot.characters[characterIndex],
+                                         resolvedTarget->instance.instanceSoid,
+                                         targetLocation)
+                ? character_item_at(snapshot.characters[characterIndex], targetLocation)
+                : nullptr;
+        const authored_inventory::Item probe{};
+        const authored_inventory::Item& offerItem = targetItem != nullptr ? *targetItem : probe;
         if (requestedSocketLane < targetDetail.ordinarySocketCount
-            && build_data::is_socket_plug_allowed(
-                targetDefinition.definitionIndex, requestedSocketLane, plugDefinitionIndex)) {
+            && plug_offered_in_lane(offerItem,
+                                    targetDefinition.definitionIndex,
+                                    requestedSocketLane,
+                                    plugDefinitionIndex)) {
             resolvedSocketLane = requestedSocketLane;
         } else {
             for (std::size_t lane = 0; lane < targetDetail.ordinarySocketCount; ++lane) {
-                if (!build_data::is_socket_plug_allowed(targetDefinition.definitionIndex,
-                                                        static_cast<std::uint8_t>(lane),
-                                                        plugDefinitionIndex)) {
+                if (!plug_offered_in_lane(offerItem,
+                                          targetDefinition.definitionIndex,
+                                          static_cast<std::uint8_t>(lane),
+                                          plugDefinitionIndex)) {
                     continue;
                 }
                 if (resolvedSocketLane < authored_inventory::kPlugCapacity) {

--- a/Sunrise/src/state/runtime/state_account_socket_runtime.cpp
+++ b/Sunrise/src/state/runtime/state_account_socket_runtime.cpp
@@ -70,6 +70,67 @@ void report_socket_plug(std::string_view stage,
     }
 }
 
+/** Rows of a lane's randomized set the owned-row mask can name, one bit per row. */
+inline constexpr std::size_t kRollRowCapacity = 64;
+/** Stands for "this plug is not a member of the lane's randomized set". */
+inline constexpr std::size_t kNoRollRow = std::numeric_limits<std::size_t>::max();
+
+/** Walks one lane's randomized set in native order, keeping the row one exact plug sits on. */
+struct RollRowScan {
+    std::uint16_t plugDefinitionIndex{};
+    std::size_t row{};
+    std::size_t found{kNoRollRow};
+};
+
+/** Counts one native-order randomized member, recording the row when it names the wanted plug. */
+[[nodiscard]] bool match_roll_row(void* context, std::uint16_t plugDefinitionIndex) noexcept {
+    auto* scan = static_cast<RollRowScan*>(context);
+    if (scan->found == kNoRollRow && plugDefinitionIndex == scan->plugDefinitionIndex) {
+        scan->found = scan->row;
+    }
+    ++scan->row;
+    return true;
+}
+
+/**
+ * Finds the native-order row one plug occupies in one lane's randomized set.
+ * @return The row, or kNoRollRow when the lane has no roll pool or the plug is not in it.
+ */
+[[nodiscard]] std::size_t roll_row_of(std::uint16_t itemDefinitionIndex,
+                                      std::uint8_t lane,
+                                      std::uint16_t plugDefinitionIndex) noexcept {
+    RollRowScan scan{plugDefinitionIndex, 0, kNoRollRow};
+    if (!build_data::visit_socket_roll_pool(itemDefinitionIndex, lane, &match_roll_row, &scan)) {
+        return kNoRollRow;
+    }
+    return scan.found;
+}
+
+/**
+ * Answers whether one lane owns the randomized-set row one plug sits on. A rolled lane's owned
+ * rows are the only route back to the rolled plug: the randomized set is not in the allowed pool.
+ */
+[[nodiscard]] bool owns_roll_row(const authored_inventory::Item& item,
+                                 std::uint16_t itemDefinitionIndex,
+                                 std::uint8_t lane,
+                                 std::uint16_t plugDefinitionIndex) noexcept {
+    if (lane >= item.availablePlugRows.size()
+        || (item.rolledLaneMask & static_cast<std::uint16_t>(1U << lane)) == 0) {
+        return false;
+    }
+    const std::size_t row = roll_row_of(itemDefinitionIndex, lane, plugDefinitionIndex);
+    return row < kRollRowCapacity
+           && (item.availablePlugRows[lane] & (std::uint64_t{1} << row)) != 0;
+}
+
+bool plug_offered_in_lane(const authored_inventory::Item& item,
+                          std::uint16_t itemDefinitionIndex,
+                          std::uint8_t lane,
+                          std::uint16_t plugDefinitionIndex) noexcept {
+    return build_data::is_socket_plug_allowed(itemDefinitionIndex, lane, plugDefinitionIndex)
+           || owns_roll_row(item, itemDefinitionIndex, lane, plugDefinitionIndex);
+}
+
 /** Materializes native initial plugs as a complete authored socket block. */
 [[nodiscard]] bool materialize_native_sockets(const item_details::Definition& detail,
                                               authored_inventory::Sockets& sockets) noexcept {
@@ -154,10 +215,19 @@ void report_socket_plug(std::string_view stage,
         || detail.ordinarySocketCount > authored_inventory::kPlugCapacity
         || !build_data::find_item_definition_index(plugDefinitionIndex, plugDefinition)
         || plugDefinition.definitionIndex != plugDefinitionIndex
-        || plugDefinition.definitionHash == authored_inventory::kNoDefinitionHash
-        || !build_data::is_socket_plug_allowed(
-            targetDefinition.definitionIndex, socketLane, plugDefinitionIndex)) {
+        || plugDefinition.definitionHash == authored_inventory::kNoDefinitionHash) {
         return fail("definition_or_compatibility");
+    }
+
+    // What a lane offers is the curated allowed pool plus, on a rolled lane, the randomized-set
+    // rows this instance owns -- the same two sources the Client's inspection grid walks. Taking
+    // the owned rows keeps the roll reversible: the rolled plug is never in the allowed pool, so
+    // its owned row is the only way back to it after a curated plug is put in its place.
+    const bool rolledLane =
+        (target->rolledLaneMask & static_cast<std::uint16_t>(1U << socketLane)) != 0;
+    if (!plug_offered_in_lane(
+            *target, targetDefinition.definitionIndex, socketLane, plugDefinitionIndex)) {
+        return fail("plug_not_offered");
     }
 
     // Ownership only matters where the plug is a finite supply the account draws down. A shader is
@@ -290,6 +360,18 @@ void report_socket_plug(std::string_view stage,
         return fail("target_copy");
     }
     changed->sockets = authoredSockets;
+    if (rolledLane) {
+        // The lane's pinned socket-entry state names the randomized-set row the hover preview
+        // resolves through, so it must follow the plug that just landed or hover keeps showing
+        // the rolled perk the inspection grid no longer reads. A plug outside the randomized set
+        // has no row to pin: the lane unpins and the entry falls back to its definition state.
+        const std::size_t grantedRollRow = roll_row_of(
+            targetDefinition.definitionIndex, socketLane, grantedDefinition.definitionIndex);
+        changed->rollRowByLane[socketLane] =
+            grantedRollRow < std::numeric_limits<std::uint8_t>::max()
+                ? static_cast<std::uint8_t>(grantedRollRow + 1U)
+                : std::uint8_t{0};
+    }
 
     AccountState candidate = chargedAccount;
     candidate.characters[characterIndex] = after;

--- a/Sunrise/src/state/runtime/state_account_socket_runtime.cpp
+++ b/Sunrise/src/state/runtime/state_account_socket_runtime.cpp
@@ -223,8 +223,6 @@ bool plug_offered_in_lane(const authored_inventory::Item& item,
     // rows this instance owns -- the same two sources the Client's inspection grid walks. Taking
     // the owned rows keeps the roll reversible: the rolled plug is never in the allowed pool, so
     // its owned row is the only way back to it after a curated plug is put in its place.
-    const bool rolledLane =
-        (target->rolledLaneMask & static_cast<std::uint16_t>(1U << socketLane)) != 0;
     if (!plug_offered_in_lane(
             *target, targetDefinition.definitionIndex, socketLane, plugDefinitionIndex)) {
         return fail("plug_not_offered");
@@ -360,18 +358,6 @@ bool plug_offered_in_lane(const authored_inventory::Item& item,
         return fail("target_copy");
     }
     changed->sockets = authoredSockets;
-    if (rolledLane) {
-        // The lane's pinned socket-entry state names the randomized-set row the hover preview
-        // resolves through, so it must follow the plug that just landed or hover keeps showing
-        // the rolled perk the inspection grid no longer reads. A plug outside the randomized set
-        // has no row to pin: the lane unpins and the entry falls back to its definition state.
-        const std::size_t grantedRollRow = roll_row_of(
-            targetDefinition.definitionIndex, socketLane, grantedDefinition.definitionIndex);
-        changed->rollRowByLane[socketLane] =
-            grantedRollRow < std::numeric_limits<std::uint8_t>::max()
-                ? static_cast<std::uint8_t>(grantedRollRow + 1U)
-                : std::uint8_t{0};
-    }
 
     AccountState candidate = chargedAccount;
     candidate.characters[characterIndex] = after;

--- a/Sunrise/src/state/runtime/state_account_transaction_helpers.h
+++ b/Sunrise/src/state/runtime/state_account_transaction_helpers.h
@@ -134,6 +134,16 @@ find_resolved_position(const middleware::datagen::family4::loadout::ResolvedLoad
     std::size_t& movedItemCount) noexcept;
 [[nodiscard]] bool same_character(const CharacterState& left, const CharacterState& right) noexcept;
 /**
+ * Answers whether one exact ordinary socket lane of one instance offers one plug for insertion:
+ * the definition's curated allowed pool, plus the randomized-set rows the instance owns on a
+ * rolled lane. This is the single rule both the lane resolution and the staging apply, so a plug
+ * the inspection grid shows never resolves to no lane.
+ */
+[[nodiscard]] bool plug_offered_in_lane(const account::inventory::Item& item,
+                                        std::uint16_t itemDefinitionIndex,
+                                        std::uint8_t lane,
+                                        std::uint16_t plugDefinitionIndex) noexcept;
+/**
  * @param pinnedPlugHash For a rolled socket's apply or re-roll, the result plug an earlier
  *        staging rolled, so a re-staging reproduces the same after-image; 0 rolls afresh.
  */

--- a/Sunrise/src/state/runtime/state_item_random_roll.cpp
+++ b/Sunrise/src/state/runtime/state_item_random_roll.cpp
@@ -223,10 +223,14 @@ bool roll_random_bytes(authored_inventory::Item& item,
         }
 
         RollPool roll{};
-        (void)build_data::visit_socket_roll_pool(itemDefinition.definitionIndex,
-                                                 static_cast<std::uint8_t>(lane),
-                                                 &collect_roll_member,
-                                                 &roll);
+        if (!build_data::visit_socket_roll_pool(itemDefinition.definitionIndex,
+                                                static_cast<std::uint8_t>(lane),
+                                                &collect_roll_member,
+                                                &roll)) {
+            // A pool wider than the 64 owned-row bits cannot be represented faithfully. The
+            // visitor fails at capacity, so discard its prefix and leave this lane authored.
+            roll = {};
+        }
         // A masterwork socket is an ordinary lane whose allowed pool carries the global
         // masterwork-stat plugs under their ten fixed categories. Its members never join the
         // randomized set, so the roll pool alone cannot see it. One Tier-1 plug per stat family
@@ -249,10 +253,9 @@ bool roll_random_bytes(authored_inventory::Item& item,
 
         // A masterwork lane is authored directly: one random stat's Tier-1 plug from the scanned
         // reusable candidates replaces the definition's initial plug in the lane. Perk lanes are
-        // authored through the randomized set: the Client resolves the lane's socket entry through
-        // a nonzero state N (the 1-based randomized-set row), so Sunrise picks a row r, authors the
-        // instance plug straight out of the same native-order set, and pins the entry state to
-        // r + 1, keeping hover and inspection on the identical rolled perk.
+        // authored from the randomized set's native row order, and the selected row is marked owned
+        // below. The authored plug drives inspection while the owned-row mask drives hover and keeps
+        // the rolled perk reachable after a curated plug replaces it.
         std::uint16_t chosenPlugIndex = 0;
         std::size_t chosenRow = 0;
         std::uint64_t ownedRows = 0;
@@ -337,15 +340,6 @@ bool roll_random_bytes(authored_inventory::Item& item,
         item.availablePlugRows[lane] = ownedRows;
         item.rolledLaneMask |= static_cast<std::uint16_t>(1U << lane);
         ++rolledLanes;
-        // Pin the 1-based row on the socket entry that backs this perk lane so the hover preview
-        // resolves through the same plug set the inspection grid reads. A masterwork lane reads
-        // straight out of the instance and needs no pin. A lane with no matching entry
-        // (kNoSocketEntry) simply never pins -- the safe no-op.
-        const std::uint8_t laneEntry = build_data::socket_entry_index(
-            itemDefinition.definitionIndex, static_cast<std::uint8_t>(lane));
-        if (!masterworkSocket && laneEntry != items::socket_plugs::kNoSocketEntry) {
-            item.rollRowByLane[lane] = static_cast<std::uint8_t>(chosenRow + 1U);
-        }
 
         std::array<char, core::log::kLineCapacity> laneLine{};
         const int laneCount = std::snprintf(
@@ -354,7 +348,7 @@ bool roll_random_bytes(authored_inventory::Item& item,
             "ev=item_roll stage=lane lane=%zu rows=%zu "
             "curated=%zu row=%zu stats=%zu valid=%zu "
             "byte_val=0x%02X socket_type=%u category=0x%08X "
-            "masterwork=%u entry=%u "
+            "masterwork=%u "
             "initial=0x%08X chosen=0x%08X owned_mask=0x%016llX",
             lane,
             roll.count,
@@ -366,13 +360,12 @@ bool roll_random_bytes(authored_inventory::Item& item,
             itemDetail.socketTypes[lane],
             hasInitialPlug ? initialPlug.plugCategoryHash : 0U,
             static_cast<unsigned>(masterworkSocket ? 1U : 0U),
-            static_cast<unsigned>(laneEntry),
             hasInitialPlug ? initialPlug.definitionHash : 0U,
             chosenPlug.definitionHash,
             static_cast<unsigned long long>(item.availablePlugRows[lane]));
         if (laneCount > 0) {
             core::log::write(core::log::Channel::state,
-                             core::log::Level::info,
+                             core::log::Level::debug,
                              {laneLine.data(), static_cast<std::size_t>(laneCount)});
         }
     }
@@ -399,7 +392,7 @@ bool roll_random_bytes(authored_inventory::Item& item,
                                     item.randomRoll[7]);
     if (count > 0) {
         core::log::write(core::log::Channel::state,
-                         core::log::Level::info,
+                         core::log::Level::debug,
                          {line.data(), static_cast<std::size_t>(count)});
     }
     return true;

--- a/Sunrise/src/state/runtime/state_item_random_roll.cpp
+++ b/Sunrise/src/state/runtime/state_item_random_roll.cpp
@@ -1,0 +1,408 @@
+#include "state_item_random_roll.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdio>
+
+#include "../../core/logging/log.h"
+#include "../build_data/runtime.h"
+
+namespace sunrise::state::runtime::detail {
+namespace {
+
+namespace authored_inventory = account::inventory;
+namespace item_details = build_data::items::details;
+namespace items = build_data::items;
+
+/** Cosmetic and mod buckets whose lanes carry an owned choice, never a rolled one. */
+constexpr std::uint8_t kOrnamentBucketId = 13;
+constexpr std::uint8_t kShaderBucketId = 14;
+constexpr std::uint8_t kModBucketId = 37;
+/** One lane offers at most this many plugs before the pool is treated as full. */
+constexpr std::size_t kMaxLaneCandidates = 64;
+/**
+ * Game socket-type index of the trait columns (the manifest's trait socket-type hash
+ * 2614797986, whitelisted plug category 7906839 "frames"). A trait column is retail-shaped:
+ * exactly one owned plug, the rolled trait. Every other rolled lane owns the lane's curated
+ * choices (the manifest's per-socket reusablePlugItems list).
+ */
+constexpr std::uint16_t kTraitSocketType = 92;
+/**
+ * Native equipment slots of the three character weapon slots. The slot numbers are not the
+ * semantic order the UI shows: kinetic is 7, energy 8, heavy 9.
+ */
+constexpr std::int8_t kFirstWeaponEquipmentSlot = 7;
+constexpr std::int8_t kLastWeaponEquipmentSlot = 9;
+
+/**
+ * Only a character weapon carries the randomized perk columns a roll is meant to fill. Armour,
+ * cosmetics and every profile-owned row keep the curated plugs their definition ships with, so
+ * they are refused here rather than in each caller.
+ * @param bucketId Installed inventory bucket of the acquired definition.
+ * @return True when the bucket is one of the three character weapon slots.
+ */
+[[nodiscard]] bool weapon_bucket(std::uint8_t bucketId) noexcept {
+    namespace buckets = build_data::inventory::buckets;
+    buckets::Descriptor descriptor{};
+    if (!build_data::find_inventory_bucket_descriptor(bucketId, descriptor)
+        || descriptor.arraySelector != buckets::ArraySelector::character) {
+        return false;
+    }
+    return descriptor.equipmentSlot >= kFirstWeaponEquipmentSlot
+           && descriptor.equipmentSlot <= kLastWeaponEquipmentSlot;
+}
+
+/**
+ * A lane is rollable only when the plug it ships with is a perk. A shader, an ornament or a mod
+ * is an owned choice the account applies, so rolling one hands out cosmetics and mods the account
+ * never earned and changes the weapon's appearance on every drop.
+ * @param plugDefinitionIndex Installed definition of the lane's initial plug.
+ * @return True when the lane may be rolled.
+ */
+[[nodiscard]] bool is_perk_lane(std::uint16_t plugDefinitionIndex) noexcept {
+    items::Definition plug{};
+    if (!build_data::find_item_definition_index(plugDefinitionIndex, plug)) {
+        return false;
+    }
+    return plug.bucketId != kShaderBucketId && plug.bucketId != kOrnamentBucketId
+           && plug.bucketId != kModBucketId;
+}
+
+/// The ten global masterwork-stat plug categories (one per weapon stat, identical on every
+/// weapon). A masterwork socket's candidates live in its reusable set under these categories,
+/// never in the randomized set, so the roll pool alone cannot see them.
+constexpr std::array<std::uint32_t, 10> kMasterworkStatCategories{
+    199786516U,  // handling
+    482070447U,  // draw time
+    717646604U,  // reload speed
+    1238043140U, // accuracy
+    1392237582U, // range
+    1762223024U, // stability
+    1847616696U, // blast radius
+    2321551094U, // projectile speed
+    2458812152U, // impact
+    2827428737U, // charge time
+};
+
+/** One masterwork socket's Tier-1 stat plugs, at most one per stat family. */
+struct MasterworkScan {
+    std::array<std::uint16_t, kMasterworkStatCategories.size()> candidates{};
+    std::size_t count{};
+    std::uint64_t seenCategories{};
+};
+
+/// Keeps the first Tier-1 plug of every masterwork-stat family the lane's allowed pool carries.
+[[nodiscard]] bool collect_masterwork_candidate(void* context,
+                                                std::uint16_t plugDefinitionIndex) noexcept {
+    auto* scan = static_cast<MasterworkScan*>(context);
+    if (scan->count >= scan->candidates.size()) {
+        return true;
+    }
+    items::Definition plug{};
+    if (!build_data::find_item_definition_index(plugDefinitionIndex, plug)
+        || plug.actionStatValue != 1) {
+        return true;
+    }
+    std::size_t category = kMasterworkStatCategories.size();
+    for (std::size_t index = 0; index < kMasterworkStatCategories.size(); ++index) {
+        if (plug.plugCategoryHash == kMasterworkStatCategories[index]) {
+            category = index;
+            break;
+        }
+    }
+    if (category == kMasterworkStatCategories.size()) {
+        return true;
+    }
+    const std::uint64_t bit = std::uint64_t{1} << category;
+    if ((scan->seenCategories & bit) != 0) {
+        return true;
+    }
+    scan->seenCategories |= bit;
+    scan->candidates[scan->count++] = plugDefinitionIndex;
+    return true;
+}
+
+/** One lane's native-order randomized draw set, kept exactly as the Client indexes it. */
+struct RollPool {
+    std::array<std::uint16_t, kMaxLaneCandidates> indices{};
+    std::size_t count{};
+};
+
+/** Appends one native-order randomized member of one lane's draw set. */
+[[nodiscard]] bool collect_roll_member(void* context, std::uint16_t plugDefinitionIndex) noexcept {
+    auto* pool = static_cast<RollPool*>(context);
+    if (pool->count >= pool->indices.size()) {
+        return false;
+    }
+    pool->indices[pool->count++] = plugDefinitionIndex;
+    return true;
+}
+
+/**
+ * One lane's curated choices: the allowed pool (embedded + reusable + initial), i.e. the
+ * manifest's per-socket reusablePlugItems list -- the small swappable subset a retail drop
+ * offers for insertion. The randomized roll set is interned separately and never offers.
+ */
+struct CuratedScan {
+    std::array<std::uint16_t, kMaxLaneCandidates> indices{};
+    std::size_t count{};
+};
+
+/** Appends one curated member of one lane's allowed pool. */
+[[nodiscard]] bool collect_curated_member(void* context,
+                                          std::uint16_t plugDefinitionIndex) noexcept {
+    auto* scan = static_cast<CuratedScan*>(context);
+    if (scan->count >= scan->indices.size()) {
+        return false;
+    }
+    scan->indices[scan->count++] = plugDefinitionIndex;
+    return true;
+}
+
+/** SplitMix64 finalizer, which decorrelates neighbouring seeds into unrelated byte lanes. */
+[[nodiscard]] std::uint64_t mix(std::uint64_t value) noexcept {
+    value += 0x9E3779B97F4A7C15ULL;
+    value = (value ^ (value >> 30U)) * 0xBF58476D1CE4E5B9ULL;
+    value = (value ^ (value >> 27U)) * 0x94D049BB133111EBULL;
+    return value ^ (value >> 31U);
+}
+
+} // namespace
+
+bool roll_random_bytes(authored_inventory::Item& item,
+                       const items::Definition& itemDefinition,
+                       const item_details::Definition& itemDetail,
+                       std::uint64_t seed) noexcept {
+    if (itemDetail.ordinarySocketState != item_details::OrdinarySocketState::present
+        || itemDetail.ordinarySocketCount == 0) {
+        return false;
+    }
+    if (!weapon_bucket(itemDefinition.bucketId)) {
+        return false;
+    }
+    // An exotic ships one authored roll, so leaving its bytes zero is the correct outcome.
+    if (itemDefinition.tier == static_cast<std::uint8_t>(items::Tier::exotic)) {
+        return false;
+    }
+    // Every refusal has to come before the bytes are written. A refused item keeps the curated
+    // native defaults, and roll bytes left on it would have the Client randomize its sockets from
+    // entropy no authored plug agrees with.
+    if (itemDetail.ordinarySocketCount > authored_inventory::kPlugCapacity) {
+        return false;
+    }
+
+    // The instance is folded in after the caller's seed is mixed, never XORed into it raw. A
+    // caller that already put the instance in its seed would otherwise cancel it back out and
+    // leave the roll keyed on the seed's remaining entropy alone.
+    std::uint64_t stream = mix(mix(seed) ^ item.instanceSoid);
+    for (std::size_t index = 0; index < item.randomRoll.size(); ++index) {
+        stream = mix(stream ^ (static_cast<std::uint64_t>(index) << 56U));
+        // The high byte carries the most avalanche, so it is the one worth keeping.
+        item.randomRoll[index] = static_cast<std::uint8_t>(stream >> 56U);
+    }
+
+    // The Client reads an occupied socket lane straight out and never consults that lane's plug
+    // set, and it leaves an empty lane empty rather than filling it from the set. So the plug has
+    // to be authored here: every lane offering more than one plug takes a rolled pick and every
+    // fixed lane keeps its authored plug. Sockets with no initial plug in definition (0xFFFF) are
+    // populated from their plug pool.
+    authored_inventory::Sockets sockets{};
+    sockets.policy = authored_inventory::SocketPolicy::authored;
+    sockets.plugCount = itemDetail.ordinarySocketCount;
+    std::uint32_t rolledLanes = 0;
+    item.rolledLaneMask = 0;
+    for (std::size_t lane = 0; lane < itemDetail.ordinarySocketCount; ++lane) {
+        const std::uint16_t initialPlugIndex = itemDetail.initialPlugIndices[lane];
+        items::Definition initialPlug{};
+        const bool hasInitialPlug =
+            initialPlugIndex != item_details::kUnavailableItemIndex
+            && build_data::find_item_definition_index(initialPlugIndex, initialPlug);
+
+        if (hasInitialPlug) {
+            sockets.plugs[lane] = initialPlug.definitionHash;
+        }
+
+        RollPool roll{};
+        (void)build_data::visit_socket_roll_pool(itemDefinition.definitionIndex,
+                                                 static_cast<std::uint8_t>(lane),
+                                                 &collect_roll_member,
+                                                 &roll);
+        // A masterwork socket is an ordinary lane whose allowed pool carries the global
+        // masterwork-stat plugs under their ten fixed categories. Its members never join the
+        // randomized set, so the roll pool alone cannot see it. One Tier-1 plug per stat family
+        // is collected; the rolled pick among the weapon-valid ones is the drop's masterwork
+        // stat.
+        MasterworkScan masterworkScan{};
+        (void)build_data::visit_socket_plug_pool(itemDefinition.definitionIndex,
+                                                 static_cast<std::uint8_t>(lane),
+                                                 &collect_masterwork_candidate,
+                                                 &masterworkScan);
+        const bool masterworkSocket = masterworkScan.count != 0;
+        if (!masterworkSocket) {
+            if (roll.count < 1) {
+                continue;
+            }
+            if (hasInitialPlug && !is_perk_lane(initialPlugIndex)) {
+                continue;
+            }
+        }
+
+        // A masterwork lane is authored directly: one random stat's Tier-1 plug from the scanned
+        // reusable candidates replaces the definition's initial plug in the lane. Perk lanes are
+        // authored through the randomized set: the Client resolves the lane's socket entry through
+        // a nonzero state N (the 1-based randomized-set row), so Sunrise picks a row r, authors the
+        // instance plug straight out of the same native-order set, and pins the entry state to
+        // r + 1, keeping hover and inspection on the identical rolled perk.
+        std::uint16_t chosenPlugIndex = 0;
+        std::size_t chosenRow = 0;
+        std::uint64_t ownedRows = 0;
+        std::size_t curatedCount = 0;
+        // Retail restricts a masterwork stat to one the weapon itself declares: the manifest
+        // carries all ten stat families in every weapon's reusable masterwork pool, yet a scout
+        // never rolls Velocity and a launcher never rolls Impact. The candidates are narrowed
+        // to plugs whose boosted stat row sits in the weapon's own stat block before the pick.
+        std::size_t validCount = 0;
+        std::array<std::uint16_t, kMasterworkStatCategories.size()> validCandidates{};
+        // The declared count is a byte and the stat block is fixed, so the walk takes whichever
+        // is smaller rather than trusting a detail row that outran its own array.
+        const std::size_t statCount = itemDetail.statCount < itemDetail.stats.size()
+                                          ? itemDetail.statCount
+                                          : itemDetail.stats.size();
+        if (masterworkSocket) {
+            for (std::size_t index = 0; index < masterworkScan.count; ++index) {
+                items::Definition plug{};
+                if (!build_data::find_item_definition_index(masterworkScan.candidates[index], plug)
+                    || plug.actionStatRow == item_details::kEmptyStatRow) {
+                    continue;
+                }
+                for (std::size_t stat = 0; stat < statCount; ++stat) {
+                    if (itemDetail.stats[stat].row == plug.actionStatRow) {
+                        validCandidates[validCount++] = masterworkScan.candidates[index];
+                        break;
+                    }
+                }
+            }
+            if (validCount == 0) {
+                // No stat the weapon declares is masterworkable: keep the definition's default
+                // plug rather than authoring an invalid one, the safe-skip outcome.
+                continue;
+            }
+            const std::size_t pick =
+                lane < item.randomRoll.size()
+                    ? static_cast<std::size_t>(item.randomRoll[lane] % validCount)
+                    : (stream = mix(stream ^ (static_cast<std::uint64_t>(lane) << 32U)),
+                       static_cast<std::size_t>(stream % validCount));
+            chosenPlugIndex = validCandidates[pick];
+            // No owned rows: the client renders the lane's plug directly and never offers the
+            // masterwork stat for insertion, matching retail drops.
+            ownedRows = 0;
+        } else {
+            chosenRow = lane < item.randomRoll.size()
+                            ? static_cast<std::size_t>(item.randomRoll[lane] % roll.count)
+                            : (stream = mix(stream ^ (static_cast<std::uint64_t>(lane) << 32U)),
+                               static_cast<std::size_t>(stream % roll.count));
+            // Retail column shape. A trait column owns exactly one plug -- the rolled trait.
+            // Every other rolled lane (barrel, magazine, sight, ...) owns the rolled pick plus
+            // the lane's curated choices -- the manifest's per-socket reusablePlugItems list, the
+            // small swappable subset the definition publishes. The pick must always be set: the
+            // hover renders the owned rows and must agree with the plug the inspection grid
+            // reads, and the definition's initial plug stays offered when it lives in the set.
+            ownedRows = std::uint64_t{1} << chosenRow;
+            if (itemDetail.socketTypes[lane] != kTraitSocketType) {
+                // The allowed pool is now the curated offer set (embedded + reusable +
+                // initial). Mark every curated member that also sits in the randomized set
+                // as owned alongside the pick; a curated-only member has no roll row to own.
+                CuratedScan curated{};
+                (void)build_data::visit_socket_plug_pool(itemDefinition.definitionIndex,
+                                                         static_cast<std::uint8_t>(lane),
+                                                         &collect_curated_member,
+                                                         &curated);
+                curatedCount = curated.count;
+                for (std::size_t index = 0; index < curated.count; ++index) {
+                    for (std::size_t row = 0; row < roll.count; ++row) {
+                        if (roll.indices[row] == curated.indices[index]) {
+                            ownedRows |= std::uint64_t{1} << row;
+                            break;
+                        }
+                    }
+                }
+            }
+            chosenPlugIndex = roll.indices[chosenRow];
+        }
+        items::Definition chosenPlug{};
+        if (!build_data::find_item_definition_index(chosenPlugIndex, chosenPlug)) {
+            continue;
+        }
+        sockets.plugs[lane] = chosenPlug.definitionHash;
+        item.availablePlugRows[lane] = ownedRows;
+        item.rolledLaneMask |= static_cast<std::uint16_t>(1U << lane);
+        ++rolledLanes;
+        // Pin the 1-based row on the socket entry that backs this perk lane so the hover preview
+        // resolves through the same plug set the inspection grid reads. A masterwork lane reads
+        // straight out of the instance and needs no pin. A lane with no matching entry
+        // (kNoSocketEntry) simply never pins -- the safe no-op.
+        const std::uint8_t laneEntry = build_data::socket_entry_index(
+            itemDefinition.definitionIndex, static_cast<std::uint8_t>(lane));
+        if (!masterworkSocket && laneEntry != items::socket_plugs::kNoSocketEntry) {
+            item.rollRowByLane[lane] = static_cast<std::uint8_t>(chosenRow + 1U);
+        }
+
+        std::array<char, core::log::kLineCapacity> laneLine{};
+        const int laneCount = std::snprintf(
+            laneLine.data(),
+            laneLine.size(),
+            "ev=item_roll stage=lane lane=%zu rows=%zu "
+            "curated=%zu row=%zu stats=%zu valid=%zu "
+            "byte_val=0x%02X socket_type=%u category=0x%08X "
+            "masterwork=%u entry=%u "
+            "initial=0x%08X chosen=0x%08X owned_mask=0x%016llX",
+            lane,
+            roll.count,
+            curatedCount,
+            chosenRow,
+            masterworkScan.count,
+            validCount,
+            static_cast<unsigned>(lane < item.randomRoll.size() ? item.randomRoll[lane] : 0U),
+            itemDetail.socketTypes[lane],
+            hasInitialPlug ? initialPlug.plugCategoryHash : 0U,
+            static_cast<unsigned>(masterworkSocket ? 1U : 0U),
+            static_cast<unsigned>(laneEntry),
+            hasInitialPlug ? initialPlug.definitionHash : 0U,
+            chosenPlug.definitionHash,
+            static_cast<unsigned long long>(item.availablePlugRows[lane]));
+        if (laneCount > 0) {
+            core::log::write(core::log::Channel::state,
+                             core::log::Level::info,
+                             {laneLine.data(), static_cast<std::size_t>(laneCount)});
+        }
+    }
+    item.sockets = sockets;
+
+    std::array<char, core::log::kLineCapacity> line{};
+    const int count = std::snprintf(line.data(),
+                                    line.size(),
+                                    "ev=item_roll stage=random_bytes result=ok instance=0x%llX "
+                                    "weapon=0x%08X seed=0x%llX rolled_lanes=%u lanes=%u "
+                                    "bytes=%02X%02X%02X%02X%02X%02X%02X%02X",
+                                    static_cast<unsigned long long>(item.instanceSoid),
+                                    itemDefinition.definitionHash,
+                                    static_cast<unsigned long long>(seed),
+                                    rolledLanes,
+                                    itemDetail.ordinarySocketCount,
+                                    item.randomRoll[0],
+                                    item.randomRoll[1],
+                                    item.randomRoll[2],
+                                    item.randomRoll[3],
+                                    item.randomRoll[4],
+                                    item.randomRoll[5],
+                                    item.randomRoll[6],
+                                    item.randomRoll[7]);
+    if (count > 0) {
+        core::log::write(core::log::Channel::state,
+                         core::log::Level::info,
+                         {line.data(), static_cast<std::size_t>(count)});
+    }
+    return true;
+}
+
+} // namespace sunrise::state::runtime::detail

--- a/Sunrise/src/state/runtime/state_item_random_roll.h
+++ b/Sunrise/src/state/runtime/state_item_random_roll.h
@@ -9,23 +9,19 @@
 namespace sunrise::state::runtime::detail {
 
 /**
- * Gives one item instance the per-instance entropy the Client reduces into a plug choice for
- * every socket whose plug set is randomized.
+ * Authors one eligible weapon instance's random bytes, rolled ordinary-socket plugs, masterwork,
+ * and owned-row offer masks from the installed build-data catalogs.
  *
- * The Client owns the choice: for a socket entry with no explicit state it takes one random-roll
- * byte, picked by that entry's own selector byte, modulo the entry's plug set row count. Leaving
- * the bytes zero pins every randomized socket to its plug set's first row, which is what a caller
- * that wants one exact curated roll gets by not calling this.
- *
- * Every refusal happens before the item is touched, so a refused item keeps the curated native
- * defaults whole. An item is refused when it is not a character weapon, when it is an exotic
- * (which ships one authored roll), or when it declares no usable ordinary socket block.
+ * Every item-level refusal happens before the item is touched, so a refused item keeps the curated
+ * native defaults whole. Non-weapons, exotics, and definitions without a usable ordinary socket
+ * block are refused. Individual malformed or unrepresentable lanes safely retain their authored
+ * plug while other valid lanes may still roll.
  *
  * @param item Authored item instance updated in place.
  * @param itemDefinition Base item definition, used to gate on bucket and tier.
- * @param itemDetail Base item detail, used to skip items with no ordinary socket block.
+ * @param itemDetail Base item detail, socket, and stat data used to author the roll.
  * @param seed 64-bit entropy seed, mixed before the instance is folded in.
- * @return True when the item received random-roll bytes.
+ * @return True when the item passed the item-level gates and received random-roll state.
  */
 [[nodiscard]] bool roll_random_bytes(account::inventory::Item& item,
                                      const build_data::items::Definition& itemDefinition,

--- a/Sunrise/src/state/runtime/state_item_random_roll.h
+++ b/Sunrise/src/state/runtime/state_item_random_roll.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cstdint>
+
+#include "../account/inventory/inventory_state.h"
+#include "../build_data/items/details/definition.h"
+#include "../build_data/items/item_catalog.h"
+
+namespace sunrise::state::runtime::detail {
+
+/**
+ * Gives one item instance the per-instance entropy the Client reduces into a plug choice for
+ * every socket whose plug set is randomized.
+ *
+ * The Client owns the choice: for a socket entry with no explicit state it takes one random-roll
+ * byte, picked by that entry's own selector byte, modulo the entry's plug set row count. Leaving
+ * the bytes zero pins every randomized socket to its plug set's first row, which is what a caller
+ * that wants one exact curated roll gets by not calling this.
+ *
+ * Every refusal happens before the item is touched, so a refused item keeps the curated native
+ * defaults whole. An item is refused when it is not a character weapon, when it is an exotic
+ * (which ships one authored roll), or when it declares no usable ordinary socket block.
+ *
+ * @param item Authored item instance updated in place.
+ * @param itemDefinition Base item definition, used to gate on bucket and tier.
+ * @param itemDetail Base item detail, used to skip items with no ordinary socket block.
+ * @param seed 64-bit entropy seed, mixed before the instance is folded in.
+ * @return True when the item received random-roll bytes.
+ */
+[[nodiscard]] bool roll_random_bytes(account::inventory::Item& item,
+                                     const build_data::items::Definition& itemDefinition,
+                                     const build_data::items::details::Definition& itemDetail,
+                                     std::uint64_t seed) noexcept;
+
+} // namespace sunrise::state::runtime::detail


### PR DESCRIPTION
## Summary

Adds server-authored random rolls for eligible non-exotic weapons acquired into a character inventory.

- Separates each socket lane's curated offer set from its native-order randomized draw pool.
- Authors rolled perk plugs, weapon-valid Tier-1 masterworks, random-roll bytes, and per-instance owned-row masks.
- Keeps rolled plugs reachable after curated socket swaps through one shared offer rule.
- Corrects hover rendering after the native socket-mask rebuild so hover and inspection show the same rolled perk.
- Leaves armour, cosmetics, profile-owned rows, exotics, and shader/ornament/mod lanes on their authored definitions.

## Socket relations

A lane's embedded, reusable, and initial plugs form its small curated insertion set. The randomized set is stored separately in native row order and is used only as the draw pool. An instance publishes the randomized rows it owns; the rolled pick's bit is always retained.

Trait columns own exactly the rolled trait. Other rolled lanes own the rolled pick plus curated members that share rows with the randomized set.

## Safety and validation

- Item-level refusal happens before mutation.
- Randomized pools wider than the 64 representable owned-row bits fail closed instead of truncating.
- Socket validation and staging share the same curated-plus-owned offer rule.
- Socket-entry state is not used to pin rolls; hover/inspection agreement comes from the authored plug and `availablePlugRows`.
- Cache format is bumped from 44 to 50, including invalidation of stale version-49 curated-pool extraction.
- Detailed roll telemetry is debug-level.

## Scope

This PR implements randomized item acquisition. It does not include the local Player-panel drop button used for live testing or the future engram/world-drop producer.

The current Collections UI only submits reacquirable fixed/non-randomized definitions, so this does not make blocked randomized Collection gear pullable.

## Validation

- Repeated local test acquisitions produced distinct rolls.
- Hover and inspection matched without socket-entry pinning.
- Curated socket swaps remained reversible.
- Native Visual Studio MSBuild/MSVC, Release x64, toolset v145, `/W4 /WX`.

## Notes

No copyrighted data is included. Plug sets, socket rows, and item stats are extracted from the installed runtime build data. The remaining literals are identifiers and native index constants consistent with existing project style.
