### PR TITLE
Extract activity titles and native uses for Activity Override

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Destiny 2 Offline Exploration Mod
 - Exploration Features (Fly, Noclip, Activity Override, ...)
 - Basic Inventory Management
 
+Activity Override also shows package-derived activity titles and known activity types when
+available. See [Activity metadata](docs/activity-metadata.md) for usage, data contracts, and tests.
+
 ## WIP
 
 This mod is a work in progress. Things might break or work in unexpected ways. There is also currently

--- a/Sunrise/Sunrise.vcxproj
+++ b/Sunrise/Sunrise.vcxproj
@@ -442,6 +442,8 @@
     <ClCompile Include="src\state\build_data\runtime\build_data_roster_runtime.cpp" />
     <ClCompile Include="src\client\content\scenarios\scenario_build.cpp" />
     <ClCompile Include="src\client\content\scenarios\scenario_collect.cpp" />
+    <ClCompile Include="src\client\content\scenarios\scenario_activity_labels.cpp" />
+    <ClCompile Include="src\client\content\scenarios\scenario_activity_types.cpp" />
     <ClCompile Include="src\client\content\spawn_sets\spawn_set_build.cpp" />
     <ClCompile Include="src\client\content\hash_names\hash_name_build.cpp" />
     <ClCompile Include="src\client\content\hash_names\hash_name_matcher.cpp" />
@@ -611,7 +613,10 @@
     <ClCompile Include="src\middleware\content\packages\reader\package_header.cpp" />
     <ClCompile Include="src\middleware\content\packages\tables\bubble_state_reader.cpp" />
     <ClCompile Include="src\middleware\content\packages\tables\definition_index_table.cpp" />
+    <ClCompile Include="src\middleware\content\packages\tables\activity_metadata_reader.cpp" />
+    <ClCompile Include="src\middleware\content\packages\tables\activity_type_mapping.cpp" />
     <ClCompile Include="src\middleware\content\packages\tables\item_definition_reader.cpp" />
+    <ClCompile Include="src\middleware\content\packages\tables\localized_string_reader.cpp" />
     <ClCompile Include="src\middleware\content\packages\tables\region_reader.cpp" />
     <ClCompile Include="src\middleware\content\packages\tables\roster_intersection.cpp" />
     <ClCompile Include="src\middleware\content\packages\tables\scenario_reader.cpp" />
@@ -1275,8 +1280,12 @@
     <ClInclude Include="src\middleware\content\packages\reader\package_table_cache.h" />
     <ClInclude Include="src\middleware\content\packages\tables\ability_pool_reader.h" />
     <ClInclude Include="src\middleware\content\packages\tables\bubble_state_reader.h" />
+    <ClInclude Include="src\middleware\content\packages\tables\activity_metadata_reader.h" />
+    <ClInclude Include="src\middleware\content\packages\tables\activity_type_mapping.h" />
+    <ClInclude Include="src\client\content\scenarios\activity_type_build.h" />
     <ClInclude Include="src\middleware\content\packages\tables\internal.h" />
     <ClInclude Include="src\middleware\content\packages\tables\items.h" />
+    <ClInclude Include="src\middleware\content\packages\tables\localized_string_reader.h" />
     <ClInclude Include="src\middleware\content\packages\tables\region_reader.h" />
     <ClInclude Include="src\middleware\content\packages\tables\roster_intersection.h" />
     <ClInclude Include="src\middleware\content\packages\tables\scenario_reader.h" />

--- a/Sunrise/src/client/content/items/packages/package_item_build.cpp
+++ b/Sunrise/src/client/content/items/packages/package_item_build.cpp
@@ -80,11 +80,11 @@ bool build() noexcept {
         report(0, reason);
         return false;
     }
-    // The destination layouts and the spawn sets share this pass's directory, keys, and block
-    // storage. Both are independent of the item table, so a failure here leaves it alone.
+    // Destination metadata, spawn sets, and hash names share this pass's reader storage. Activity
+    // uses also read the investment root once located below; none depends on the item table.
     {
         const reader::Source packageSource{directory.chars.data(), &keys};
-        (void)content::scenarios::build(packageSource, storage.scratch);
+        (void)content::scenarios::build(packageSource, storage.scratch, storage.root);
         (void)content::spawn_sets::build(packageSource, storage.scratch);
         (void)content::hash_names::build(packageSource, storage.scratch);
     }

--- a/Sunrise/src/client/content/scenarios/activity_type_build.h
+++ b/Sunrise/src/client/content/scenarios/activity_type_build.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "../../../middleware/content/packages/reader/reader.h"
+#include "../../../middleware/content/packages/tables/activity_metadata_reader.h"
+#include "../../../middleware/content/packages/tables/activity_type_mapping.h"
+#include "../../../state/build_data/scenarios/definition.h"
+
+namespace sunrise::client::content::scenarios {
+
+/** Fixed pass storage, owned by the existing scenario worker and kept off its stack. */
+struct ActivityTypeStorage {
+    std::vector<std::byte> activities{};
+    std::vector<std::byte> nativeTypes{};
+    std::vector<std::byte> uiTypes{};
+    std::vector<std::byte> registry{};
+    std::vector<std::byte> header{};
+    std::vector<std::byte> language{};
+    middleware::content::packages::tables::Array activityArray{};
+    middleware::content::packages::tables::Array nativeTypeArray{};
+    middleware::content::packages::tables::Array uiTypeArray{};
+    std::array<state::build_data::scenarios::ActivityUse,
+               middleware::content::packages::tables::kActivityTypeCapacity>
+        types{};
+    std::array<middleware::content::packages::tables::ActivityGraphNode,
+               middleware::content::packages::tables::kActivityIndexCapacity>
+        nodes{};
+    std::array<std::uint16_t, middleware::content::packages::tables::kActivityPlaylistEdgeCapacity>
+        edges{};
+    std::size_t edgeCount{};
+    std::array<std::uint8_t, middleware::content::packages::tables::kActivityIndexCapacity>
+        visited{};
+    std::array<std::uint16_t, middleware::content::packages::tables::kActivityIndexCapacity>
+        queue{};
+    std::array<std::uint8_t, state::build_data::scenarios::kDefinitionCapacity> reachable{};
+    /** Evidence flags for each scenario/native type pair, before publishing stable hash keys. */
+    std::array<
+        std::array<std::uint8_t, middleware::content::packages::tables::kActivityTypeCapacity>,
+        state::build_data::scenarios::kDefinitionCapacity>
+        uses{};
+    std::size_t typeCursor{};
+    std::size_t activityCursor{};
+    std::size_t playlistCursor{};
+    std::size_t namesDecoded{};
+    std::size_t nameFailures{};
+    std::size_t directScenarios{};
+    std::size_t mappedScenarios{};
+    std::size_t overflowScenarios{};
+    std::size_t playlists{};
+    std::uint32_t uiRootTag{};
+    std::size_t uiRootCount{};
+    bool loaded{};
+    bool uiLoaded{};
+    bool built{};
+};
+
+/**
+ * Resolves direct and playlist activity uses within bounded scenario-worker slices.
+ * @param source Installed package directory and borrowed block keys.
+ * @param scratch Existing package-reader scratch.
+ * @param investmentRoot Root already resolved by the shared investment extraction pass.
+ * @param storage Persistent pass storage, never retaining keys or borrowed package views.
+ * @param rows Compacted live scenario rows, unchanged except for their activity-use metadata.
+ * @return True when extraction finishes, including a diagnosed fallback to unclassified rows.
+ */
+[[nodiscard]] bool
+build_activity_types(const middleware::content::packages::reader::Source& source,
+                     middleware::content::packages::reader::Scratch& scratch,
+                     std::span<const std::byte> investmentRoot,
+                     ActivityTypeStorage& storage,
+                     std::span<state::build_data::scenarios::Definition> rows) noexcept;
+
+} // namespace sunrise::client::content::scenarios

--- a/Sunrise/src/client/content/scenarios/internal.h
+++ b/Sunrise/src/client/content/scenarios/internal.h
@@ -10,6 +10,7 @@
 #include "../../../middleware/content/packages/tables/roster_intersection.h"
 #include "../../../middleware/content/packages/tables/slot_descriptor_reader.h"
 #include "../../../state/build_data/scenarios/definition.h"
+#include "activity_type_build.h"
 
 namespace sunrise::client::content::scenarios {
 
@@ -73,12 +74,58 @@ inline constexpr std::size_t kLiveTagCapacity = 1'024;
 inline constexpr std::uint64_t kResolveWindowMs = 15'000;
 /** Tag reads one collection call may spend, for the same reason the roster walk is bounded. */
 inline constexpr std::size_t kResolveReadBudget = 150;
+/** Activity metadata tags measured at 468 in the archived package set. */
+inline constexpr std::size_t kActivityTagCapacity = 1'024;
+/** Installed localized-string containers measure 4,489; this keeps bounded headroom. */
+inline constexpr std::size_t kLocalizedStringTagCapacity = 8'192;
+/** Activity or string metadata rows resolved per worker slice before the roster walk resumes. */
+inline constexpr std::size_t kLabelReadBudget = 24;
 
 /** One live scenario tag and the map-package stem of the package that carries it. */
 struct LiveTag {
     std::uint32_t tag{};
     std::array<char, layouts::kSpawnStemCapacity> stem{};
     std::uint8_t stemLength{};
+};
+
+/** Fixed working storage for activity-label extraction. */
+struct ActivityLabelStorage {
+    std::array<std::uint32_t, kActivityTagCapacity> activityTags{};
+    std::size_t activityTagCount{};
+    std::size_t activityCursor{};
+    std::array<std::uint32_t, kLocalizedStringTagCapacity> stringTags{};
+    std::size_t stringTagCount{};
+    std::size_t stringCursor{};
+    /** Player-facing resource hash associated with each row in the caller's compacted span. */
+    std::array<std::uint32_t, layouts::kDefinitionCapacity> displayNameHashes{};
+    /** Rows with two different activity hashes stay unmapped instead of accepting scan order. */
+    std::array<std::uint8_t, layouts::kDefinitionCapacity> ambiguousMappings{};
+    /** Sorted unique resource hashes used to reject irrelevant string rows in logarithmic time. */
+    std::array<std::uint32_t, layouts::kDefinitionCapacity> targetHashes{};
+    std::size_t targetHashCount{};
+    std::vector<std::byte> activity{};
+    std::vector<std::byte> stringHeader{};
+    std::vector<std::byte> languageStrings{};
+    std::size_t activityReadFailures{};
+    std::size_t activityParseFailures{};
+    std::size_t definitionTagFailures{};
+    std::size_t mappingConflicts{};
+    std::size_t stringHeaderReadFailures{};
+    std::size_t stringHeaderParseFailures{};
+    std::size_t languageTagFailures{};
+    std::size_t stringHashFailures{};
+    std::size_t stringDataReadFailures{};
+    std::size_t stringDataParseFailures{};
+    std::size_t labelsRejected{};
+    std::size_t labelsPlaceholders{};
+    std::size_t assigned{};
+    std::size_t conflicts{};
+    bool activityTagOverflow{};
+    bool stringTagOverflow{};
+    bool targetHashesBuilt{};
+    bool activitiesScanned{};
+    bool stringsScanned{};
+    bool built{};
 };
 
 /** One pass of fixed storage, kept off the caller stack. */
@@ -99,6 +146,8 @@ struct Storage {
     /** Tick after which the collection stops waiting for the rows that have not read. */
     std::uint64_t resolveDeadlineTick{};
     std::vector<std::byte> blob{};
+    ActivityLabelStorage labels{};
+    ActivityTypeStorage activityTypes{};
     RosterStorage roster{};
     /** Resolved rows, moved to the front. The roster walk runs over exactly these. */
     std::size_t keptCount{};
@@ -141,6 +190,19 @@ void compact_rows(Storage& storage) noexcept;
  * @param storage Pass storage whose resolve state is cleared.
  */
 void rearm_resolve(Storage& storage) noexcept;
+
+/**
+ * Extracts localized labels for resolved scenario rows.
+ * @param source Installed package source.
+ * @param scratch Lock-owned reader storage.
+ * @param storage Label scan and read state.
+ * @param rows Scenario rows to annotate.
+ * @return True after all discovered tags are attempted.
+ */
+[[nodiscard]] bool build_activity_labels(const reader::Source& source,
+                                         reader::Scratch& scratch,
+                                         ActivityLabelStorage& storage,
+                                         std::span<layouts::Definition> rows) noexcept;
 
 /**
  * Reduces one descriptor's two schemas to the slot flag bits the wire body carries.

--- a/Sunrise/src/client/content/scenarios/scenario_activity_labels.cpp
+++ b/Sunrise/src/client/content/scenarios/scenario_activity_labels.cpp
@@ -1,0 +1,346 @@
+#include <algorithm>
+#include <array>
+#include <cstdio>
+#include <string_view>
+
+#include "../../../core/logging/log.h"
+#include "../../../middleware/content/packages/tables/activity_metadata_reader.h"
+#include "../../../middleware/content/packages/tables/localized_string_reader.h"
+#include "internal.h"
+
+namespace sunrise::client::content::scenarios {
+namespace {
+
+namespace packages = middleware::content::packages;
+namespace tables = packages::tables;
+
+/** Resource-hash sentinel used when content intentionally carries no player-facing text. */
+constexpr std::uint32_t kAbsentResourceHash = 0x811C9DC5U;
+/** Records one activity metadata tag discovered by the class sweep. */
+bool collect_activity(void* context, std::uint32_t tag) noexcept {
+    auto& storage = *static_cast<ActivityLabelStorage*>(context);
+    if (storage.activityTagCount >= storage.activityTags.size()) {
+        storage.activityTagOverflow = true;
+        return false;
+    }
+    storage.activityTags[storage.activityTagCount++] = tag;
+    return true;
+}
+
+/** Records one installed localized-string container. */
+bool collect_strings(void* context, std::uint32_t tag) noexcept {
+    auto& storage = *static_cast<ActivityLabelStorage*>(context);
+    if (storage.stringTagCount >= storage.stringTags.size()) {
+        storage.stringTagOverflow = true;
+        return false;
+    }
+    storage.stringTags[storage.stringTagCount++] = tag;
+    return true;
+}
+
+/** @return One row's bounded player-facing label. */
+[[nodiscard]] std::string_view label_of(const layouts::Definition& row) noexcept {
+    return {row.activityLabel.data(), row.activityLabelLength};
+}
+
+/** @return True when extraction completed with a malformed, ambiguous, or unreadable input. */
+[[nodiscard]] bool partial(const ActivityLabelStorage& storage) noexcept {
+    return storage.activityReadFailures != 0 || storage.activityParseFailures != 0
+           || storage.definitionTagFailures != 0 || storage.mappingConflicts != 0
+           || storage.stringHeaderReadFailures != 0 || storage.stringHeaderParseFailures != 0
+           || storage.languageTagFailures != 0 || storage.stringHashFailures != 0
+           || storage.stringDataReadFailures != 0 || storage.stringDataParseFailures != 0
+           || storage.labelsRejected != 0 || storage.conflicts != 0;
+}
+
+/** Reports the complete bounded extraction result. */
+void report(const ActivityLabelStorage& storage, const char* result, bool warning) noexcept {
+    std::array<char, core::log::kLineCapacity> line{};
+    const int written = std::snprintf(
+        line.data(),
+        line.size(),
+        "ev=build_data stage=activity_labels activities=%zu strings=%zu targets=%zu assigned=%zu "
+        "read_fail=%zu parse_fail=%zu tag_fail=%zu map_conflicts=%zu header_read_fail=%zu "
+        "header_parse_fail=%zu language_fail=%zu hash_fail=%zu data_read_fail=%zu "
+        "data_parse_fail=%zu rejected=%zu placeholders=%zu label_conflicts=%zu result=%s",
+        storage.activityTagCount,
+        storage.stringTagCount,
+        storage.targetHashCount,
+        storage.assigned,
+        storage.activityReadFailures,
+        storage.activityParseFailures,
+        storage.definitionTagFailures,
+        storage.mappingConflicts,
+        storage.stringHeaderReadFailures,
+        storage.stringHeaderParseFailures,
+        storage.languageTagFailures,
+        storage.stringHashFailures,
+        storage.stringDataReadFailures,
+        storage.stringDataParseFailures,
+        storage.labelsRejected,
+        storage.labelsPlaceholders,
+        storage.conflicts,
+        result);
+    if (written > 0) {
+        core::log::write(
+            core::log::Channel::state,
+            warning ? core::log::Level::warn : core::log::Level::info,
+            {line.data(), (std::min)(static_cast<std::size_t>(written), line.size() - 1)});
+    }
+}
+
+/** Associates one activity's display-name hash with the scenario tag it references. */
+void resolve_activity(const reader::Source& source,
+                      reader::Scratch& scratch,
+                      std::uint32_t tag,
+                      ActivityLabelStorage& storage,
+                      std::span<layouts::Definition> rows) noexcept {
+    if (!reader::read_tag(source, scratch, tag, storage.activity)) {
+        ++storage.activityReadFailures;
+        return;
+    }
+    tables::ActivityMetadata activity{};
+    if (!tables::activity_metadata(storage.activity, activity)) {
+        ++storage.activityParseFailures;
+        return;
+    }
+    if (activity.displayNameHash == 0 || activity.displayNameHash == kAbsentResourceHash) {
+        return;
+    }
+    for (std::uint64_t index = 0; index < activity.definitionTags.count; ++index) {
+        std::uint32_t definitionTag = 0;
+        if (!tables::activity_definition_tag_at(storage.activity, activity, index, definitionTag)) {
+            ++storage.definitionTagFailures;
+            continue;
+        }
+        for (std::size_t row = 0; row < rows.size(); ++row) {
+            if (rows[row].tag != definitionTag) {
+                continue;
+            }
+            if (storage.ambiguousMappings[row] != 0) {
+                continue;
+            }
+            if (storage.displayNameHashes[row] == 0) {
+                storage.displayNameHashes[row] = activity.displayNameHash;
+            } else if (storage.displayNameHashes[row] != activity.displayNameHash) {
+                storage.displayNameHashes[row] = 0;
+                storage.ambiguousMappings[row] = 1;
+                ++storage.mappingConflicts;
+            }
+        }
+    }
+}
+
+/** Builds the sorted unique set used to reject irrelevant localized-string rows. */
+void build_target_hashes(ActivityLabelStorage& storage,
+                         std::span<const layouts::Definition> rows) noexcept {
+    storage.targetHashes = {};
+    storage.targetHashCount = 0;
+    for (std::size_t row = 0; row < rows.size(); ++row) {
+        const std::uint32_t hash = storage.displayNameHashes[row];
+        if (hash != 0 && storage.targetHashCount < storage.targetHashes.size()) {
+            storage.targetHashes[storage.targetHashCount++] = hash;
+        }
+    }
+    auto targets = std::span(storage.targetHashes).first(storage.targetHashCount);
+    std::sort(targets.begin(), targets.end());
+    storage.targetHashCount =
+        static_cast<std::size_t>(std::unique(targets.begin(), targets.end()) - targets.begin());
+    storage.targetHashesBuilt = true;
+}
+
+/** @return True when at least one unambiguous scenario maps to this resource hash. */
+[[nodiscard]] bool maps_hash(const ActivityLabelStorage& storage, std::uint32_t hash) noexcept {
+    const auto targets = std::span(storage.targetHashes).first(storage.targetHashCount);
+    return std::binary_search(targets.begin(), targets.end(), hash);
+}
+
+/** @return True when a printable ASCII label contains an English letter or decimal digit. */
+[[nodiscard]] bool meaningful_label(std::span<const char> label) noexcept {
+    for (const char value : label) {
+        if ((value >= 'A' && value <= 'Z') || (value >= 'a' && value <= 'z')
+            || (value >= '0' && value <= '9')) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/** Applies one decoded string to every scenario waiting for its resource hash. */
+void assign_label(ActivityLabelStorage& storage,
+                  std::span<layouts::Definition> rows,
+                  std::uint32_t hash,
+                  std::span<const char> label) noexcept {
+    for (std::size_t row = 0; row < rows.size(); ++row) {
+        if (storage.displayNameHashes[row] != hash) {
+            continue;
+        }
+        if (rows[row].activityLabelLength == 0) {
+            std::copy(label.begin(), label.end(), rows[row].activityLabel.begin());
+            rows[row].activityLabelLength = static_cast<std::uint8_t>(label.size());
+            ++storage.assigned;
+        } else if (label_of(rows[row]) != std::string_view(label.data(), label.size())) {
+            rows[row].activityLabel = {};
+            rows[row].activityLabelLength = 0;
+            storage.displayNameHashes[row] = 0;
+            if (storage.assigned != 0) {
+                --storage.assigned;
+            }
+            ++storage.conflicts;
+        }
+    }
+}
+
+/** Searches one installed string container for the activity hashes still missing labels. */
+void resolve_strings(const reader::Source& source,
+                     reader::Scratch& scratch,
+                     std::uint32_t tag,
+                     ActivityLabelStorage& storage,
+                     std::span<layouts::Definition> rows) noexcept {
+    if (!reader::read_tag(source, scratch, tag, storage.stringHeader)) {
+        ++storage.stringHeaderReadFailures;
+        return;
+    }
+    tables::LocalizedStrings strings{};
+    if (!tables::localized_strings(storage.stringHeader, strings)) {
+        ++storage.stringHeaderParseFailures;
+        return;
+    }
+    bool wanted = false;
+    for (std::uint64_t index = 0; index < strings.hashes.count; ++index) {
+        std::uint32_t hash = 0;
+        if (!tables::localized_hash_at(storage.stringHeader, strings, index, hash)) {
+            ++storage.stringHashFailures;
+            return;
+        }
+        wanted = wanted || maps_hash(storage, hash);
+    }
+    if (!wanted) {
+        return;
+    }
+    std::uint32_t languageTag = 0;
+    if (!tables::localized_english_tag(storage.stringHeader, languageTag)) {
+        ++storage.languageTagFailures;
+        return;
+    }
+    if (!reader::read_tag(source, scratch, languageTag, storage.languageStrings)) {
+        ++storage.stringDataReadFailures;
+        return;
+    }
+    std::uint64_t stringCount = 0;
+    if (!tables::localized_string_count(storage.languageStrings, stringCount)
+        || stringCount != strings.hashes.count) {
+        ++storage.stringDataParseFailures;
+        return;
+    }
+    for (std::uint64_t index = 0; index < strings.hashes.count; ++index) {
+        std::uint32_t hash = 0;
+        if (!tables::localized_hash_at(storage.stringHeader, strings, index, hash)) {
+            ++storage.stringHashFailures;
+            return;
+        }
+        if (!maps_hash(storage, hash)) {
+            continue;
+        }
+        std::array<char, layouts::kActivityLabelCapacity> label{};
+        std::uint8_t labelLength = 0;
+        if (!tables::localized_ascii_string_at(
+                storage.languageStrings, index, label, labelLength)) {
+            ++storage.labelsRejected;
+            continue;
+        }
+        const auto text = std::span(label).first(labelLength);
+        if (!meaningful_label(text)) {
+            ++storage.labelsPlaceholders;
+            continue;
+        }
+        assign_label(storage, rows, hash, text);
+    }
+}
+
+/** Releases the dynamic tag-read buffers once the domain is complete. */
+void release_buffers(ActivityLabelStorage& storage) noexcept {
+    storage.activity.clear();
+    storage.activity.shrink_to_fit();
+    storage.stringHeader.clear();
+    storage.stringHeader.shrink_to_fit();
+    storage.languageStrings.clear();
+    storage.languageStrings.shrink_to_fit();
+}
+
+} // namespace
+
+/** Extracts localized activity labels and associates them with scenario rows by definition tag. */
+bool build_activity_labels(const reader::Source& source,
+                           reader::Scratch& scratch,
+                           ActivityLabelStorage& storage,
+                           std::span<layouts::Definition> rows) noexcept {
+    if (storage.built) {
+        return true;
+    }
+    if (!storage.activitiesScanned) {
+        reader::ScanResult scan{};
+        if (!reader::scan_class(source.directory,
+                                tables::kActivityMetadataClass,
+                                &collect_activity,
+                                &storage,
+                                scan)) {
+            storage.built = true;
+            report(storage,
+                   storage.activityTagOverflow ? "activity_capacity" : "activity_sweep",
+                   true);
+            return true;
+        }
+        storage.activitiesScanned = true;
+    }
+    std::size_t reads = 0;
+    while (storage.activityCursor < storage.activityTagCount && reads < kLabelReadBudget) {
+        resolve_activity(
+            source, scratch, storage.activityTags[storage.activityCursor], storage, rows);
+        ++storage.activityCursor;
+        ++reads;
+    }
+    if (storage.activityCursor < storage.activityTagCount) {
+        return false;
+    }
+    if (!storage.targetHashesBuilt) {
+        build_target_hashes(storage, rows);
+    }
+    if (storage.targetHashCount == 0) {
+        release_buffers(storage);
+        storage.built = true;
+        report(storage, partial(storage) ? "partial" : "empty", true);
+        return true;
+    }
+
+    if (!storage.stringsScanned) {
+        reader::ScanResult scan{};
+        if (!reader::scan_class(source.directory,
+                                tables::kLocalizedStringsClass,
+                                &collect_strings,
+                                &storage,
+                                scan)) {
+            storage.built = true;
+            release_buffers(storage);
+            report(storage, storage.stringTagOverflow ? "string_capacity" : "string_sweep", true);
+            return true;
+        }
+        storage.stringsScanned = true;
+    }
+    reads = 0;
+    while (storage.stringCursor < storage.stringTagCount && reads < kLabelReadBudget) {
+        resolve_strings(source, scratch, storage.stringTags[storage.stringCursor], storage, rows);
+        ++storage.stringCursor;
+        ++reads;
+    }
+    if (storage.stringCursor < storage.stringTagCount) {
+        return false;
+    }
+    release_buffers(storage);
+    storage.built = true;
+    const bool incomplete = partial(storage);
+    report(storage, incomplete ? "partial" : "ok", incomplete);
+    return true;
+}
+
+} // namespace sunrise::client::content::scenarios

--- a/Sunrise/src/client/content/scenarios/scenario_activity_types.cpp
+++ b/Sunrise/src/client/content/scenarios/scenario_activity_types.cpp
@@ -1,0 +1,340 @@
+#include <algorithm>
+#include <cstdio>
+#include <string_view>
+
+#include "../../../core/logging/log.h"
+#include "../../../middleware/content/packages/tables/localized_string_reader.h"
+#include "activity_type_build.h"
+
+namespace sunrise::client::content::scenarios {
+namespace {
+
+namespace reader = middleware::content::packages::reader;
+namespace tables = middleware::content::packages::tables;
+namespace layouts = state::build_data::scenarios;
+
+/** Bounds package reads and graph roots per worker slice, keeping shutdown responsive. */
+constexpr std::size_t kTypeReadBudget = 8;
+constexpr std::size_t kActivityWorkBudget = 24;
+constexpr std::uint32_t kAbsentNameHash = 0x811C9DC5U;
+static_assert(layouts::kNameCapacity == tables::kActivityScenarioNameCapacity);
+
+/** Records a UI root, refusing ambiguity instead of choosing the class sweep's first result. */
+bool collect_ui_root(void* context, std::uint32_t tag) noexcept {
+    auto& storage = *static_cast<ActivityTypeStorage*>(context);
+    storage.uiRootTag = tag;
+    return ++storage.uiRootCount == 1;
+}
+
+/** Reads a root reference's blob and checks its package-entry class. */
+[[nodiscard]] bool read_class(const reader::Source& source,
+                              reader::Scratch& scratch,
+                              std::uint32_t tag,
+                              std::uint32_t expectedClass,
+                              std::vector<std::byte>& output) noexcept {
+    std::uint32_t actualClass = 0;
+    return tables::package_of(tag) != tables::kAbsentPackageId
+           && reader::read_tag(source, scratch, tag, output, actualClass)
+           && actualClass == expectedClass;
+}
+
+/** Resolves the separately authored UI root using the existing package class sweep. */
+[[nodiscard]] bool load_ui(const reader::Source& source,
+                           reader::Scratch& scratch,
+                           ActivityTypeStorage& storage) noexcept {
+    reader::ScanResult scan{};
+    if (!reader::scan_class(
+            source.directory, tables::kInvestmentUiRootClass, collect_ui_root, &storage, scan)
+        || storage.uiRootCount != 1
+        || !read_class(
+            source, scratch, storage.uiRootTag, tables::kInvestmentUiRootClass, storage.header)) {
+        return false;
+    }
+    std::uint32_t typeTag = 0;
+    std::uint32_t registryTag = 0;
+    return tables::activity_reference_tag(storage.header, tables::kActivityTypeUiTagOffset, typeTag)
+           && tables::activity_reference_tag(
+               storage.header, tables::kInvestmentStringRegistryTagOffset, registryTag)
+           && read_class(
+               source, scratch, typeTag, tables::kActivityTypeUiTableClass, storage.uiTypes)
+           && tables::activity_types(storage.uiTypes, true, storage.uiTypeArray)
+           && storage.uiTypeArray.count == storage.nativeTypeArray.count
+           && read_class(source,
+                         scratch,
+                         registryTag,
+                         tables::kInvestmentStringRegistryClass,
+                         storage.registry);
+}
+
+/** Reads the authoritative tables through the root already located by the package pass. */
+[[nodiscard]] bool load_tables(const reader::Source& source,
+                               reader::Scratch& scratch,
+                               std::span<const std::byte> root,
+                               ActivityTypeStorage& storage) noexcept {
+    std::uint32_t activityTag = 0;
+    std::uint32_t typeTag = 0;
+    if (!tables::slot_tag(root, tables::kActivityTableSlot, activityTag)
+        || !tables::slot_tag(root, tables::kActivityTypeTableSlot, typeTag)
+        || !read_class(
+            source, scratch, activityTag, tables::kActivityTableClass, storage.activities)
+        || !tables::activity_index(storage.activities, storage.activityArray)
+        || !read_class(
+            source, scratch, typeTag, tables::kActivityTypeTableClass, storage.nativeTypes)
+        || !tables::activity_types(storage.nativeTypes, false, storage.nativeTypeArray)) {
+        return false;
+    }
+    for (std::size_t index = 0; index < storage.nativeTypeArray.count; ++index) {
+        auto& type = storage.types[index];
+        if (!tables::activity_type_hash_at(
+                storage.nativeTypes, storage.nativeTypeArray, index, type.typeHash)
+            || type.typeHash == 0) {
+            return false;
+        }
+        for (std::size_t earlier = 0; earlier < index; ++earlier) {
+            if (storage.types[earlier].typeHash == type.typeHash) {
+                return false;
+            }
+        }
+    }
+    storage.uiLoaded = load_ui(source, scratch, storage);
+    storage.loaded = true;
+    return true;
+}
+
+/** Reads only the referenced English container; equal text is never treated as type identity. */
+[[nodiscard]] bool resolve_type_name(const reader::Source& source,
+                                     reader::Scratch& scratch,
+                                     ActivityTypeStorage& storage,
+                                     std::size_t index) noexcept {
+    tables::ActivityTypeName name{};
+    auto& type = storage.types[index];
+    if (!tables::activity_type_name_at(storage.uiTypes, storage.uiTypeArray, index, name)
+        || name.hash != type.typeHash) {
+        return false;
+    }
+    if (name.containerIndex == 0xFFFFU || name.resourceHash == kAbsentNameHash
+        || name.resourceHash == 0) {
+        return true;
+    }
+    std::uint32_t headerTag = 0;
+    std::uint32_t languageTag = 0;
+    tables::LocalizedStrings strings{};
+    if (!tables::activity_string_container_tag(storage.registry, name.containerIndex, headerTag)
+        || !read_class(source, scratch, headerTag, tables::kLocalizedStringsClass, storage.header)
+        || !tables::localized_strings(storage.header, strings)
+        || !tables::localized_english_tag(storage.header, languageTag)) {
+        return false;
+    }
+    std::uint64_t ordinal = strings.hashes.count;
+    for (std::uint64_t row = 0; row < strings.hashes.count; ++row) {
+        std::uint32_t hash = 0;
+        if (!tables::localized_hash_at(storage.header, strings, row, hash)) {
+            return false;
+        }
+        if (hash == name.resourceHash) {
+            if (ordinal != strings.hashes.count) {
+                return false;
+            }
+            ordinal = row;
+        }
+    }
+    std::uint64_t count = 0;
+    if (ordinal == strings.hashes.count
+        || !reader::read_tag(source, scratch, languageTag, storage.language)
+        || !tables::localized_string_count(storage.language, count) || count != strings.hashes.count
+        || !tables::localized_ascii_string_at(
+            storage.language, ordinal, type.label, type.labelLength)) {
+        return false;
+    }
+    if (type.labelLength != 0) {
+        ++storage.namesDecoded;
+    }
+    return true;
+}
+
+/** Parses one activity and resolves its exact package key against the compacted scenario rows. */
+[[nodiscard]] bool resolve_activity(ActivityTypeStorage& storage,
+                                    std::span<const layouts::Definition> rows,
+                                    std::size_t index) noexcept {
+    tables::ActivityDefinition activity{};
+    if (!tables::activity_definition_at(storage.activities,
+                                        storage.activityArray,
+                                        index,
+                                        storage.nativeTypeArray.count,
+                                        activity)
+        || activity.playlist.count > storage.edges.size() - storage.edgeCount) {
+        return false;
+    }
+    auto& node = storage.nodes[index];
+    node.typeIndex = activity.typeIndex;
+    node.firstChild = static_cast<std::uint32_t>(storage.edgeCount);
+    node.childCount = static_cast<std::uint16_t>(activity.playlist.count);
+    for (std::size_t edge = 0; edge < activity.playlist.count; ++edge) {
+        std::uint16_t child = 0;
+        if (!tables::activity_playlist_child_at(
+                storage.activities, activity.playlist, edge, storage.activityArray.count, child)) {
+            return false;
+        }
+        storage.edges[storage.edgeCount++] = child;
+    }
+    storage.playlists += node.childCount != 0 ? 1U : 0U;
+    for (std::size_t row = 0; row < rows.size(); ++row) {
+        if (activity.scenarioName
+            == std::string_view(rows[row].name.data(), rows[row].nameLength)) {
+            node.scenarioIndex = static_cast<std::uint16_t>(row);
+            storage.uses[row][node.typeIndex] |= layouts::kDirectActivityUse;
+            break;
+        }
+    }
+    return true;
+}
+
+/** Publishes a canonical set per scenario. An overflowing set is wholly unclassified. */
+void assign_uses(ActivityTypeStorage& storage, std::span<layouts::Definition> rows) noexcept {
+    for (std::size_t row = 0; row < rows.size(); ++row) {
+        auto& definition = rows[row];
+        bool direct = false;
+        for (std::size_t index = 0; index < storage.nativeTypeArray.count; ++index) {
+            const std::uint8_t sources = storage.uses[row][index];
+            if (sources == 0) {
+                continue;
+            }
+            direct = direct || (sources & layouts::kDirectActivityUse) != 0;
+            if (definition.activityUseCount == definition.activityUses.size()) {
+                definition.activityUses = {};
+                definition.activityUseCount = 0;
+                ++storage.overflowScenarios;
+                break;
+            }
+            auto& use = definition.activityUses[definition.activityUseCount++];
+            use = storage.types[index];
+            use.sources = sources;
+        }
+        const auto uses = std::span(definition.activityUses).first(definition.activityUseCount);
+        std::sort(uses.begin(), uses.end(), [](const auto& left, const auto& right) noexcept {
+            return left.typeHash < right.typeHash;
+        });
+        storage.directScenarios += direct ? 1U : 0U;
+        storage.mappedScenarios += !uses.empty() ? 1U : 0U;
+    }
+}
+
+/** Reports the result and releases package bytes; bounded graph storage contains no borrowed data.
+ */
+void finish(ActivityTypeStorage& storage, const char* result, bool warning) noexcept {
+    std::array<char, core::log::kLineCapacity> line{};
+    const int written = std::snprintf(
+        line.data(),
+        line.size(),
+        "ev=build_data stage=activity_types activities=%llu parsed=%zu types=%llu ui=%u "
+        "names=%zu name_fail=%zu playlists=%zu edges=%zu direct_scenarios=%zu mapped=%zu "
+        "overflow=%zu result=%s",
+        static_cast<unsigned long long>(storage.activityArray.count),
+        storage.activityCursor,
+        static_cast<unsigned long long>(storage.nativeTypeArray.count),
+        storage.uiLoaded ? 1U : 0U,
+        storage.namesDecoded,
+        storage.nameFailures,
+        storage.playlists,
+        storage.edgeCount,
+        storage.directScenarios,
+        storage.mappedScenarios,
+        storage.overflowScenarios,
+        result);
+    if (written > 0) {
+        core::log::write(
+            core::log::Channel::state,
+            warning ? core::log::Level::warn : core::log::Level::info,
+            {line.data(), (std::min)(static_cast<std::size_t>(written), line.size() - 1)});
+    }
+    for (auto* blob : {&storage.activities,
+                       &storage.nativeTypes,
+                       &storage.uiTypes,
+                       &storage.registry,
+                       &storage.header,
+                       &storage.language}) {
+        blob->clear();
+        blob->shrink_to_fit();
+    }
+    storage.built = true;
+}
+
+} // namespace
+
+bool build_activity_types(const reader::Source& source,
+                          reader::Scratch& scratch,
+                          std::span<const std::byte> investmentRoot,
+                          ActivityTypeStorage& storage,
+                          std::span<layouts::Definition> rows) noexcept {
+    if (storage.built) {
+        return true;
+    }
+    if (rows.size() > layouts::kDefinitionCapacity) {
+        finish(storage, "scenario_capacity", true);
+        return true;
+    }
+    if (!storage.loaded) {
+        // The package pass locates its root after starting the independent scenario pass.
+        if (investmentRoot.empty()) {
+            return false;
+        }
+        if (!load_tables(source, scratch, investmentRoot, storage)) {
+            finish(storage, "tables", true);
+            return true;
+        }
+        return false;
+    }
+    for (std::size_t work = 0;
+         storage.typeCursor < storage.nativeTypeArray.count && work < kTypeReadBudget;
+         ++work, ++storage.typeCursor) {
+        if (storage.uiLoaded && !resolve_type_name(source, scratch, storage, storage.typeCursor)) {
+            storage.types[storage.typeCursor].label = {};
+            storage.types[storage.typeCursor].labelLength = 0;
+            ++storage.nameFailures;
+        }
+    }
+    if (storage.typeCursor < storage.nativeTypeArray.count) {
+        return false;
+    }
+    for (std::size_t work = 0;
+         storage.activityCursor < storage.activityArray.count && work < kActivityWorkBudget;
+         ++work, ++storage.activityCursor) {
+        if (!resolve_activity(storage, rows, storage.activityCursor)) {
+            finish(storage, "activity_or_edges", true);
+            return true;
+        }
+    }
+    if (storage.activityCursor < storage.activityArray.count) {
+        return false;
+    }
+    const auto nodes = std::span(storage.nodes).first(storage.activityCursor);
+    const auto edges = std::span(storage.edges).first(storage.edgeCount);
+    for (std::size_t work = 0; storage.playlistCursor < nodes.size() && work < kActivityWorkBudget;
+         ++work, ++storage.playlistCursor) {
+        const auto& node = nodes[storage.playlistCursor];
+        if (node.childCount == 0) {
+            continue;
+        }
+        const auto reachable = std::span(storage.reachable).first(rows.size());
+        if (!tables::activity_playlist_scenarios(
+                nodes, edges, storage.playlistCursor, reachable, storage.visited, storage.queue)) {
+            finish(storage, "playlist_graph", true);
+            return true;
+        }
+        for (std::size_t row = 0; row < rows.size(); ++row) {
+            if (reachable[row] != 0) {
+                storage.uses[row][node.typeIndex] |= layouts::kPlaylistActivityUse;
+            }
+        }
+    }
+    if (storage.playlistCursor < nodes.size()) {
+        return false;
+    }
+    assign_uses(storage, rows);
+    const bool partial =
+        !storage.uiLoaded || storage.nameFailures != 0 || storage.overflowScenarios != 0;
+    finish(storage, partial ? "partial" : "ok", partial);
+    return true;
+}
+
+} // namespace sunrise::client::content::scenarios

--- a/Sunrise/src/client/content/scenarios/scenario_build.cpp
+++ b/Sunrise/src/client/content/scenarios/scenario_build.cpp
@@ -74,7 +74,9 @@ void report(const Storage& storage,
 } // namespace
 
 /** Extracts every destination's bubble layout and roster from the installed packages, once. */
-bool build(const packages::reader::Source& source, packages::reader::Scratch& scratch) noexcept {
+bool build(const packages::reader::Source& source,
+           packages::reader::Scratch& scratch,
+           std::span<const std::byte> investmentRoot) noexcept {
     if (state::build_data::scenario_layouts_ready()) {
         return true;
     }
@@ -107,6 +109,17 @@ bool build(const packages::reader::Source& source, packages::reader::Scratch& sc
         }
         report(storage, storage.keptCount, 0, "collected");
         storage.compacted = true;
+    }
+    if (!build_activity_labels(
+            source, scratch, storage.labels, std::span(storage.rows).first(storage.keptCount))) {
+        return false;
+    }
+    if (!build_activity_types(source,
+                              scratch,
+                              investmentRoot,
+                              storage.activityTypes,
+                              std::span(storage.rows).first(storage.keptCount))) {
+        return false;
     }
     return walk_rosters(source, scratch, storage);
 }

--- a/Sunrise/src/client/content/scenarios/scenario_build.h
+++ b/Sunrise/src/client/content/scenarios/scenario_build.h
@@ -6,12 +6,17 @@ namespace sunrise::client::content::scenarios {
 
 /**
  * Extracts every destination's bubble layout from the installed packages, once.
- * Each destination costs one tag read, because activity message 1 reads only the scenario blob.
+ * Layout collection, optional activity metadata, and roster extraction share one publication.
+ *
  * @param source Package directory and borrowed block keys.
  * @param scratch Lock-owned block storage shared with the item build.
- * @return True when State already holds the domain or a full pass publishes it.
+ * @param investmentRoot Root
+ * already resolved by the shared investment package pass.
+ * @return True when State already holds
+ * the domain or a full pass publishes it.
  */
 [[nodiscard]] bool build(const middleware::content::packages::reader::Source& source,
-                         middleware::content::packages::reader::Scratch& scratch) noexcept;
+                         middleware::content::packages::reader::Scratch& scratch,
+                         std::span<const std::byte> investmentRoot) noexcept;
 
 } // namespace sunrise::client::content::scenarios

--- a/Sunrise/src/middleware/content/packages/tables/activity_metadata_reader.cpp
+++ b/Sunrise/src/middleware/content/packages/tables/activity_metadata_reader.cpp
@@ -1,0 +1,268 @@
+#include "activity_metadata_reader.h"
+
+#include "internal.h"
+
+namespace sunrise::middleware::content::packages::tables {
+namespace {
+
+/** Activity field offsets measured from the archived Shadowkeep client packages. */
+constexpr std::size_t kDisplayNameHashOffset = 0x08;
+constexpr std::size_t kDefinitionTagDescriptorOffset = 0x10;
+
+/** Recovered inline strides and fields for build 86657.20.08.23. */
+constexpr std::size_t kIndexStride = 16;
+constexpr std::size_t kUiTypeStride = 128;
+constexpr std::size_t kPlaylistStride = 56;
+constexpr std::size_t kScenarioPointer = 0x68;
+constexpr std::size_t kTypeIndex = 0xDA;
+constexpr std::size_t kPlaylistPointer = 0x18;
+
+/** Resolves a signed self-relative pointer without signed overflow, including INT64_MIN. */
+[[nodiscard]] bool relative(std::span<const std::byte> blob,
+                            std::size_t field,
+                            std::size_t& target,
+                            bool& absent) noexcept {
+    target = 0;
+    absent = false;
+    std::int64_t displacement = 0;
+    if (!read(blob, field, displacement)) {
+        return false;
+    }
+    if (displacement == 0) {
+        absent = true;
+        return true;
+    }
+    if (displacement > 0) {
+        const auto distance = static_cast<std::uint64_t>(displacement);
+        if (distance >= blob.size() - field) {
+            return false;
+        }
+        target = field + static_cast<std::size_t>(distance);
+    } else {
+        const auto distance = static_cast<std::uint64_t>(-(displacement + 1)) + 1;
+        if (distance > field) {
+            return false;
+        }
+        target = field - static_cast<std::size_t>(distance);
+    }
+    return target < blob.size();
+}
+
+/** Validates a bounded array's class and entire inline row extent before indexing it. */
+[[nodiscard]] bool fits(std::span<const std::byte> blob,
+                        const Array& array,
+                        std::uint32_t elementClass,
+                        std::size_t stride,
+                        std::size_t capacity) noexcept {
+    return array.elementClass == elementClass && array.count <= capacity
+           && array.dataOffset <= blob.size()
+           && array.count <= (blob.size() - array.dataOffset) / stride;
+}
+
+/** Reads the exact package key; display titles and alternate activity-path strings do not join. */
+[[nodiscard]] bool scenario_name(std::span<const std::byte> blob,
+                                 std::size_t definition,
+                                 std::string_view& output) noexcept {
+    std::size_t offset = 0;
+    bool absent = false;
+    if (!relative(blob, definition + kScenarioPointer, offset, absent)) {
+        return false;
+    }
+    if (absent) {
+        return true;
+    }
+    for (std::size_t length = 0; length <= kActivityScenarioNameCapacity; ++length) {
+        if (length >= blob.size() - offset) {
+            return false;
+        }
+        const char value = static_cast<char>(blob[offset + length]);
+        if (value == '\0') {
+            output = {reinterpret_cast<const char*>(blob.data() + offset), length};
+            return true;
+        }
+        if (length == kActivityScenarioNameCapacity
+            || !((value >= 'a' && value <= 'z') || (value >= '0' && value <= '9')
+                 || value == '_')) {
+            return false;
+        }
+    }
+    return false;
+}
+
+} // namespace
+
+bool activity_index(std::span<const std::byte> blob, Array& output) noexcept {
+    output = {};
+    Array candidate{};
+    if (!find_array_at(blob, kTableArrayDescriptor, candidate)
+        || !fits(blob, candidate, kActivityIndexClass, kIndexStride, kActivityIndexCapacity)) {
+        return false;
+    }
+    output = candidate;
+    return true;
+}
+
+bool activity_definition_at(std::span<const std::byte> blob,
+                            const Array& array,
+                            std::size_t index,
+                            std::size_t typeCount,
+                            ActivityDefinition& output) noexcept {
+    output = {};
+    if (!fits(blob, array, kActivityIndexClass, kIndexStride, kActivityIndexCapacity)
+        || index >= array.count || typeCount == 0 || typeCount > kActivityTypeCapacity) {
+        return false;
+    }
+    ActivityDefinition candidate{};
+    const std::size_t entry = array.dataOffset + index * kIndexStride;
+    std::size_t definition = 0;
+    bool absent = false;
+    std::uint32_t hash = 0;
+    if (!read(blob, entry, hash) || !relative(blob, entry + 8, definition, absent) || absent
+        || blob.size() - definition <= kTypeIndex || !read(blob, definition, candidate.hash)
+        || candidate.hash != hash || !read(blob, definition + kTypeIndex, candidate.typeIndex)
+        || candidate.typeIndex >= typeCount
+        || !scenario_name(blob, definition, candidate.scenarioName)) {
+        return false;
+    }
+    std::size_t playlist = 0;
+    if (!relative(blob, definition + kPlaylistPointer, playlist, absent)) {
+        return false;
+    }
+    if (!absent) {
+        // The descriptor is after the playlist prefix. Empty descriptors need no dereference.
+        if (blob.size() - playlist < 24) {
+            return false;
+        }
+        std::uint64_t count = 0;
+        if (!read(blob, playlist + 8, count)) {
+            return false;
+        }
+        if (count != 0
+            && (!find_array_at(blob, playlist + 8, candidate.playlist)
+                || !fits(blob,
+                         candidate.playlist,
+                         kActivityPlaylistRowClass,
+                         kPlaylistStride,
+                         kActivityIndexCapacity))) {
+            return false;
+        }
+    }
+    output = candidate;
+    return true;
+}
+
+bool activity_playlist_child_at(std::span<const std::byte> blob,
+                                const Array& playlist,
+                                std::size_t index,
+                                std::size_t activityCount,
+                                std::uint16_t& output) noexcept {
+    output = 0;
+    std::int16_t child = -1;
+    if (!fits(blob, playlist, kActivityPlaylistRowClass, kPlaylistStride, kActivityIndexCapacity)
+        || index >= playlist.count || activityCount > kActivityIndexCapacity
+        || !read(blob, playlist.dataOffset + index * kPlaylistStride + 8, child) || child < 0
+        || static_cast<std::size_t>(child) >= activityCount) {
+        return false;
+    }
+    output = static_cast<std::uint16_t>(child);
+    return true;
+}
+
+bool activity_types(std::span<const std::byte> blob, bool ui, Array& output) noexcept {
+    output = {};
+    Array candidate{};
+    if (!find_array_at(blob, kTableArrayDescriptor, candidate)
+        || !fits(blob,
+                 candidate,
+                 ui ? kActivityTypeUiRowClass : kActivityTypeRowClass,
+                 ui ? kUiTypeStride : kIndexStride,
+                 kActivityTypeCapacity)) {
+        return false;
+    }
+    output = candidate;
+    return true;
+}
+
+bool activity_type_hash_at(std::span<const std::byte> blob,
+                           const Array& array,
+                           std::size_t index,
+                           std::uint32_t& output) noexcept {
+    output = 0;
+    return fits(blob, array, kActivityTypeRowClass, kIndexStride, kActivityTypeCapacity)
+           && index < array.count && read(blob, array.dataOffset + index * kIndexStride, output);
+}
+
+bool activity_type_name_at(std::span<const std::byte> blob,
+                           const Array& array,
+                           std::size_t index,
+                           ActivityTypeName& output) noexcept {
+    output = {};
+    if (!fits(blob, array, kActivityTypeUiRowClass, kUiTypeStride, kActivityTypeCapacity)
+        || index >= array.count) {
+        return false;
+    }
+    const std::size_t offset = array.dataOffset + index * kUiTypeStride;
+    ActivityTypeName candidate{};
+    if (!read(blob, offset, candidate.hash) || !read(blob, offset + 4, candidate.containerIndex)
+        || !read(blob, offset + 8, candidate.resourceHash)) {
+        return false;
+    }
+    output = candidate;
+    return true;
+}
+
+bool activity_reference_tag(std::span<const std::byte> blob,
+                            std::size_t offset,
+                            std::uint32_t& output) noexcept {
+    output = 0;
+    std::uint32_t candidate = 0;
+    if (!read(blob, offset, candidate) || package_of(candidate) == kAbsentPackageId) {
+        return false;
+    }
+    output = candidate;
+    return true;
+}
+
+bool activity_string_container_tag(std::span<const std::byte> blob,
+                                   std::uint16_t index,
+                                   std::uint32_t& output) noexcept {
+    output = 0;
+    Array array{};
+    /** The registry has 3,108 rows; its name references use 16-bit ordinals. */
+    constexpr std::size_t kRegistryCapacity = 65535;
+    return find_array_at(blob, kTableArrayDescriptor, array)
+           && fits(blob, array, kInvestmentStringRegistryRowClass, 8, kRegistryCapacity)
+           && index < array.count
+           && activity_reference_tag(
+               blob, array.dataOffset + static_cast<std::size_t>(index) * 8 + 4, output);
+}
+
+/** Reads one archived activity definition. */
+bool activity_metadata(std::span<const std::byte> blob, ActivityMetadata& output) noexcept {
+    output = {};
+    if (!read(blob, kDisplayNameHashOffset, output.displayNameHash)
+        || !find_array_at(blob, kDefinitionTagDescriptorOffset, output.definitionTags)
+        || output.definitionTags.elementClass != kActivityDefinitionTagClass
+        || output.definitionTags.count > kActivityDefinitionTagCapacity) {
+        output = {};
+        return false;
+    }
+    return true;
+}
+
+/** Reads one tag from an activity's definition array. */
+bool activity_definition_tag_at(std::span<const std::byte> blob,
+                                const ActivityMetadata& activity,
+                                std::uint64_t index,
+                                std::uint32_t& tag) noexcept {
+    tag = 0;
+    std::size_t offset = 0;
+    return element_offset(activity.definitionTags.dataOffset,
+                          activity.definitionTags.count,
+                          kActivityDefinitionTagStride,
+                          index,
+                          offset)
+           && read(blob, offset, tag);
+}
+
+} // namespace sunrise::middleware::content::packages::tables

--- a/Sunrise/src/middleware/content/packages/tables/activity_metadata_reader.h
+++ b/Sunrise/src/middleware/content/packages/tables/activity_metadata_reader.h
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <string_view>
+
+#include "definition_index_table.h"
+
+namespace sunrise::middleware::content::packages::tables {
+
+/** Tag class of an activity definition in the archived Shadowkeep package set. */
+inline constexpr std::uint32_t kActivityMetadataClass = 0x80808AAEU;
+/** Element class of the definition-tag array each activity owns. */
+inline constexpr std::uint32_t kActivityDefinitionTagClass = 0x80808491U;
+/** A definition-tag array element is one bare 32-bit tag handle. */
+inline constexpr std::size_t kActivityDefinitionTagStride = sizeof(std::uint32_t);
+/** Corrupt activity metadata cannot cause an unbounded tag walk. */
+inline constexpr std::size_t kActivityDefinitionTagCapacity = 64;
+
+/** Activity fields needed to associate one player-facing name with its client scenario. */
+struct ActivityMetadata {
+    std::uint32_t displayNameHash{};
+    Array definitionTags{};
+};
+
+/**
+ * Reads one archived activity definition.
+ * @param blob Whole activity definition.
+ * @param output Receives the display-name hash and definition-tag array.
+ * @return True when both fields are structurally valid.
+ */
+[[nodiscard]] bool activity_metadata(std::span<const std::byte> blob,
+                                     ActivityMetadata& output) noexcept;
+
+/**
+ * Reads one tag from an activity's definition array.
+ * @param blob Whole activity definition.
+ * @param activity Parsed activity metadata.
+ * @param index Tag ordinal.
+ * @param tag Receives the tag handle.
+ * @return True when the element lies inside the blob.
+ */
+[[nodiscard]] bool activity_definition_tag_at(std::span<const std::byte> blob,
+                                              const ActivityMetadata& activity,
+                                              std::uint64_t index,
+                                              std::uint32_t& tag) noexcept;
+
+/** Archived investment-root slots naming activities and their native types. */
+inline constexpr std::size_t kActivityTableSlot = 4;
+inline constexpr std::size_t kActivityTypeTableSlot = 5;
+/** Package-entry classes, distinct from the inline array element classes. */
+inline constexpr std::uint32_t kActivityTableClass = 0x808076F0U;
+inline constexpr std::uint32_t kActivityTypeTableClass = 0x80807773U;
+inline constexpr std::uint32_t kActivityTypeUiTableClass = 0x80805F3CU;
+inline constexpr std::uint32_t kInvestmentStringRegistryClass = 0x80805F98U;
+inline constexpr std::uint32_t kInvestmentUiRootClass = 0x80805BB1U;
+/** UI-root references are tag handles, not the numeric investment root's slot ordinals. */
+inline constexpr std::size_t kActivityTypeUiTagOffset = 0x70;
+inline constexpr std::size_t kInvestmentStringRegistryTagOffset = 0x490;
+/** Inline array element classes verified against the archived native consumers. */
+inline constexpr std::uint32_t kActivityIndexClass = 0x808076FCU;
+inline constexpr std::uint32_t kActivityTypeRowClass = 0x80807778U;
+inline constexpr std::uint32_t kActivityTypeUiRowClass = 0x80805F40U;
+inline constexpr std::uint32_t kActivityPlaylistRowClass = 0x80807736U;
+inline constexpr std::uint32_t kInvestmentStringRegistryRowClass = 0x80805F9EU;
+/** Headroom above 1,170 activities; indices in playlist rows are signed 16-bit values. */
+inline constexpr std::size_t kActivityIndexCapacity = 4096;
+/** Native definitions carry one byte of type index; it is not a public API mode enum. */
+inline constexpr std::size_t kActivityTypeCapacity = 256;
+/** Scenario names are bounded by the 40-byte selection field. */
+inline constexpr std::size_t kActivityScenarioNameCapacity = 40;
+
+/** Borrowed fields of one activity definition; views remain valid only while its blob lives. */
+struct ActivityDefinition {
+    std::uint32_t hash{};
+    std::uint8_t typeIndex{};
+    std::string_view scenarioName{};
+    Array playlist{};
+};
+
+/** One native type's ordinary UI name reference, not its conditional secondary display name. */
+struct ActivityTypeName {
+    std::uint32_t hash{};
+    std::uint16_t containerIndex{};
+    std::uint32_t resourceHash{};
+};
+
+/** Reads and validates the complete extent of the activity index array. */
+[[nodiscard]] bool activity_index(std::span<const std::byte> blob, Array& output) noexcept;
+/** Reads one definition, including its optional scenario name and playlist descriptor. */
+[[nodiscard]] bool activity_definition_at(std::span<const std::byte> blob,
+                                          const Array& array,
+                                          std::size_t index,
+                                          std::size_t typeCount,
+                                          ActivityDefinition& output) noexcept;
+/** Reads a playlist's child activity index and rejects negative/out-of-table references. */
+[[nodiscard]] bool activity_playlist_child_at(std::span<const std::byte> blob,
+                                              const Array& playlist,
+                                              std::size_t index,
+                                              std::size_t activityCount,
+                                              std::uint16_t& output) noexcept;
+/** Reads the native type table, or its parallel UI table when ui is true. */
+[[nodiscard]] bool activity_types(std::span<const std::byte> blob, bool ui, Array& output) noexcept;
+/** Reads a stable type hash from the native type table. */
+[[nodiscard]] bool activity_type_hash_at(std::span<const std::byte> blob,
+                                         const Array& array,
+                                         std::size_t index,
+                                         std::uint32_t& output) noexcept;
+/** Reads the normal localized name reference from one UI type row. */
+[[nodiscard]] bool activity_type_name_at(std::span<const std::byte> blob,
+                                         const Array& array,
+                                         std::size_t index,
+                                         ActivityTypeName& output) noexcept;
+/** Reads one bounded tag reference, rejecting values outside the installed definition range. */
+[[nodiscard]] bool activity_reference_tag(std::span<const std::byte> blob,
+                                          std::size_t offset,
+                                          std::uint32_t& output) noexcept;
+/** Resolves a UI name's string-container index through the investment string registry. */
+[[nodiscard]] bool activity_string_container_tag(std::span<const std::byte> blob,
+                                                 std::uint16_t index,
+                                                 std::uint32_t& output) noexcept;
+
+} // namespace sunrise::middleware::content::packages::tables

--- a/Sunrise/src/middleware/content/packages/tables/activity_type_mapping.cpp
+++ b/Sunrise/src/middleware/content/packages/tables/activity_type_mapping.cpp
@@ -1,0 +1,51 @@
+#include "activity_type_mapping.h"
+
+#include <algorithm>
+
+#include "activity_metadata_reader.h"
+
+namespace sunrise::middleware::content::packages::tables {
+
+bool activity_playlist_scenarios(std::span<const ActivityGraphNode> nodes,
+                                 std::span<const std::uint16_t> children,
+                                 std::size_t root,
+                                 std::span<std::uint8_t> reachable,
+                                 std::span<std::uint8_t> visited,
+                                 std::span<std::uint16_t> queue) noexcept {
+    std::fill(reachable.begin(), reachable.end(), std::uint8_t{0});
+    std::fill(visited.begin(), visited.end(), std::uint8_t{0});
+    if (nodes.size() > kActivityIndexCapacity || root >= nodes.size()
+        || children.size() > kActivityPlaylistEdgeCapacity || visited.size() < nodes.size()
+        || queue.size() < nodes.size()) {
+        return false;
+    }
+    std::size_t queued = 1;
+    queue[0] = static_cast<std::uint16_t>(root);
+    visited[root] = 1;
+    for (std::size_t cursor = 0; cursor < queued; ++cursor) {
+        const ActivityGraphNode& node = nodes[queue[cursor]];
+        if (node.firstChild > children.size() || node.childCount > children.size() - node.firstChild
+            || (node.scenarioIndex != kUnmappedActivityScenario
+                && node.scenarioIndex >= reachable.size())) {
+            std::fill(reachable.begin(), reachable.end(), std::uint8_t{0});
+            return false;
+        }
+        if (node.scenarioIndex != kUnmappedActivityScenario) {
+            reachable[node.scenarioIndex] = 1;
+        }
+        for (const std::uint16_t child : children.subspan(node.firstChild, node.childCount)) {
+            if (child >= nodes.size()) {
+                std::fill(reachable.begin(), reachable.end(), std::uint8_t{0});
+                return false;
+            }
+            if (visited[child] == 0) {
+                // Visited is marked when enqueued, so duplicates cannot exhaust the queue.
+                visited[child] = 1;
+                queue[queued++] = child;
+            }
+        }
+    }
+    return true;
+}
+
+} // namespace sunrise::middleware::content::packages::tables

--- a/Sunrise/src/middleware/content/packages/tables/activity_type_mapping.h
+++ b/Sunrise/src/middleware/content/packages/tables/activity_type_mapping.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+
+namespace sunrise::middleware::content::packages::tables {
+
+/** A definition that does not name a scenario in the caller's catalogue. */
+inline constexpr std::uint16_t kUnmappedActivityScenario = 0xFFFFU;
+/** Headroom above 1,407 measured playlist edges, with a fixed traversal work bound. */
+inline constexpr std::size_t kActivityPlaylistEdgeCapacity = 16384;
+
+/** Reduced activity graph node. Child ranges refer to the caller's flat edge array. */
+struct ActivityGraphNode {
+    std::uint16_t scenarioIndex{kUnmappedActivityScenario};
+    std::uint8_t typeIndex{};
+    std::uint32_t firstChild{};
+    std::uint16_t childCount{};
+};
+
+/**
+ * Marks scenarios reached by one playlist, including a name on the playlist itself.
+ * Every node is visited at most once. Self-cycles, diamonds, and repeated edges are valid.
+ * @param nodes Complete activity graph, with validated native type indices.
+ * @param children Flat child-index array.
+ * @param root Activity whose playlist uses are being collected.
+ * @param reachable One byte per caller scenario, cleared before traversal and on failure.
+ * @param visited Scratch with at least one byte per node, cleared before traversal.
+ * @param queue Scratch with at least one index per node; no recursion or heap allocation.
+ * @return True when all reached references are bounded and the traversal completed.
+ */
+[[nodiscard]] bool activity_playlist_scenarios(std::span<const ActivityGraphNode> nodes,
+                                               std::span<const std::uint16_t> children,
+                                               std::size_t root,
+                                               std::span<std::uint8_t> reachable,
+                                               std::span<std::uint8_t> visited,
+                                               std::span<std::uint16_t> queue) noexcept;
+
+} // namespace sunrise::middleware::content::packages::tables

--- a/Sunrise/src/middleware/content/packages/tables/localized_string_reader.cpp
+++ b/Sunrise/src/middleware/content/packages/tables/localized_string_reader.cpp
@@ -1,0 +1,172 @@
+#include "localized_string_reader.h"
+
+#include <algorithm>
+#include <limits>
+
+#include "internal.h"
+
+namespace sunrise::middleware::content::packages::tables {
+namespace {
+
+/** Localized-string field offsets recovered from the archived Shadowkeep package ABI. */
+constexpr std::size_t kHashDescriptorOffset = 0x08;
+constexpr std::size_t kEnglishTagOffset = 0x18;
+constexpr std::size_t kCombinationDescriptorOffset = 0x48;
+constexpr std::size_t kCombinationStride = 0x10;
+constexpr std::size_t kCombinationPartCountOffset = 0x08;
+constexpr std::size_t kPartStride = 0x20;
+constexpr std::size_t kPartDataPointerOffset = 0x08;
+constexpr std::size_t kPartByteLengthOffset = 0x14;
+constexpr std::size_t kPartStringLengthOffset = 0x16;
+constexpr std::size_t kPartCipherShiftOffset = 0x18;
+/** Resource hashes are bare 32-bit values in the header array. */
+constexpr std::size_t kHashStride = sizeof(std::uint32_t);
+/** Bounds corrupt string headers before they can produce an unbounded hash walk. */
+constexpr std::uint64_t kHashCapacity = 16'384;
+/** Bounds corrupted combination metadata before it can produce a long walk. */
+constexpr std::int64_t kPartCapacity = 64;
+constexpr std::uint16_t kPartByteCapacity = 4096;
+
+/** Resolves one signed pointer relative to its own field. */
+[[nodiscard]] bool pointer_target(std::span<const std::byte> blob,
+                                  std::size_t pointerOffset,
+                                  std::size_t& target) noexcept {
+    target = 0;
+    std::int64_t relative = 0;
+    if (pointerOffset > static_cast<std::size_t>((std::numeric_limits<std::int64_t>::max)())
+        || !read(blob, pointerOffset, relative) || relative == 0) {
+        return false;
+    }
+    const std::int64_t base = static_cast<std::int64_t>(pointerOffset);
+    constexpr std::int64_t kMaximum = (std::numeric_limits<std::int64_t>::max)();
+    constexpr std::int64_t kMinimum = (std::numeric_limits<std::int64_t>::min)();
+    if ((relative > 0 && base > kMaximum - relative)
+        || (relative < 0 && base < kMinimum - relative)) {
+        return false;
+    }
+    const std::int64_t resolved = base + relative;
+    if (resolved < 0 || static_cast<std::uint64_t>(resolved) >= blob.size()) {
+        return false;
+    }
+    target = static_cast<std::size_t>(resolved);
+    return true;
+}
+
+/** Appends one decoded ASCII part to the bounded output. */
+[[nodiscard]] bool append_part(std::span<const std::byte> blob,
+                               std::size_t part,
+                               std::span<char> output,
+                               std::size_t& used) noexcept {
+    std::uint16_t byteLength = 0;
+    std::uint16_t stringLength = 0;
+    std::uint16_t cipherShift = 0;
+    std::size_t data = 0;
+    if (!pointer_target(blob, part + kPartDataPointerOffset, data)
+        || !read(blob, part + kPartByteLengthOffset, byteLength)
+        || !read(blob, part + kPartStringLengthOffset, stringLength)
+        || !read(blob, part + kPartCipherShiftOffset, cipherShift) || byteLength == 0
+        || byteLength > kPartByteCapacity || stringLength == 0 || stringLength != byteLength
+        || used > output.size() || output.size() - used < byteLength) {
+        return false;
+    }
+    for (std::size_t index = 0; index < byteLength; ++index) {
+        std::uint8_t encoded = 0;
+        if (!read(blob, data + index, encoded) || encoded > 0x7F) {
+            return false;
+        }
+        const std::uint8_t decoded = static_cast<std::uint8_t>(encoded + cipherShift);
+        if (decoded < 0x20 || decoded > 0x7E) {
+            return false;
+        }
+        output[used++] = static_cast<char>(decoded);
+    }
+    return true;
+}
+
+} // namespace
+
+/** Reads one localized string-container header. */
+bool localized_strings(std::span<const std::byte> blob, LocalizedStrings& output) noexcept {
+    output = {};
+    if (!find_array_at(blob, kHashDescriptorOffset, output.hashes)
+        || output.hashes.count > kHashCapacity) {
+        output = {};
+        return false;
+    }
+    return true;
+}
+
+/** Reads the verified English language tag from a localized string-container header. */
+bool localized_english_tag(std::span<const std::byte> blob, std::uint32_t& tag) noexcept {
+    tag = 0;
+    return read(blob, kEnglishTagOffset, tag) && package_of(tag) != kAbsentPackageId;
+}
+
+/** Reads one resource hash from a parsed string-container header. */
+bool localized_hash_at(std::span<const std::byte> headerBlob,
+                       const LocalizedStrings& header,
+                       std::uint64_t index,
+                       std::uint32_t& hash) noexcept {
+    hash = 0;
+    std::size_t offset = 0;
+    return element_offset(header.hashes.dataOffset, header.hashes.count, kHashStride, index, offset)
+           && read(headerBlob, offset, hash);
+}
+
+/** Reads the number of string combinations in one language-data definition. */
+bool localized_string_count(std::span<const std::byte> languageBlob,
+                            std::uint64_t& count) noexcept {
+    count = 0;
+    Array combinations{};
+    if (!find_array_at(languageBlob, kCombinationDescriptorOffset, combinations)
+        || combinations.elementClass != kStringCombinationClass
+        || combinations.count > kHashCapacity) {
+        return false;
+    }
+    count = combinations.count;
+    return true;
+}
+
+/** Decodes one printable-ASCII string by its ordinal in the parallel arrays. */
+bool localized_ascii_string_at(std::span<const std::byte> languageBlob,
+                               std::uint64_t index,
+                               std::span<char> output,
+                               std::uint8_t& length) noexcept {
+    std::fill(output.begin(), output.end(), '\0');
+    length = 0;
+    if (output.empty() || output.size() > (std::numeric_limits<std::uint8_t>::max)()) {
+        return false;
+    }
+    Array combinations{};
+    if (!find_array_at(languageBlob, kCombinationDescriptorOffset, combinations)
+        || combinations.elementClass != kStringCombinationClass
+        || combinations.count > kHashCapacity || index >= combinations.count) {
+        return false;
+    }
+    std::size_t combination = 0;
+    std::size_t firstPart = 0;
+    std::int64_t partCount = 0;
+    if (!element_offset(
+            combinations.dataOffset, combinations.count, kCombinationStride, index, combination)
+        || !pointer_target(languageBlob, combination, firstPart)
+        || !read(languageBlob, combination + kCombinationPartCountOffset, partCount)
+        || partCount <= 0 || partCount > kPartCapacity) {
+        return false;
+    }
+    std::size_t used = 0;
+    for (std::int64_t part = 0; part < partCount; ++part) {
+        const auto ordinal = static_cast<std::size_t>(part);
+        if (ordinal > ((std::numeric_limits<std::size_t>::max)() - firstPart) / kPartStride
+            || !append_part(languageBlob, firstPart + ordinal * kPartStride, output, used)) {
+            std::fill(output.begin(), output.end(), '\0');
+            return false;
+        }
+    }
+    if (used == 0) {
+        return false;
+    }
+    length = static_cast<std::uint8_t>(used);
+    return true;
+}
+
+} // namespace sunrise::middleware::content::packages::tables

--- a/Sunrise/src/middleware/content/packages/tables/localized_string_reader.h
+++ b/Sunrise/src/middleware/content/packages/tables/localized_string_reader.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+
+#include "definition_index_table.h"
+
+namespace sunrise::middleware::content::packages::tables {
+
+/** Tag class of a localized string-container header. */
+inline constexpr std::uint32_t kLocalizedStringsClass = 0x80809A88U;
+/** Element class of the combination rows in one language's string data. */
+inline constexpr std::uint32_t kStringCombinationClass = 0x80809A8EU;
+/** Resource hashes in an installed localized-string container. */
+struct LocalizedStrings {
+    Array hashes{};
+};
+
+/**
+ * Reads one localized string-container header.
+ * @param blob Whole string-container definition.
+ * @param output Receives the hash array.
+ * @return True when the hash index is structurally valid.
+ */
+[[nodiscard]] bool localized_strings(std::span<const std::byte> blob,
+                                     LocalizedStrings& output) noexcept;
+
+/**
+ * Reads the verified English language tag from a localized string-container header.
+ * @param blob Whole string-container definition.
+ * @param tag Receives the selected language-data tag.
+ * @return True when the selected slot contains a definition tag.
+ */
+[[nodiscard]] bool localized_english_tag(std::span<const std::byte> blob,
+                                         std::uint32_t& tag) noexcept;
+
+/** Reads one resource hash from a parsed string-container header. */
+[[nodiscard]] bool localized_hash_at(std::span<const std::byte> headerBlob,
+                                     const LocalizedStrings& header,
+                                     std::uint64_t index,
+                                     std::uint32_t& hash) noexcept;
+
+/**
+ * Reads the number of string combinations in one language-data definition.
+ * @param languageBlob Whole language-data definition.
+ * @param count Receives the bounded combination count.
+ * @return True when the combination array is structurally valid.
+ */
+[[nodiscard]] bool localized_string_count(std::span<const std::byte> languageBlob,
+                                          std::uint64_t& count) noexcept;
+
+/**
+ * Decodes one printable-ASCII string by its ordinal in parallel hash and combination arrays.
+ * @param languageBlob Selected language-data definition.
+ * @param index String ordinal from the container header.
+ * @param output Cleared first and receives the decoded bytes without a terminator.
+ * @param length Receives the decoded byte count.
+ * @return True when the complete printable ASCII string fits.
+ */
+[[nodiscard]] bool localized_ascii_string_at(std::span<const std::byte> languageBlob,
+                                             std::uint64_t index,
+                                             std::span<char> output,
+                                             std::uint8_t& length) noexcept;
+
+} // namespace sunrise::middleware::content::packages::tables

--- a/Sunrise/src/server/ui/activity_override/activity_override_lists.cpp
+++ b/Sunrise/src/server/ui/activity_override/activity_override_lists.cpp
@@ -27,6 +27,11 @@ Lists g_lists{};
     return {row.name.data(), row.nameLength};
 }
 
+/** @return The destination row's player-facing activity label as a bounded view. */
+[[nodiscard]] std::string_view label_of(const layouts::Definition& row) noexcept {
+    return {row.activityLabel.data(), row.activityLabelLength};
+}
+
 /** @return The destination row's map stem as a bounded view. */
 [[nodiscard]] std::string_view stem_of(const layouts::Definition& row) noexcept {
     return {row.spawnStem.data(), row.spawnStemLength};
@@ -35,6 +40,16 @@ Lists g_lists{};
 /** @return True when the left destination row sorts before the right one by name. */
 [[nodiscard]] bool name_less(const layouts::Definition& left,
                              const layouts::Definition& right) noexcept {
+    const std::string_view leftLabel = label_of(left);
+    const std::string_view rightLabel = label_of(right);
+    if (leftLabel != rightLabel) {
+        // Rows without a recovered label follow the player-facing rows rather than interrupting
+        // their alphabetical groups.
+        if (leftLabel.empty() != rightLabel.empty()) {
+            return !leftLabel.empty();
+        }
+        return leftLabel < rightLabel;
+    }
     return name_of(left) < name_of(right);
 }
 
@@ -244,6 +259,8 @@ void refresh_activities(Lists& rows) noexcept {
         return;
     }
     rows.activities = {};
+    rows.activityNames = {};
+    rows.activityNameLengths = {};
     rows.activityCount = 0;
     // The snapshot is a whole domain of fixed rows, so it is static rather than a local.
     static std::array<layouts::Definition, layouts::kDefinitionCapacity> scratch{};
@@ -258,7 +275,22 @@ void refresh_activities(Lists& rows) noexcept {
     // Extraction order is package order, which no reader can search. Name order is.
     std::sort(rowsRead.begin(), rowsRead.end(), name_less);
     for (const layouts::Definition& row : rowsRead) {
-        assign(name_of(row), rows.activities[rows.activityCount]);
+        const std::string_view name = name_of(row);
+        const std::string_view label = label_of(row);
+        if (label.empty()) {
+            assign(name, rows.activities[rows.activityCount]);
+        } else {
+            Label& activity = rows.activities[rows.activityCount];
+            (void)std::snprintf(activity.data(),
+                                activity.size(),
+                                "%.*s  (%.*s)",
+                                static_cast<int>(label.size()),
+                                label.data(),
+                                static_cast<int>(name.size()),
+                                name.data());
+        }
+        std::copy(name.begin(), name.end(), rows.activityNames[rows.activityCount].begin());
+        rows.activityNameLengths[rows.activityCount] = static_cast<std::uint8_t>(name.size());
         ++rows.activityCount;
     }
 }

--- a/Sunrise/src/server/ui/activity_override/activity_override_lists.h
+++ b/Sunrise/src/server/ui/activity_override/activity_override_lists.h
@@ -20,10 +20,15 @@ inline constexpr std::size_t kNoRow = static_cast<std::size_t>(-1);
 
 /** One null-terminated row label. */
 using Label = std::array<char, kLabelCapacity>;
+/** One selected scenario's internal package name, kept separate from its display label. */
+using ActivityName = std::array<char, state::build_data::scenarios::kNameCapacity>;
 
 /** Rows the four pickers draw, rebuilt from the catalogues rather than stored in State. */
 struct Lists {
     std::array<Label, state::build_data::scenarios::kDefinitionCapacity> activities{};
+    std::array<ActivityName, state::build_data::scenarios::kDefinitionCapacity> activityNames{};
+    std::array<std::uint8_t, state::build_data::scenarios::kDefinitionCapacity>
+        activityNameLengths{};
     std::size_t activityCount{};
     /** Published destination count the activity rows were built from. */
     std::size_t activityRevision{};

--- a/Sunrise/src/server/ui/activity_override/activity_override_panel.cpp
+++ b/Sunrise/src/server/ui/activity_override/activity_override_panel.cpp
@@ -49,6 +49,24 @@ std::size_t g_spawnRow{kNoRow};
     return {value.packageName.data(), value.packageNameLength};
 }
 
+/** @return One picker row's internal package name. */
+[[nodiscard]] std::string_view row_name(const Lists& rows, std::size_t index) noexcept {
+    if (index >= rows.activityCount) {
+        return {};
+    }
+    return {rows.activityNames[index].data(), rows.activityNameLengths[index]};
+}
+
+/** Finds the picker row carrying one internal package name. */
+[[nodiscard]] std::size_t activity_row(const Lists& rows, std::string_view name) noexcept {
+    for (std::size_t index = 0; index < rows.activityCount; ++index) {
+        if (row_name(rows, index) == name) {
+            return index;
+        }
+    }
+    return kNoRow;
+}
+
 /**
  * Draws one labelled picker over a list of row labels.
  * @param id Stable Dear ImGui scope ID.
@@ -90,8 +108,13 @@ void follow_destination(const forced::ForcedDestination& value, Lists& rows) noe
 [[nodiscard]] bool draw_activity(forced::ForcedDestination& value, Lists& rows) noexcept {
     std::array<char, kLabelCapacity> preview{};
     const std::string_view name = name_of(value);
-    (void)std::snprintf(
-        preview.data(), preview.size(), "%.*s", static_cast<int>(name.size()), name.data());
+    g_activityRow = name.empty() ? kNoRow : activity_row(rows, name);
+    if (g_activityRow < rows.activityCount) {
+        preview = rows.activities[g_activityRow];
+    } else {
+        (void)std::snprintf(
+            preview.data(), preview.size(), "%.*s", static_cast<int>(name.size()), name.data());
+    }
     if (!row_picker("activity",
                     "Activity",
                     rows.activities.data(),
@@ -100,8 +123,7 @@ void follow_destination(const forced::ForcedDestination& value, Lists& rows) noe
                     g_activityRow)) {
         return false;
     }
-    const Label& picked = rows.activities[g_activityRow];
-    const std::string_view text(picked.data());
+    const std::string_view text = row_name(rows, g_activityRow);
     value.packageName = {};
     std::copy_n(
         text.begin(), (std::min)(text.size(), value.packageName.size()), value.packageName.begin());
@@ -116,6 +138,56 @@ void follow_destination(const forced::ForcedDestination& value, Lists& rows) noe
     value.spawnSetHash = 0;
     follow_destination(value, rows);
     return true;
+}
+
+/** Shows the selected package's authored uses without claiming a particular ruleset is active. */
+void draw_activity_uses(const Lists& rows) noexcept {
+    if (rows.selected.nameLength == 0) {
+        return;
+    }
+    label::align();
+    if (rows.selected.activityUseCount == 0) {
+        ImGui::TextDisabled("Activity uses: unclassified");
+        return;
+    }
+    ImGui::TextDisabled("Activity uses");
+    // One bounded line per type preserves every use without truncating long playlist sets.
+    // Labels may repeat for distinct native hashes; the tooltip exposes identity and provenance.
+    const auto uses = std::span(rows.selected.activityUses).first(rows.selected.activityUseCount);
+    std::array<std::size_t, state::build_data::scenarios::kActivityUseCapacity> order{};
+    for (std::size_t index = 0; index < uses.size(); ++index) {
+        order[index] = index;
+    }
+    const auto sorted = std::span(order).first(uses.size());
+    std::sort(sorted.begin(), sorted.end(), [&uses](std::size_t left, std::size_t right) noexcept {
+        const auto& a = uses[left];
+        const auto& b = uses[right];
+        const std::string_view aLabel(a.label.data(), a.labelLength);
+        const std::string_view bLabel(b.label.data(), b.labelLength);
+        return aLabel != bLabel ? aLabel < bLabel : a.typeHash < b.typeHash;
+    });
+    if (ImGui::TreeNode("Known types")) {
+        for (const std::size_t index : sorted) {
+            const auto& use = uses[index];
+            if (use.labelLength == 0) {
+                ImGui::BulletText("Unnamed type 0x%08X", use.typeHash);
+            } else {
+                ImGui::BulletText("%.*s", static_cast<int>(use.labelLength), use.label.data());
+            }
+            if (ImGui::IsItemHovered()) {
+                ImGui::BeginTooltip();
+                ImGui::Text("Type hash: 0x%08X", use.typeHash);
+                using namespace state::build_data::scenarios;
+                ImGui::TextUnformatted(use.sources == kActivityUseSourceMask
+                                           ? "Direct activity and playlist references"
+                                       : use.sources == kDirectActivityUse
+                                           ? "Direct activity reference"
+                                           : "Playlist reference");
+                ImGui::EndTooltip();
+            }
+        }
+        ImGui::TreePop();
+    }
 }
 
 /**
@@ -267,6 +339,7 @@ void draw() noexcept {
 
     ImGui::Spacing();
     changed = draw_activity(value, rows) || changed;
+    draw_activity_uses(rows);
     ImGui::Spacing();
     changed = draw_bubble(value, rows) || changed;
     ImGui::Spacing();

--- a/Sunrise/src/state/build_data/cache/records/cache_scenario_records.cpp
+++ b/Sunrise/src/state/build_data/cache/records/cache_scenario_records.cpp
@@ -8,6 +8,8 @@ namespace {
 /** @return True when every field of the row fits its disk form. */
 [[nodiscard]] bool storable(const scenarios::Definition& value) noexcept {
     return value.nameLength != 0 && value.nameLength <= scenarios::kNameCapacity
+           && value.activityLabelLength <= scenarios::kActivityLabelCapacity
+           && value.activityUseCount <= scenarios::kActivityUseCapacity
            && value.bubbleCount <= scenarios::kBubbleCapacity && value.truncated <= 1
            && value.rosterGroupCount <= scenarios::kDestinationGroupCapacity
            && value.bubbleGroupCount <= scenarios::kDestinationBubbleGroupCapacity
@@ -56,8 +58,15 @@ bool encode(const scenarios::Definition& value, ScenarioRecord& record) noexcept
         return false;
     }
     std::copy(value.name.begin(), value.name.end(), record.name.begin());
+    std::copy(value.activityLabel.begin(), value.activityLabel.end(), record.activityLabel.begin());
     record.tag = value.tag;
     record.nameLength = value.nameLength;
+    record.activityLabelLength = value.activityLabelLength;
+    record.activityUseCount = value.activityUseCount;
+    for (std::size_t index = 0; index < value.activityUses.size(); ++index) {
+        const auto& use = value.activityUses[index];
+        record.activityUses[index] = {use.typeHash, use.label, use.labelLength, use.sources};
+    }
     record.bubbleCount = value.bubbleCount;
     record.truncated = value.truncated;
     record.rosterGroupCount = value.rosterGroupCount;
@@ -91,6 +100,8 @@ bool encode(const scenarios::Definition& value, ScenarioRecord& record) noexcept
 bool decode(const ScenarioRecord& record, scenarios::Definition& value) noexcept {
     value = {};
     if (record.nameLength == 0 || record.nameLength > scenarios::kNameCapacity
+        || record.activityLabelLength > scenarios::kActivityLabelCapacity
+        || record.activityUseCount > scenarios::kActivityUseCapacity
         || record.bubbleCount > scenarios::kBubbleCapacity || record.truncated > 1
         || record.rosterGroupCount > scenarios::kDestinationGroupCapacity
         || record.bubbleGroupCount > scenarios::kDestinationBubbleGroupCapacity
@@ -100,8 +111,16 @@ bool decode(const ScenarioRecord& record, scenarios::Definition& value) noexcept
         return false;
     }
     std::copy(record.name.begin(), record.name.end(), value.name.begin());
+    std::copy(
+        record.activityLabel.begin(), record.activityLabel.end(), value.activityLabel.begin());
     value.tag = record.tag;
     value.nameLength = record.nameLength;
+    value.activityLabelLength = record.activityLabelLength;
+    value.activityUseCount = record.activityUseCount;
+    for (std::size_t index = 0; index < record.activityUses.size(); ++index) {
+        const auto& use = record.activityUses[index];
+        value.activityUses[index] = {use.typeHash, use.label, use.labelLength, use.sources};
+    }
     value.bubbleCount = record.bubbleCount;
     value.truncated = record.truncated;
     value.rosterGroupCount = record.rosterGroupCount;

--- a/Sunrise/src/state/build_data/cache/records/format.h
+++ b/Sunrise/src/state/build_data/cache/records/format.h
@@ -29,7 +29,7 @@ inline constexpr std::array<char, 8> kCacheMagic{'S', 'U', 'N', 'R', 'I', 'S', '
  * Bump it when a stored shape changes, and when the extraction filling it changes what it writes.
  * A cached row survives a code change, so a corrected walk keeps publishing the old rows.
  */
-inline constexpr std::uint32_t kCacheFormatVersion = 44;
+inline constexpr std::uint32_t kCacheFormatVersion = 46;
 /** Signed -1 on disk means there is no equipment slot. */
 inline constexpr std::int8_t kAbsentEquipmentSlot = -1;
 /** The standard 64-bit FNV-1a offset basis starts the payload checksum. */
@@ -259,11 +259,23 @@ struct SocketEntryTableRecord {
     std::array<std::uint8_t, socket_entry_lists::kEntryCapacity> kinds{};
 };
 
-/** Disk form of one destination's extracted bubble layout and roster groups. */
+/** Packed type identity, localized label, and direct/playlist evidence flags. */
+struct ActivityUseRecord {
+    std::uint32_t typeHash{};
+    std::array<char, scenarios::kActivityLabelCapacity> label{};
+    std::uint8_t labelLength{};
+    std::uint8_t sources{};
+};
+
+/** Disk form of a scenario, including its localized title and authored activity uses. */
 struct ScenarioRecord {
     std::array<char, scenarios::kNameCapacity> name{};
+    std::array<char, scenarios::kActivityLabelCapacity> activityLabel{};
     std::uint32_t tag{};
     std::uint8_t nameLength{};
+    std::uint8_t activityLabelLength{};
+    std::uint8_t activityUseCount{};
+    std::array<ActivityUseRecord, scenarios::kActivityUseCapacity> activityUses{};
     std::uint8_t bubbleCount{};
     std::uint8_t truncated{};
     std::uint8_t rosterGroupCount{};
@@ -272,7 +284,7 @@ struct ScenarioRecord {
     /** Groups published through the delta's per-bubble sub-blocks. */
     std::uint8_t bubbleGroupCount{};
     /** Must be zero, so the packed destination row always matches. */
-    std::array<std::uint8_t, 2> reserved{};
+    std::array<std::uint8_t, 1> reserved{};
     std::array<char, scenarios::kSpawnStemCapacity> spawnStem{};
     std::array<std::uint8_t, scenarios::kBubbleCapacity> bubbleStates{};
     /** Each bubble's own name hash, in the same order as the states. */
@@ -436,17 +448,20 @@ static_assert(sizeof(VendorInstalledRowRecord)
               == 2 * sizeof(std::uint16_t) + vendors::kInstalledRowStride);
 static_assert(sizeof(HashNameRecord)
               == hash_names::kNameLength + sizeof(std::uint32_t) + 4 * sizeof(std::uint8_t));
-static_assert(sizeof(ScenarioRecord)
-              == scenarios::kNameCapacity + sizeof(std::uint32_t) + 10 * sizeof(std::uint8_t)
-                     + scenarios::kSpawnStemCapacity
-                     + 2 * scenarios::kBubbleCapacity * sizeof(std::uint8_t)
-                     + scenarios::kBubbleCapacity * sizeof(std::uint32_t)
-                     + scenarios::kBubbleCapacity * sizeof(std::uint16_t)
-                     + (scenarios::kDestinationGroupCapacity
-                        + scenarios::kDestinationPackageCapacity
-                        + scenarios::kDestinationBubbleGroupCapacity)
-                           * sizeof(std::uint16_t)
-                     + scenarios::kDestinationBubbleGroupCapacity * scenarios::kBubbleMaskBytes);
+static_assert(sizeof(ActivityUseRecord)
+              == sizeof(std::uint32_t) + scenarios::kActivityLabelCapacity
+                     + 2 * sizeof(std::uint8_t));
+static_assert(
+    sizeof(ScenarioRecord)
+    == scenarios::kNameCapacity + scenarios::kActivityLabelCapacity + sizeof(std::uint32_t)
+           + 11 * sizeof(std::uint8_t) + scenarios::kActivityUseCapacity * sizeof(ActivityUseRecord)
+           + scenarios::kSpawnStemCapacity + 2 * scenarios::kBubbleCapacity * sizeof(std::uint8_t)
+           + scenarios::kBubbleCapacity * sizeof(std::uint32_t)
+           + scenarios::kBubbleCapacity * sizeof(std::uint16_t)
+           + (scenarios::kDestinationGroupCapacity + scenarios::kDestinationPackageCapacity
+              + scenarios::kDestinationBubbleGroupCapacity)
+                 * sizeof(std::uint16_t)
+           + scenarios::kDestinationBubbleGroupCapacity * scenarios::kBubbleMaskBytes);
 static_assert(sizeof(SpawnStemRecord)
               == spawn_sets::kStemNameCapacity + sizeof(std::uint32_t) + 3 * sizeof(std::uint16_t)
                      + 2 * sizeof(std::uint8_t));

--- a/Sunrise/src/state/build_data/scenarios/definition.h
+++ b/Sunrise/src/state/build_data/scenarios/definition.h
@@ -21,6 +21,25 @@ inline constexpr std::size_t kBubbleCapacity = 64;
  * bytes wide, so a longer scenario name could never match.
  */
 inline constexpr std::size_t kNameCapacity = 40;
+/** English text capacity that keeps a titled row inside the picker's 96-byte label storage. */
+inline constexpr std::size_t kActivityLabelCapacity = 48;
+/** Headroom above the measured per-scenario type set, including playlist-derived uses. */
+inline constexpr std::size_t kActivityUseCapacity = 32;
+/** A directly named activity and a playlist ancestor are distinct evidence sources. */
+inline constexpr std::uint8_t kDirectActivityUse = 1;
+inline constexpr std::uint8_t kPlaylistActivityUse = 2;
+inline constexpr std::uint8_t kActivityUseSourceMask = kDirectActivityUse | kPlaylistActivityUse;
+
+/** Native type identity, optional length-delimited English text, and reference provenance. */
+struct ActivityUse {
+    std::uint32_t typeHash{};
+    std::array<char, kActivityLabelCapacity> label{};
+    std::uint8_t labelLength{};
+    /** Bitwise union of direct and playlist evidence; never a gameplay capability claim. */
+    std::uint8_t sources{};
+
+    bool operator==(const ActivityUse&) const = default;
+};
 /** The byte a bubble carries when its first slice-set state is enabled. */
 inline constexpr std::uint8_t kBubbleEnabledByte = 0x80;
 /** The byte every other bubble carries, including one with no readable state array. */
@@ -74,13 +93,19 @@ struct RosterGroup {
     std::array<std::uint16_t, kRosterSlotCapacity> slotIndices{};
 };
 
-/** One destination's bubble layout, reduced to what the activity messages publish. */
+/** One destination's shared metadata, bubble layout, and activity-message roster data. */
 struct Definition {
     /** Lowercase package name without its `:scenario_client` suffix. */
     std::array<char, kNameCapacity> name{};
+    /** Optional English title, length-delimited and never a lookup key. */
+    std::array<char, kActivityLabelCapacity> activityLabel{};
     /** Tag the layout was read from, kept so a stale cache can be told from a missing one. */
     std::uint32_t tag{};
     std::uint8_t nameLength{};
+    std::uint8_t activityLabelLength{};
+    /** Uses are unique and sorted by type hash. Empty means no classification was recovered. */
+    std::uint8_t activityUseCount{};
+    std::array<ActivityUse, kActivityUseCapacity> activityUses{};
     /** Used entries in the arrays below. */
     std::uint8_t bubbleCount{};
     /** Set when the scenario declared more bubbles than the wire array holds. */

--- a/Sunrise/src/state/build_data/scenarios/scenario_catalog.cpp
+++ b/Sunrise/src/state/build_data/scenarios/scenario_catalog.cpp
@@ -51,6 +51,8 @@ Table<RosterGroup, kRosterGroupCapacity> g_groups;
  */
 [[nodiscard]] bool canonical(const Definition& definition, std::size_t groupCount) noexcept {
     if (definition.nameLength == 0 || definition.nameLength > kNameCapacity
+        || definition.activityLabelLength > kActivityLabelCapacity
+        || definition.activityUseCount > kActivityUseCapacity
         || definition.bubbleCount > kBubbleCapacity || definition.truncated > 1
         || definition.rosterGroupCount > kDestinationGroupCapacity
         || definition.bubbleGroupCount > kDestinationBubbleGroupCapacity
@@ -90,6 +92,32 @@ Table<RosterGroup, kRosterGroupCapacity> g_groups;
     for (std::size_t index = definition.nameLength; index < kNameCapacity; ++index) {
         if (definition.name[index] != '\0') {
             return false;
+        }
+    }
+    for (std::size_t index = 0; index < kActivityLabelCapacity; ++index) {
+        const char value = definition.activityLabel[index];
+        if (index < definition.activityLabelLength ? (value < ' ' || value > '~') : value != '\0') {
+            return false;
+        }
+    }
+    for (std::size_t index = 0; index < kActivityUseCapacity; ++index) {
+        const ActivityUse& use = definition.activityUses[index];
+        if (index >= definition.activityUseCount) {
+            if (use != ActivityUse{}) {
+                return false;
+            }
+            continue;
+        }
+        if (use.typeHash == 0 || use.labelLength > use.label.size() || use.sources == 0
+            || (use.sources & ~kActivityUseSourceMask) != 0
+            || (index != 0 && use.typeHash <= definition.activityUses[index - 1].typeHash)) {
+            return false;
+        }
+        for (std::size_t byte = 0; byte < use.label.size(); ++byte) {
+            if (byte < use.labelLength ? (use.label[byte] < ' ' || use.label[byte] > '~')
+                                       : use.label[byte] != '\0') {
+                return false;
+            }
         }
     }
     for (std::size_t index = 0; index < kBubbleCapacity; ++index) {

--- a/docs/activity-metadata.md
+++ b/docs/activity-metadata.md
@@ -1,0 +1,70 @@
+# Activity metadata
+
+Activity Override shows optional English titles alongside internal scenario names. Search matches
+either; selecting a row still uses its internal package key. Expand **Known types** beneath
+**Activity uses** to see the selected scenario's native activity types. Hover a type for its hash
+and direct/playlist provenance. These associations do not select a ruleset or imply playability.
+
+Metadata comes from the user's archived `86657.20.08.23` packages. Titles join metadata definition
+tags to scenarios; uses join exact scenario names in investment activities and their playlist
+descendants. The existing package worker, reader, BuildData catalog, and cache own this work.
+Package I/O does not run on UI frames. No hook, native function address, or live manifest is added.
+
+## Data contract
+
+Read through `state/build_data/runtime.h` using `find_scenario_layout` or
+`snapshot_scenario_layouts`. Both return owned copies, independent of the UI and extraction buffers:
+
+```cpp
+namespace data = sunrise::state::build_data;
+data::scenarios::Definition row{};
+if (data::find_scenario_layout(packageName, row)) {
+    const std::string_view title(row.activityLabel.data(), row.activityLabelLength);
+    const auto uses = std::span(row.activityUses).first(row.activityUseCount);
+    // Views belong to this local row. Compare use.typeHash, not its display label.
+}
+```
+
+- Titles and type labels are optional, length-delimited printable ASCII, at most 48 bytes. A full
+  buffer need not have a terminator. Empty titles fall back to the internal name.
+- Each scenario holds up to 32 uses, unique and sorted by stable type hash. `sources` combines
+  `kDirectActivityUse` and `kPlaylistActivityUse`. Different hashes can have identical labels.
+- An empty use set means unclassified. These native types are not the public API mode enum and
+  do not retain individual activity IDs, difficulties, modifiers, or playlist paths.
+- A whole-catalog snapshot needs caller-owned storage for `scenarios::kDefinitionCapacity`, kept
+  off a small stack. Undersized snapshots fail; missing rows differ from rows with empty metadata.
+
+## Validation and fallback
+
+Activity tables validate classes, extents, ordinals, identities, and signed relative pointers.
+Playlist traversal is bounded and cycle-safe. Type names require a unique UI root and matching
+native/UI identities; unreadable names retain their native hashes. Invalid tables/graphs abandon
+type publication, and a use-set overflow leaves that scenario wholly unclassified.
+
+Conflicting title mappings/text and punctuation-only placeholders are suppressed. The string
+decoder rejects unsupported encodings and overlong output. `activity_labels` and `activity_types`
+logs distinguish read/parse failures, conflicts, name failures, and capacity overflow. Recovered
+offsets, classes, and strides are documented beside the parsers in
+`middleware/content/packages/tables/activity_metadata_reader.*` and `localized_string_reader.*`.
+
+Cache version 46 stores the metadata and older versions rebuild normally. Canonical validation
+checks lengths, text, source flags, ordering, and zeroed unused storage on extraction/restoration.
+Changes to stored layout or extraction semantics require cache invalidation. English is the only
+verified language; another language needs a measured slot/encoding, decoder/font support, and
+language-aware cache handling.
+
+## Tests
+
+The focused synthetic harness covers parsers, graph traversal, and metadata/cache invariants:
+
+```powershell
+cmake -S tests/activity_metadata -B build/activity-metadata-tests -G "Visual Studio 18 2026" -A x64
+cmake --build build/activity-metadata-tests --config Release
+ctest --test-dir build/activity-metadata-tests -C Release --output-on-failure
+```
+
+Fixtures contain no game data; parser/graph checks also build with a host C++20 compiler outside
+Windows. Catalog/cache checks run on Windows. Runtime validation still needs the exact archived
+client: sign-on/orbit, title/internal-name search, repeated selection, unnamed/unclassified
+fallbacks, distinct hashes with equal labels, destination loading, clean shutdown, and cold/warm/
+stale-cache behavior. Record results in the PR; keep game bytes and captures local.

--- a/tests/activity_metadata/CMakeLists.txt
+++ b/tests/activity_metadata/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.25)
+project(SunriseActivityMetadataTests LANGUAGES CXX)
+enable_testing()
+
+set(SUNRISE_SOURCE "${CMAKE_CURRENT_LIST_DIR}/../../Sunrise/src")
+add_executable(activity_metadata_tests
+    activity_metadata_tests.cpp
+    "${SUNRISE_SOURCE}/middleware/content/packages/tables/definition_index_table.cpp"
+    "${SUNRISE_SOURCE}/middleware/content/packages/tables/activity_metadata_reader.cpp"
+    "${SUNRISE_SOURCE}/middleware/content/packages/tables/activity_type_mapping.cpp"
+    "${SUNRISE_SOURCE}/middleware/content/packages/tables/localized_string_reader.cpp")
+target_include_directories(activity_metadata_tests PRIVATE "${SUNRISE_SOURCE}")
+target_compile_features(activity_metadata_tests PRIVATE cxx_std_20)
+if(MSVC)
+    target_compile_options(activity_metadata_tests PRIVATE /W4 /WX)
+else()
+    target_compile_options(activity_metadata_tests PRIVATE -Wall -Wextra -Werror)
+endif()
+if(WIN32)
+    target_compile_definitions(activity_metadata_tests PRIVATE NOMINMAX WIN32_LEAN_AND_MEAN)
+    target_sources(activity_metadata_tests PRIVATE
+        "${SUNRISE_SOURCE}/state/build_data/cache/records/cache_scenario_records.cpp"
+        "${SUNRISE_SOURCE}/state/build_data/scenarios/scenario_catalog.cpp")
+endif()
+add_test(NAME activity_metadata COMMAND activity_metadata_tests)

--- a/tests/activity_metadata/activity_metadata_tests.cpp
+++ b/tests/activity_metadata/activity_metadata_tests.cpp
@@ -1,0 +1,340 @@
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <span>
+#include <string_view>
+#include <vector>
+
+#include "middleware/content/packages/tables/activity_metadata_reader.h"
+#include "middleware/content/packages/tables/activity_type_mapping.h"
+#include "middleware/content/packages/tables/localized_string_reader.h"
+#ifdef _WIN32
+#include "state/build_data/cache/records/codec.h"
+#include "state/build_data/scenarios/scenario_catalog.h"
+#endif
+
+namespace tables = sunrise::middleware::content::packages::tables;
+namespace {
+std::size_t checks{};
+std::size_t failures{};
+
+void expect(bool value, const char* name) {
+    ++checks;
+    if (!value) {
+        ++failures;
+        std::fprintf(stderr, "FAIL: %s\n", name);
+    }
+}
+
+template <typename T> void put(std::vector<std::byte>& blob, std::size_t offset, T value) {
+    if (offset > blob.size() || sizeof value > blob.size() - offset) {
+        std::abort();
+    }
+    std::memcpy(blob.data() + offset, &value, sizeof value);
+}
+
+void array(std::vector<std::byte>& blob,
+           std::size_t descriptor,
+           std::size_t header,
+           std::uint64_t count,
+           std::uint32_t elementClass) {
+    put(blob, descriptor, count);
+    put(blob,
+        descriptor + 8,
+        static_cast<std::int64_t>(header) - static_cast<std::int64_t>(descriptor + 8));
+    put(blob, header - 4, std::uint32_t{0x80809FBD});
+    put(blob, header, count);
+    put(blob, header + 8, elementClass);
+}
+
+/** Invented bytes only: this fixture contains no extracted game content. */
+std::vector<std::byte> fixture() {
+    std::vector<std::byte> blob(0x300);
+    array(blob, 8, 0x30, 1, tables::kActivityIndexClass);
+    put(blob, 0x40, std::uint32_t{123});
+    put(blob, 0x48, std::int64_t{0x18});
+    put(blob, 0x60, std::uint32_t{123});
+    put(blob, 0xC8, std::int64_t{0xB8});
+    put(blob, 0x13A, std::uint8_t{9});
+    constexpr char name[] = "example_scenario";
+    std::memcpy(blob.data() + 0x180, name, sizeof name);
+    return blob;
+}
+
+void parser_tests() {
+    auto blob = fixture();
+    tables::Array rows{};
+    tables::ActivityDefinition value{};
+    expect(tables::activity_index(blob, rows), "index extent");
+    auto parse = [&]() { return tables::activity_definition_at(blob, rows, 0, 54, value); };
+    expect(parse() && value.hash == 123 && value.typeIndex == 9
+               && value.scenarioName == "example_scenario" && value.playlist.count == 0,
+           "definition and exact scenario name");
+    expect(!tables::activity_definition_at(blob, rows, 1, 54, value) && value.hash == 0,
+           "invalid ordinal clears output");
+    expect(!tables::activity_definition_at(blob, rows, 0, 9, value), "type index bound");
+    expect(!tables::activity_definition_at(std::span(blob).first(0x13A), rows, 0, 54, value),
+           "truncated definition");
+    put(blob, 0xC8, std::int64_t{0});
+    expect(parse() && value.scenarioName.empty(), "absent scenario name");
+    put(blob, 0xC8, (std::numeric_limits<std::int64_t>::max)());
+    expect(!parse(), "positive relative overflow");
+    put(blob, 0xC8, (std::numeric_limits<std::int64_t>::min)());
+    expect(!parse(), "negative relative overflow");
+    blob = fixture();
+    put(blob, 0x48, std::int64_t{0});
+    expect(!parse(), "absent definition");
+    blob = fixture();
+    put(blob, 0x60, std::uint32_t{124});
+    expect(!parse(), "repeated identity mismatch");
+    blob = fixture();
+    put(blob, 0x180, '/');
+    expect(!parse(), "non-package name rejected");
+    blob = fixture();
+    std::memset(blob.data() + 0x180, 'a', 41);
+    expect(!parse(), "unterminated name rejected");
+    put(blob, 0x1A8, '\0');
+    expect(parse() && value.scenarioName.size() == 40, "40-byte key boundary");
+    blob = fixture();
+    array(blob, 8, 0x30, 1, tables::kActivityTypeRowClass);
+    expect(!tables::activity_index(blob, rows), "wrong index class");
+    blob = fixture();
+    expect(tables::activity_index(blob, rows), "restore valid index");
+    put(blob, 0x78, std::int64_t{0x138}); // playlist at 0x1B0
+    array(blob, 0x1B8, 0x1E0, 1, tables::kActivityPlaylistRowClass);
+    put(blob, 0x1F8, std::int16_t{0});
+    expect(parse() && value.playlist.count == 1, "playlist descriptor");
+    std::uint16_t child = 0;
+    expect(tables::activity_playlist_child_at(blob, value.playlist, 0, 1, child) && child == 0,
+           "self-reference is a valid child index");
+    put(blob, 0x1F8, std::int16_t{-1});
+    expect(!tables::activity_playlist_child_at(blob, value.playlist, 0, 1, child),
+           "negative child");
+    put(blob, 0x1F8, std::int16_t{1});
+    expect(!tables::activity_playlist_child_at(blob, value.playlist, 0, 1, child),
+           "child past table");
+    array(blob, 0x1B8, 0x1E0, 1, tables::kActivityIndexClass);
+    expect(!parse(), "wrong playlist class");
+
+    blob.assign(256, std::byte{});
+    array(blob, 8, 0x30, 1, tables::kActivityTypeUiRowClass);
+    put(blob, 0x40, std::uint32_t{456});
+    put(blob, 0x44, std::uint16_t{2});
+    put(blob, 0x48, std::uint32_t{789});
+    tables::ActivityTypeName name{};
+    expect(tables::activity_types(blob, true, rows)
+               && tables::activity_type_name_at(blob, rows, 0, name) && name.hash == 456
+               && name.containerIndex == 2 && name.resourceHash == 789,
+           "type UI name reference");
+    expect(!tables::activity_types(std::span(blob).first(191), true, rows), "truncated UI row");
+    array(blob, 8, 0x30, 1, tables::kActivityTypeRowClass);
+    std::uint32_t hash = 0;
+    expect(tables::activity_types(blob, false, rows)
+               && tables::activity_type_hash_at(blob, rows, 0, hash) && hash == 456,
+           "stable native type identity");
+    array(blob, 8, 0x30, 1, tables::kInvestmentStringRegistryRowClass);
+    put(blob, 0x44, std::uint32_t{0x80800033});
+    expect(tables::activity_string_container_tag(blob, 0, hash) && hash == 0x80800033,
+           "registry container reference");
+    expect(!tables::activity_string_container_tag(blob, 1, hash), "registry index bound");
+    put(blob, 0x44, std::uint32_t{1});
+    expect(!tables::activity_string_container_tag(blob, 0, hash), "registry invalid tag");
+}
+
+void graph_tests() {
+    std::array<tables::ActivityGraphNode, 4> nodes{};
+    nodes[0] = {tables::kUnmappedActivityScenario, 1, 0, 3};
+    nodes[1] = {0, 2, 3, 1};
+    nodes[2] = {1, 3, 4, 1};
+    nodes[3] = {2, 4, 5, 1};
+    std::array<std::uint16_t, 6> edges{1, 2, 1, 3, 3, 0};
+    std::array<std::uint8_t, 3> reachable{};
+    std::array<std::uint8_t, 4> visited{};
+    std::array<std::uint16_t, 4> queue{};
+    auto walk = [&]() {
+        return tables::activity_playlist_scenarios(nodes, edges, 0, reachable, visited, queue);
+    };
+    expect(walk() && reachable == std::array<std::uint8_t, 3>{1, 1, 1},
+           "cycle, diamond, and repeated edge terminate with every scenario");
+    expect(walk() && reachable == std::array<std::uint8_t, 3>{1, 1, 1},
+           "repeat traversal resets scratch");
+    edges[5] = 3;
+    expect(walk() && reachable[2] == 1, "self cycle terminates");
+    edges[5] = 4;
+    expect(!walk() && reachable == decltype(reachable){}, "bad edge clears partial result");
+    edges[5] = 0;
+    nodes[2].firstChild = 100;
+    expect(!walk() && reachable == decltype(reachable){}, "bad child range clears result");
+    nodes[2].firstChild = 4;
+    nodes[2].scenarioIndex = 3;
+    expect(!walk(), "scenario index bound");
+    nodes[2].scenarioIndex = 1;
+    expect(!tables::activity_playlist_scenarios(
+               nodes, edges, 0, reachable, visited, std::span(queue).first(3)),
+           "queue capacity");
+    expect(!tables::activity_playlist_scenarios(nodes, edges, 4, reachable, visited, queue),
+           "root index bound");
+}
+
+/** Title metadata and string readers, exercised with invented resources rather than game data. */
+void label_tests() {
+    std::vector<std::byte> metadata(0x50);
+    put(metadata, 8, std::uint32_t{123});
+    array(metadata, 0x10, 0x30, 2, tables::kActivityDefinitionTagClass);
+    put(metadata, 0x40, std::uint32_t{0x80800011});
+    put(metadata, 0x44, std::uint32_t{0x80800022});
+    tables::ActivityMetadata activity{};
+    std::uint32_t tag = 0;
+    expect(tables::activity_metadata(metadata, activity) && activity.displayNameHash == 123,
+           "title metadata resource hash");
+    expect(tables::activity_definition_tag_at(metadata, activity, 1, tag) && tag == 0x80800022,
+           "title metadata scenario reference");
+    expect(!tables::activity_definition_tag_at(metadata, activity, 2, tag),
+           "title metadata tag ordinal bound");
+    put(metadata, 0x38, std::uint32_t{0x80800001});
+    expect(!tables::activity_metadata(metadata, activity), "title metadata class validation");
+
+    std::vector<std::byte> header(0x50);
+    array(header, 8, 0x30, 2, 0x80800001);
+    put(header, 0x18, std::uint32_t{0x80800033});
+    put(header, 0x40, std::uint32_t{123});
+    put(header, 0x44, std::uint32_t{456});
+    tables::LocalizedStrings strings{};
+    expect(tables::localized_strings(header, strings)
+               && tables::localized_hash_at(header, strings, 1, tag) && tag == 456,
+           "localized resource ordinal");
+    expect(tables::localized_english_tag(header, tag) && tag == 0x80800033,
+           "verified English slot");
+    std::vector<std::byte> language(0xE0);
+    array(language, 0x48, 0x70, 1, tables::kStringCombinationClass);
+    put(language, 0x80, std::int64_t{0x20});
+    put(language, 0x88, std::int64_t{1});
+    put(language, 0xA8, std::int64_t{0x28});
+    put(language, 0xB4, std::uint16_t{4});
+    put(language, 0xB6, std::uint16_t{4});
+    put(language, 0xB8, std::uint16_t{1});
+    constexpr char encoded[] = "Sdrs"; // The verified ASCII shift decodes this synthetic text.
+    std::memcpy(language.data() + 0xD0, encoded, 4);
+    std::array<char, 4> decoded{};
+    std::uint8_t length = 0;
+    std::uint64_t count = 0;
+    auto decode = [&]() { return tables::localized_ascii_string_at(language, 0, decoded, length); };
+    expect(tables::localized_string_count(language, count) && count == 1,
+           "language combination count");
+    expect(decode() && std::string_view(decoded.data(), length) == "Test",
+           "exact-capacity shifted ASCII has no required terminator");
+    expect(!tables::localized_ascii_string_at(language, 0, std::span(decoded).first(3), length),
+           "localized output overflow rejected");
+    put(language, 0xB6, std::uint16_t{3});
+    expect(!decode() && length == 0 && decoded == decltype(decoded){},
+           "mismatched localized lengths clear output");
+    put(language, 0xB6, std::uint16_t{4});
+    put(language, 0xD2, std::uint8_t{0xFF});
+    expect(!decode() && length == 0 && decoded == decltype(decoded){},
+           "unsupported encoding clears partially decoded text");
+    put(language, 0xA8, (std::numeric_limits<std::int64_t>::max)());
+    expect(!decode(), "localized pointer overflow rejected");
+}
+
+#ifdef _WIN32
+void cache_tests() {
+    namespace layouts = sunrise::state::build_data::scenarios;
+    namespace records = sunrise::state::build_data::cache::records;
+    layouts::Definition row{};
+    row.name[0] = 'x';
+    row.nameLength = 1;
+    row.activityUseCount = 2;
+    row.activityUses[0].typeHash = 10;
+    row.activityUses[0].sources = layouts::kDirectActivityUse;
+    row.activityUses[0].label[0] = 'A';
+    row.activityUses[0].labelLength = 1;
+    row.activityUses[1].typeHash = 20;
+    row.activityUses[1].sources = layouts::kActivityUseSourceMask;
+    records::ScenarioRecord disk{};
+    records::ScenarioRecord diskAgain{};
+    layouts::Definition restored{};
+    auto valid = [](const auto& value) { return layouts::valid(std::span(&value, 1), {}); };
+    expect(valid(row), "canonical many-to-many uses with unnamed fallback");
+    expect(records::encode(row, disk) && records::decode(disk, restored) && valid(restored)
+               && restored.activityUseCount == 2 && restored.activityUses == row.activityUses,
+           "cache round trip preserves identity, labels, and provenance");
+    expect(records::encode(restored, diskAgain) && std::memcmp(&disk, &diskAgain, sizeof disk) == 0,
+           "canonical cache byte equality");
+    disk.activityUseCount = 33;
+    expect(!records::decode(disk, restored), "cache use-count bound");
+    row.activityUses[1].typeHash = 10;
+    expect(!valid(row), "duplicate type identity rejected");
+    row.activityUses[1].typeHash = 5;
+    expect(!valid(row), "noncanonical ordering rejected");
+    row.activityUses[1].typeHash = 20;
+    row.activityUses[1].sources = 4;
+    expect(!valid(row), "unknown provenance bits rejected");
+    row.activityUses[1].sources = layouts::kPlaylistActivityUse;
+    row.activityUses[0].label[1] = 'z';
+    expect(!valid(row), "label tail must be zero");
+    row.activityUses[0].label[1] = 0;
+    row.activityUseCount = 1;
+    expect(!valid(row), "unused use rows must be zero");
+    row.activityUses[1] = {};
+    expect(valid(row), "canonical unused rows");
+
+    row.activityLabel[0] = '\n';
+    row.activityLabelLength = 1;
+    expect(!valid(row), "nonprintable activity title rejected");
+    row.activityLabel[0] = '\0';
+    expect(!valid(row), "embedded title terminator rejected");
+    row.activityLabel.fill('T');
+    row.activityLabelLength = static_cast<std::uint8_t>(row.activityLabel.size());
+    expect(valid(row) && records::encode(row, disk) && records::decode(disk, restored)
+               && restored.activityLabel == row.activityLabel
+               && restored.activityLabelLength == row.activityLabelLength,
+           "full-capacity title survives cache without a terminator");
+    disk.activityLabelLength = static_cast<std::uint8_t>(row.activityLabel.size() + 1);
+    expect(!records::decode(disk, restored), "cache title length bound");
+    row.activityLabelLength = 1;
+    expect(!valid(row), "unused title tail must be zero");
+}
+
+/** New display metadata must not change scenario identity or admit invalid replacements. */
+void consumer_tests() {
+    namespace layouts = sunrise::state::build_data::scenarios;
+    layouts::clear();
+    layouts::Definition row{};
+    row.name[0] = 'x';
+    row.nameLength = 1;
+    row.activityLabel[0] = 'T';
+    row.activityLabelLength = 1;
+    row.activityUseCount = 2;
+    row.activityUses[0] = {10, {'A'}, 1, layouts::kDirectActivityUse};
+    row.activityUses[1] = {20, {'A'}, 1, layouts::kPlaylistActivityUse};
+    layouts::Definition found{};
+    expect(layouts::replace(std::span(&row, 1), {}) && layouts::find("x", found)
+               && found.activityUseCount == 2 && found.activityUses == row.activityUses,
+           "catalog preserves distinct identities with equal English names");
+    row.activityUses[1].typeHash = 10;
+    expect(!layouts::replace(std::span(&row, 1), {}) && layouts::find("x", found)
+               && found.activityUses[1].typeHash == 20,
+           "invalid replacement preserves the previous catalog");
+    expect(!layouts::find("T", found) && found.activityUseCount == 0,
+           "display title is never a lookup key and misses clear output");
+    layouts::clear();
+}
+#endif
+} // namespace
+
+int main() {
+    parser_tests();
+    graph_tests();
+    label_tests();
+#ifdef _WIN32
+    cache_tests();
+    consumer_tests();
+#endif
+    std::printf("Activity metadata tests: %zu checks, %zu failures\n", checks, failures);
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Activity Override currently lists internal scenario names without describing the activities that
use them. This adds package-derived English titles and native activity types to the same picker.
For example, `pvp_ness` displays as `Altar of Flame (pvp_ness)`; expanding **Known types** shows
its direct/playlist uses. Search matches titles and internal names, while selection keeps the
internal package key.

## Implementation

- Extract titles and native activity/playlist associations through the existing bounded scenario
  worker, package reader, and scratch storage. The shared string reader handles the verified
  English slot. Recovered classes, offsets, and strides are documented beside the parsers.
- Publish owned metadata through the existing BuildData catalog and cache (version 46). Type
  hashes remain distinct even when labels match. Invalid input falls back to internal names,
  unnamed hashes, or unclassified scenarios; playlist traversal is bounded and cycle-safe.
- Display this metadata in the existing server UI. No native hook, separate cache, network route,
  or game-content table is introduced. `docs/activity-metadata.md` describes the data contract.

## Validation

Base: `01888412edd6aba5071b78fef83917c9e6ef21f4` (`master`).
Tested commit: `5c14dc3558bc9b84792b6beea489bf36b1107085`.

```powershell
msbuild Sunrise.sln /m /p:Configuration=Release /p:Platform=x64 /verbosity:minimal
cmake -S tests/activity_metadata -B build/activity-metadata-tests -G "Visual Studio 18 2026" -A x64
cmake --build build/activity-metadata-tests --config Release
ctest --test-dir build/activity-metadata-tests -C Release --output-on-failure
git diff upstream/master..HEAD --check
```

Release x64 passes with Visual Studio Build Tools 2026, v145, MSVC 19.51.36256, and SDK
10.0.26100.0. The synthetic harness passes 64 checks under `/W4 /WX`; it covers parser bounds,
malformed pointers/ordinals, cyclic playlists, and metadata/catalog/cache invariants. LLVM 22.1.8
clang-tidy passes all 11 changed production C++ files using the repository configuration and a
valid compilation database. Formatting and diff checks pass.

On a separate archived `86657.20.08.23` installation:

- Verified startup, local sign-on/orbit, titled activity selection, named/unnamed native types,
  and distinct entries with equal labels. Title search and warm restoration were checked before
  the final comment-only rebuild; the fresh extraction also displayed the same metadata.
- Loaded Director -> Earth -> Trostland and exited normally through the game menu. The cold
  and stale-cache runs ended without shutdown error events.
- Cold and stale-v45 rebuilds both recovered 53 titles and 298 of 466 classified scenarios:
  1,170 activities, 54 types, 51 type names, 83 playlists, 1,407 edges, zero use-set overflow.
  Two string headers fail structural validation, one placeholder is rejected, one title conflict
  is suppressed, and two type-name references are unresolved; these produce bounded fallbacks.
- Cold, stale, and retained warm caches are byte-identical (SHA-256
  `27F936535EF3CC2F6A730647861157939C62C24760D946D5AFC0E0D5701ECC23`). Warm startup performs
  no metadata extraction. Direct upstream-v44 migration was not separately exercised.

Final tested DLL SHA-256: `D3D1385EE6C34020610FA88764773428C2B204DE573A7D1AAB3F99179AFBBA2E`.
An interrupted earlier warm run logged a graphics-hook shutdown failure; subsequent normal
menu/title-screen exits did not reproduce it. The graphics-hook lifecycle is outside this diff.

## Limits

English printable ASCII only, up to 48 bytes per label; coverage is partial. Activity uses are
metadata associations, not a ruleset selector or proof of mission/mode playability. Synthetic
tests do not exercise package I/O, UI-root discovery, or the interactive UI.

No game data, extracted packages, generated name tables, caches, DLLs, credentials, or runtime
captures are included. Required content is read from the user's own archived installation.
