### PR TITLE
Fix catalyst-enabled sign-in exceeding native unlock override capacity

### DIFF
--- a/Sunrise/src/client/content/items/packages/package_item_rows.cpp
+++ b/Sunrise/src/client/content/items/packages/package_item_rows.cpp
@@ -1,9 +1,13 @@
 #include <array>
+#include <cstring>
 #include <span>
+#include <vector>
 
+#include "../../../../middleware/content/packages/tables/definition_index_table.h"
 #include "../../../../state/build_data/items/catalysts/exotic_catalyst_builder.h"
 #include "../../../../state/build_data/items/details/item_detail_catalog.h"
 #include "../../../../state/build_data/runtime.h"
+#include "../../../../state/unlocks/definition.h"
 #include "internal.h"
 #include "package_socket_plug_build.h"
 
@@ -19,6 +23,35 @@ namespace build_items = state::build_data::items;
  * TODO: replace with a build_data predicate for catalyst build support; nothing exports one yet.
  */
 bool g_catalystsUnsupported = false;
+
+/** Reads the package's account flag-map table into its own blob, leaving the item blobs alone. */
+[[nodiscard]] bool read_catalyst_account_mappings(
+    const reader::Source& source,
+    Storage& storage,
+    std::vector<build_items::catalysts::AccountFlagMapping>& output) noexcept {
+    std::uint32_t tag = 0;
+    tables::Array rows{};
+    std::vector<std::byte> blob;
+    if (!tables::slot_tag(storage.root, tables::kUnlockFlagMapTableSlot, tag) || tag == 0
+        || tables::package_of(tag) == tables::kAbsentPackageId
+        || !reader::read_tag(source, storage.scratch, tag, blob)
+        || !tables::find_array_at(blob, tables::kAccountFlagMapDescriptor, rows) || rows.count == 0
+        || rows.count > state::unlocks::kAccountFlagCapacity || rows.dataOffset > blob.size()
+        || rows.count > (blob.size() - rows.dataOffset) / tables::kUnlockMapRowStride) {
+        return false;
+    }
+    output.clear();
+    for (std::size_t row = 0; row < rows.count; ++row) {
+        std::int16_t slot = -1;
+        const auto at = rows.dataOffset + row * tables::kUnlockMapRowStride
+                        + tables::kUnlockMapDestinationSlotOffset;
+        std::memcpy(&slot, blob.data() + at, sizeof slot);
+        if (slot >= 0) {
+            output.push_back({static_cast<std::uint16_t>(slot), static_cast<std::uint16_t>(row)});
+        }
+    }
+    return true;
+}
 
 /** @return True when one extracted detail can join the currently published numeric domains. */
 [[nodiscard]] bool publishable_detail(const build_details::Definition& detail) noexcept {
@@ -194,6 +227,12 @@ bool build_item_rows(const reader::Source& source,
             catalystRows{};
         std::size_t catalystCount = 0;
         state::build_data::items::catalysts::Report catalystReport{};
+        std::vector<state::build_data::items::catalysts::AccountFlagMapping> catalystMappings;
+        if (published && needCatalysts
+            && !read_catalyst_account_mappings(source, storage, catalystMappings)) {
+            reason = "catalyst_account_mapping";
+            return false;
+        }
         const state::build_data::items::catalysts::Source catalystSource{
             {},
             std::span(storage.rows).first(rowCount),
@@ -204,6 +243,7 @@ bool build_item_rows(const reader::Source& source,
             storage.catalystCompletionConditions,
             storage.catalystAcquisitionGates,
             storage.catalystObjectiveValues,
+            catalystMappings,
         };
         bool catalystBuilt = false;
         if (published && needCatalysts) {

--- a/Sunrise/src/state/build_data/cache/records/cache_exotic_catalyst_record_codec.cpp
+++ b/Sunrise/src/state/build_data/cache/records/cache_exotic_catalyst_record_codec.cpp
@@ -18,6 +18,7 @@ bool encode(const items::catalysts::Definition& value, ExoticCatalystRecord& rec
     record.progressPlugDefinitionIndex = value.progressPlugDefinitionIndex;
     record.effectDefinitionIndex = value.effectDefinitionIndex;
     record.acquisitionDefinitionIndex = value.acquisitionDefinitionIndex;
+    record.completionAccountFlagIndices = value.completionAccountFlagIndices;
     record.completionFlagDefinitionIndices = value.completion.flags;
     for (std::size_t index = 0; index < value.completion.values.size(); ++index) {
         record.completionValueIndices[index] = value.completion.values[index].index;
@@ -49,6 +50,7 @@ bool decode(const ExoticCatalystRecord& record, items::catalysts::Definition& va
     value.progressPlugDefinitionIndex = record.progressPlugDefinitionIndex;
     value.effectDefinitionIndex = record.effectDefinitionIndex;
     value.acquisitionDefinitionIndex = record.acquisitionDefinitionIndex;
+    value.completionAccountFlagIndices = record.completionAccountFlagIndices;
     value.completion.flags = record.completionFlagDefinitionIndices;
     for (std::size_t index = 0; index < value.completion.values.size(); ++index) {
         value.completion.values[index] = {record.completionValueIndices[index],

--- a/Sunrise/src/state/build_data/cache/records/format.h
+++ b/Sunrise/src/state/build_data/cache/records/format.h
@@ -34,8 +34,9 @@ inline constexpr std::array<char, 8> kCacheMagic{'S', 'U', 'N', 'R', 'I', 'S', '
  * Current build-data cache format. Any other version on disk is rebuilt rather than read.
  * Bump it when a stored shape changes or when the extraction filling it changes what it writes,
  * because a cached row survives a code change and a corrected walk keeps publishing old rows.
+ * 63 added the catalyst completion flags' account bank indices to the catalyst record.
  */
-inline constexpr std::uint32_t kCacheFormatVersion = 62;
+inline constexpr std::uint32_t kCacheFormatVersion = 63;
 /** Signed -1 on disk means there is no equipment slot. */
 inline constexpr std::int8_t kAbsentEquipmentSlot = -1;
 /** The standard 64-bit FNV-1a offset basis starts the payload checksum. */
@@ -250,6 +251,8 @@ struct ExoticCatalystRecord {
     std::uint16_t progressPlugDefinitionIndex{};
     std::uint16_t effectDefinitionIndex{};
     std::uint16_t acquisitionDefinitionIndex{};
+    std::array<std::uint16_t, items::catalysts::kCompletionFlagCapacity>
+        completionAccountFlagIndices{};
     std::array<std::uint16_t, items::catalysts::kCompletionFlagCapacity>
         completionFlagDefinitionIndices{};
     std::array<std::uint16_t, items::catalysts::kCompletionValueCapacity> completionValueIndices{};
@@ -665,7 +668,7 @@ static_assert(sizeof(SocketPlugRuleRecord)
 static_assert(sizeof(SocketPlugPoolRecord) == 2 * sizeof(std::uint32_t));
 static_assert(sizeof(SocketPlugMemberRecord) == sizeof(std::uint16_t));
 static_assert(sizeof(ExoticCatalystRecord)
-              == 6 * sizeof(std::uint32_t) + 14 * sizeof(std::uint16_t) + 4 * sizeof(std::uint8_t));
+              == 6 * sizeof(std::uint32_t) + 18 * sizeof(std::uint16_t) + 4 * sizeof(std::uint8_t));
 static_assert(sizeof(InventoryBucketRecord)
               == 4 * sizeof(std::uint8_t) + 2 * sizeof(std::uint16_t));
 static_assert(sizeof(SocketEntryListRecord)

--- a/Sunrise/src/state/build_data/items/catalysts/definition.h
+++ b/Sunrise/src/state/build_data/items/catalysts/definition.h
@@ -115,6 +115,12 @@ enum class Error : std::uint8_t {
     return "unknown";
 }
 
+/** Native account acquired-flag row feeding an evaluated unlock slot. */
+struct AccountFlagMapping {
+    std::uint16_t slot{};
+    std::uint16_t accountIndex{};
+};
+
 /** One build-derived exotic weapon catalyst relation. */
 struct Definition {
     std::uint32_t itemDefinitionHash{};
@@ -127,6 +133,12 @@ struct Definition {
     std::uint16_t effectDefinitionIndex{};
     /** Family-5 acquired-state slot that makes the catalyst socket visible. */
     std::uint16_t acquisitionDefinitionIndex{kUnavailableAcquisitionIndex};
+    /** Account rows for the completion flags, or unavailable for override-only slots. */
+    std::array<std::uint16_t, kCompletionFlagCapacity> completionAccountFlagIndices{
+        kUnavailableCompletionFlagIndex,
+        kUnavailableCompletionFlagIndex,
+        kUnavailableCompletionFlagIndex,
+        kUnavailableCompletionFlagIndex};
     /** Family-5 terms required by the catalyst's active effect item. */
     CompletionRequirements completion{};
     /** Account objective referenced by a legacy progress plug, when present. */

--- a/Sunrise/src/state/build_data/items/catalysts/exotic_catalyst_build_data_runtime.cpp
+++ b/Sunrise/src/state/build_data/items/catalysts/exotic_catalyst_build_data_runtime.cpp
@@ -117,6 +117,10 @@ bool complete_exotic_catalyst_investment(Family5State& family) noexcept {
     return items::catalysts::append_investment_overrides(family);
 }
 
+bool complete_exotic_catalyst_flags(std::span<std::uint8_t> flags) noexcept {
+    return items::catalysts::append_account_completions(flags);
+}
+
 bool complete_exotic_catalyst_objectives(std::span<std::int32_t> values) noexcept {
     return items::catalysts::append_objective_completions(values);
 }

--- a/Sunrise/src/state/build_data/items/catalysts/exotic_catalyst_builder.cpp
+++ b/Sunrise/src/state/build_data/items/catalysts/exotic_catalyst_builder.cpp
@@ -511,6 +511,25 @@ bool derive(const Source& source,
         definition.effectDefinitionIndex = completed->effectDefinitionIndex;
         definition.acquisitionDefinitionIndex = completed->acquisitionDefinitionIndex;
         definition.completion = completed->completion;
+        for (std::size_t flag = 0; flag < definition.completion.flagCount; ++flag) {
+            const auto mapping =
+                std::find_if(source.accountFlagMappings.begin(),
+                             source.accountFlagMappings.end(),
+                             [&](const AccountFlagMapping& row) {
+                                 return row.slot == definition.completion.flags[flag];
+                             });
+            if (mapping != source.accountFlagMappings.end()) {
+                if (mapping->accountIndex >= state::unlocks::kAccountFlagCapacity) {
+                    return fail(output,
+                                count,
+                                report,
+                                Error::invalidCompletion,
+                                item->definitionHash,
+                                completed->socketLane);
+                }
+                definition.completionAccountFlagIndices[flag] = mapping->accountIndex;
+            }
+        }
         definition.objective = completed->objective;
         definition.socketLane = completed->socketLane;
         definition.availability =
@@ -569,6 +588,8 @@ bool matches_cached(const Source& source,
     std::array<CompletionCondition, 2 * kDefinitionCapacity> completionConditions{};
     std::array<AcquisitionGate, kDefinitionCapacity> acquisitionGates{};
     std::array<std::int32_t, state::unlocks::kObjectiveValueCapacity> objectiveValues{};
+    std::array<AccountFlagMapping, kDefinitionCapacity * kCompletionFlagCapacity> accountMappings{};
+    std::size_t mappingCount = 0;
     std::size_t completionCount = 0;
     std::size_t acquisitionCount = 0;
     std::size_t objectiveCount = 0;
@@ -597,6 +618,27 @@ bool matches_cached(const Source& source,
     for (const Definition& definition : definitions) {
         if (definition.availability == Availability::unsupported) {
             continue;
+        }
+        for (std::size_t flag = 0; flag < definition.completionAccountFlagIndices.size(); ++flag) {
+            const auto mapped = definition.completionAccountFlagIndices[flag];
+            if (mapped == kUnavailableCompletionFlagIndex) {
+                continue;
+            }
+            if (flag >= definition.completion.flagCount
+                || mapped >= state::unlocks::kAccountFlagCapacity
+                || mappingCount >= accountMappings.size()) {
+                return false;
+            }
+            const auto slot = definition.completion.flags[flag];
+            for (std::size_t prior = 0; prior < mappingCount; ++prior) {
+                if ((accountMappings[prior].slot == slot
+                     && accountMappings[prior].accountIndex != mapped)
+                    || (accountMappings[prior].accountIndex == mapped
+                        && accountMappings[prior].slot != slot)) {
+                    return false;
+                }
+            }
+            accountMappings[mappingCount++] = {slot, mapped};
         }
         const details::Definition* detail =
             find_detail(source.details, definition.itemDefinitionIndex);
@@ -688,6 +730,7 @@ bool matches_cached(const Source& source,
                   return first.socketType < second.socketType;
               });
     Source rebuilt = source;
+    rebuilt.accountFlagMappings = std::span(accountMappings).first(mappingCount);
     rebuilt.completionConditions = std::span(completionConditions).first(completionCount);
     rebuilt.acquisitionGates = std::span(acquisitionGates).first(acquisitionCount);
     rebuilt.objectiveCompletionValues = std::span(objectiveValues).first(objectiveCount);

--- a/Sunrise/src/state/build_data/items/catalysts/exotic_catalyst_builder.h
+++ b/Sunrise/src/state/build_data/items/catalysts/exotic_catalyst_builder.h
@@ -34,6 +34,8 @@ struct Source {
     std::span<const AcquisitionGate> acquisitionGates;
     /** Dense objective-indexed completion values read from the installed objective table. */
     std::span<const std::int32_t> objectiveCompletionValues;
+    /** Package account-flag mapping; slot identities are not account array indices. */
+    std::span<const AccountFlagMapping> accountFlagMappings;
 };
 
 /** @return The generated facts pinned to Destiny 2 build 86657.20.08.23. */

--- a/Sunrise/src/state/build_data/items/catalysts/exotic_catalyst_catalog.cpp
+++ b/Sunrise/src/state/build_data/items/catalysts/exotic_catalyst_catalog.cpp
@@ -167,6 +167,15 @@ bool valid(std::span<const Definition> definitions) noexcept {
             definition.objective.definitionIndex != kUnavailableObjectiveIndex;
         const bool directEffect =
             definition.completedPlugDefinitionIndex == definition.effectDefinitionIndex;
+        for (std::size_t flag = 0; flag < definition.completionAccountFlagIndices.size(); ++flag) {
+            const auto mapped = definition.completionAccountFlagIndices[flag];
+            if (mapped != kUnavailableCompletionFlagIndex
+                && (mapped >= state::unlocks::kAccountFlagCapacity
+                    || flag >= definition.completion.flagCount
+                    || definition.availability == Availability::unsupported)) {
+                return false;
+            }
+        }
         if (definition.itemDefinitionHash == 0
             || definition.socketLane >= details::kInitialPlugCapacity
             || !valid_availability(definition.availability)
@@ -301,7 +310,15 @@ bool append_investment_overrides(state::Family5State& family) noexcept {
             return false;
         }
         for (std::size_t flag = 0; flag < definition.completion.flagCount; ++flag) {
-            if (!upsert_flag(candidate, definition.completion.flags[flag])) {
+            const auto slot = definition.completion.flags[flag];
+            // A mapped completion rides in the account bank, so it takes a Family-5 row only when
+            // the state already carries one for that slot, which is then raised to the set value.
+            const bool present = std::any_of(candidate.flags.begin(),
+                                             candidate.flags.begin() + candidate.flagCount,
+                                             [slot](const auto& row) { return row.slot == slot; });
+            if ((definition.completionAccountFlagIndices[flag] == kUnavailableCompletionFlagIndex
+                 || present)
+                && !upsert_flag(candidate, slot)) {
                 return false;
             }
         }
@@ -313,6 +330,40 @@ bool append_investment_overrides(state::Family5State& family) noexcept {
         }
     }
     family = candidate;
+    return true;
+}
+
+/**
+ * Sets the account acquired flags that released catalyst completions map to.
+ * @param flags Candidate account flag bank; unchanged unless every mapped flag is inside it.
+ * @return False when a mapped flag falls outside the bank.
+ */
+bool append_account_completions(std::span<std::uint8_t> flags) noexcept {
+    if (!completion_enabled()) {
+        return true;
+    }
+    const std::shared_lock guard(g_lock);
+    // Range-check every mapping first, so one outside the bank leaves the input untouched.
+    for (const Definition& definition : g_definitions.rows()) {
+        if (definition.availability != Availability::released) {
+            continue;
+        }
+        for (const auto mapped : definition.completionAccountFlagIndices) {
+            if (mapped != kUnavailableCompletionFlagIndex && mapped >= flags.size()) {
+                return false;
+            }
+        }
+    }
+    for (const Definition& definition : g_definitions.rows()) {
+        if (definition.availability != Availability::released) {
+            continue;
+        }
+        for (const auto mapped : definition.completionAccountFlagIndices) {
+            if (mapped != kUnavailableCompletionFlagIndex) {
+                flags[mapped] = state::unlocks::kFlagSet;
+            }
+        }
+    }
     return true;
 }
 

--- a/Sunrise/src/state/build_data/items/catalysts/exotic_catalyst_catalog.h
+++ b/Sunrise/src/state/build_data/items/catalysts/exotic_catalyst_catalog.h
@@ -70,9 +70,10 @@ void set_completion_enabled(bool enabled) noexcept;
                                           std::span<std::optional<std::uint16_t>> plugs) noexcept;
 
 /**
- * Adds acquired-state gates, completion flags, and completion values for released catalysts.
- * Existing authored rows with the same slot are raised to the required value. The input stays
- * unchanged when either fixed override bank cannot hold the complete deduplicated result.
+ * Adds acquired-state gates, completion flags without an account mapping, and completion values
+ * for released catalysts. Existing authored rows with the same slot are raised to the required
+ * value, mapped or not. The input stays unchanged when either fixed override bank cannot hold
+ * the complete deduplicated result.
  * @param family Candidate Family-5 state.
  * @return True when completion is disabled or every released override fits atomically.
  */
@@ -85,6 +86,14 @@ void set_completion_enabled(bool enabled) noexcept;
  * @return True when completion is disabled or every objective applies atomically.
  */
 [[nodiscard]] bool append_objective_completions(std::span<std::int32_t> values) noexcept;
+
+/**
+ * Sets the account acquired flags that released catalyst completions map to.
+ * The input stays unchanged if any mapped flag is outside the supplied bank.
+ * @param flags Candidate account acquired-flag bank.
+ * @return True when completion is disabled or every mapped flag applies atomically.
+ */
+[[nodiscard]] bool append_account_completions(std::span<std::uint8_t> flags) noexcept;
 
 /**
  * Copies the complete catalog under its shared lock.

--- a/Sunrise/src/state/build_data/runtime.h
+++ b/Sunrise/src/state/build_data/runtime.h
@@ -253,7 +253,8 @@ complete_exotic_catalyst(std::uint16_t itemDefinitionIndex,
                          std::span<std::optional<std::uint16_t>> plugs) noexcept;
 
 /**
- * Adds all released catalyst acquisition and completion overrides to one Family-5 snapshot.
+ * Adds the released catalyst acquisition gates, the completion flags without an account mapping,
+ * and the completion values to one Family-5 snapshot.
  * @param family Candidate Family-5 state.
  * @return True when all overrides fit and the complete state commits.
  */
@@ -265,6 +266,13 @@ complete_exotic_catalyst(std::uint16_t itemDefinitionIndex,
  * @return True when all derived objectives fit and apply.
  */
 [[nodiscard]] bool complete_exotic_catalyst_objectives(std::span<std::int32_t> values) noexcept;
+
+/**
+ * Raises the account acquired flags that the package maps released catalyst completions to.
+ * @param flags Candidate account acquired-flag bank.
+ * @return True when completion is disabled or every mapped flag is inside the bank.
+ */
+[[nodiscard]] bool complete_exotic_catalyst_flags(std::span<std::uint8_t> flags) noexcept;
 
 /**
  * Resolves the item row that supplies one socketed catalyst's native perks and stat changes.

--- a/Sunrise/src/state/investment/investment.h
+++ b/Sunrise/src/state/investment/investment.h
@@ -6,8 +6,8 @@
 
 namespace sunrise::state {
 
-/** Each family-5 override count ships in a 7-bit wire field, so 127 rows is the wire limit. */
-inline constexpr std::size_t kUnlockOverrideCapacity = 127;
+/** The native family-5 lists hold 100 rows each (RE/27). The 7-bit wire count is not the limit. */
+inline constexpr std::size_t kUnlockOverrideCapacity = 100;
 
 /** One logical unlock-flag value stored by slot. */
 struct UnlockFlagOverride {

--- a/Sunrise/src/state/runtime/state_progression_runtime.cpp
+++ b/Sunrise/src/state/runtime/state_progression_runtime.cpp
@@ -91,25 +91,6 @@ using SaleRows = std::array<build_data::ArtifactSaleRow, build_data::kArtifactSa
 }
 
 /**
- * Sets one global unlock flag override, replacing any existing entry for the slot.
- * @return False when the slot is new and the override list is full.
- */
-[[nodiscard]] bool
-upsert_flag(Family5State& family, std::uint16_t slot, std::uint8_t value) noexcept {
-    for (std::size_t index = 0; index < family.flagCount; ++index) {
-        if (family.flags[index].slot == slot) {
-            family.flags[index].value = value;
-            return true;
-        }
-    }
-    if (family.flagCount >= family.flags.size()) {
-        return false;
-    }
-    family.flags[family.flagCount++] = UnlockFlagOverride{slot, value};
-    return true;
-}
-
-/**
  * Sets one global unlock value override, replacing any existing entry for the slot.
  * @return False when the slot is new and the override list is full.
  */
@@ -142,9 +123,10 @@ upsert_value(Family5State& family, std::uint16_t slot, std::int32_t value) noexc
     return build_data::artifact_sale_rows(rows, count) && count != 0;
 }
 
-/** @return One bit per owned artifact sale row, read from the global unlock overrides. */
-[[nodiscard]] std::uint32_t
-artifact_mask_locked(const Family5State& family, const SaleRows& rows, std::size_t count) noexcept {
+/** @return One bit per sale row an authored family-5 override marks owned. Read at seed only. */
+[[nodiscard]] std::uint32_t authored_artifact_mask_locked(const Family5State& family,
+                                                          const SaleRows& rows,
+                                                          std::size_t count) noexcept {
     std::uint32_t mask = 0;
     for (std::size_t row = 0; row < count && row < 32; ++row) {
         if (rows[row].unlockFlagSlot != build_data::collectibles::kUnavailableFlagSlot
@@ -155,6 +137,44 @@ artifact_mask_locked(const Family5State& family, const SaleRows& rows, std::size
     return mask;
 }
 
+/** @return One bit per owned artifact sale row, read from the character acquired-flag bank. */
+[[nodiscard]] std::uint32_t artifact_mask(const SaleRows& rows, std::size_t count) noexcept {
+    std::uint32_t mask = 0;
+    for (std::size_t row = 0; row < count && row < 32; ++row) {
+        const std::uint16_t mapped = rows[row].characterFlagIndex;
+        if (mapped != build_data::collectibles::kUnavailableFlagIndex
+            && unlocks::character_object_flag_set(mapped)) {
+            mask |= 1U << row;
+        }
+    }
+    return mask;
+}
+
+/**
+ * Removes the family-5 flag rows that name artifact sale slots.
+ * The character bank carries ownership, and a family-5 copy would mask it and cost 25 rows.
+ */
+void strip_artifact_flags_locked(Family5State& family,
+                                 const SaleRows& rows,
+                                 std::size_t count) noexcept {
+    std::size_t write = 0;
+    for (std::size_t index = 0; index < family.flagCount; ++index) {
+        const UnlockFlagOverride flag = family.flags[index];
+        bool artifact = false;
+        for (std::size_t row = 0; row < count && row < 32 && !artifact; ++row) {
+            artifact = rows[row].unlockFlagSlot != build_data::collectibles::kUnavailableFlagSlot
+                       && rows[row].unlockFlagSlot == flag.slot;
+        }
+        if (!artifact) {
+            family.flags[write++] = flag;
+        }
+    }
+    for (std::size_t index = write; index < family.flagCount; ++index) {
+        family.flags[index] = {};
+    }
+    family.flagCount = write;
+}
+
 [[nodiscard]] std::uint16_t points_used(std::uint32_t mask) noexcept {
     std::uint16_t used = 0;
     for (std::uint16_t bit = 0; bit < 32; ++bit) {
@@ -163,7 +183,7 @@ artifact_mask_locked(const Family5State& family, const SaleRows& rows, std::size
     return used;
 }
 
-/** Character-bank half of an artifact publish; the account half lives in the family-5 overrides. */
+/** Character-bank write of an artifact publish; the family-5 overrides carry only the counters. */
 struct CharacterArtifactWrite {
     const SaleRows* rows{};
     std::size_t count{};
@@ -194,11 +214,11 @@ void publish_artifact_character_banks(CharacterArtifactWrite& write) noexcept {
 }
 
 /**
- * Writes one artifact ownership mask into every bank that publishes it.
+ * Writes one artifact ownership mask into the character bank and its counters into family 5.
  * @param family Global override object, mutated in place.
  * @param mask One bit per owned sale row.
  * @param experience Seasonal XP the derived counters are computed from.
- * @return False only when the bounded override lists are full.
+ * @return False only when the bounded value override list is full.
  */
 [[nodiscard]] bool publish_artifact_locked(Family5State& family,
                                            std::uint32_t mask,
@@ -208,17 +228,7 @@ void publish_artifact_character_banks(CharacterArtifactWrite& write) noexcept {
     if (!sale_rows(rows, count)) {
         return false;
     }
-    for (std::size_t row = 0; row < count && row < 32; ++row) {
-        const std::uint16_t slot = rows[row].unlockFlagSlot;
-        if (slot == build_data::collectibles::kUnavailableFlagSlot) {
-            continue;
-        }
-        if (!upsert_flag(family,
-                         slot,
-                         (mask & (1U << row)) != 0 ? unlocks::kFlagSet : unlocks::kFlagClear)) {
-            return false;
-        }
-    }
+    strip_artifact_flags_locked(family, rows, count);
     const std::uint16_t used = points_used(mask);
     if (!upsert_value(family, kArtifactPowerBonusSlot, artifact_power_bonus_for(experience))
         || !upsert_value(family, kArtifactPointsUsedSlot, used)
@@ -261,8 +271,10 @@ bool seed_seasonal_progression() noexcept {
     }
     AcquireSRWLockExclusive(&runtime::storage::g_stateLock);
     Family5State& family = runtime::storage::g_state.investment.family5;
-    const bool published =
-        publish_artifact_locked(family, artifact_mask_locked(family, rows, count), experience);
+    // An authored family-5 row still seeds ownership. The publish moves it to the character bank.
+    const std::uint32_t mask =
+        authored_artifact_mask_locked(family, rows, count) | artifact_mask(rows, count);
+    const bool published = publish_artifact_locked(family, mask, experience);
     ReleaseSRWLockExclusive(&runtime::storage::g_stateLock);
     return published;
 }
@@ -304,8 +316,7 @@ bool grant_seasonal_experience(std::int32_t amount) noexcept {
     Family5State& family = runtime::storage::g_state.investment.family5;
     SaleRows rows{};
     std::size_t count = 0;
-    const std::uint32_t mask =
-        sale_rows(rows, count) ? artifact_mask_locked(family, rows, count) : 0U;
+    const std::uint32_t mask = sale_rows(rows, count) ? artifact_mask(rows, count) : 0U;
     (void)publish_artifact_locked(family, mask, total);
     ReleaseSRWLockExclusive(&runtime::storage::g_stateLock);
     return true;
@@ -346,11 +357,7 @@ std::uint32_t artifact_mod_mask() noexcept {
     if (!sale_rows(rows, count)) {
         return 0;
     }
-    AcquireSRWLockShared(&runtime::storage::g_stateLock);
-    const std::uint32_t mask =
-        artifact_mask_locked(runtime::storage::g_state.investment.family5, rows, count);
-    ReleaseSRWLockShared(&runtime::storage::g_stateLock);
-    return mask;
+    return artifact_mask(rows, count);
 }
 
 /** Replaces the exact published mask, refusing when another action changed it first. */
@@ -363,7 +370,7 @@ bool replace_artifact_mod_mask(std::uint32_t expected, std::uint32_t replacement
     const std::int32_t experience = seasonal_experience();
     AcquireSRWLockExclusive(&runtime::storage::g_stateLock);
     Family5State& family = runtime::storage::g_state.investment.family5;
-    bool replaced = artifact_mask_locked(family, rows, count) == expected;
+    bool replaced = artifact_mask(rows, count) == expected;
     if (replaced) {
         replaced = publish_artifact_locked(family, replacement, experience);
     }
@@ -398,7 +405,7 @@ bool prepare_artifact_mod_unlock(std::uint16_t saleIndex,
     const std::uint16_t earned = artifact_points_earned_for(experience);
     AcquireSRWLockExclusive(&runtime::storage::g_stateLock);
     Family5State& family = runtime::storage::g_state.investment.family5;
-    const std::uint32_t before = artifact_mask_locked(family, rows, count);
+    const std::uint32_t before = artifact_mask(rows, count);
     const std::uint16_t used = points_used(before);
     bool prepared = (before & bit) == 0 && used < earned && used >= column_tier(saleIndex);
     if (prepared) {

--- a/Sunrise/src/state/runtime/state_runtime.cpp
+++ b/Sunrise/src/state/runtime/state_runtime.cpp
@@ -448,6 +448,9 @@ bool investment_snapshot(InvestmentState& output) noexcept {
     InvestmentState snapshot = runtime::storage::g_state.investment;
     ReleaseSRWLockShared(&runtime::storage::g_stateLock);
     if (!build_data::complete_exotic_catalyst_investment(snapshot.family5)) {
+        core::log::write(core::log::Channel::state,
+                         core::log::Level::warn,
+                         "ev=investment stage=snapshot result=fail reason=catalyst");
         return false;
     }
     output = snapshot;

--- a/Sunrise/src/state/unlocks/unlocks_records.cpp
+++ b/Sunrise/src/state/unlocks/unlocks_records.cpp
@@ -397,6 +397,7 @@ void publish_derived(Table& table) noexcept {
         // A lore chapter's authored value is not claim state, so the catalogs replace it once.
         clear_lore_objectives(table);
         (void)build_data::complete_exotic_catalyst_objectives(table.objectiveValues);
+        (void)build_data::complete_exotic_catalyst_flags(table.accountFlags);
         g_loreSeedOwed = false;
     }
     (void)node_catalog::apply_visibility(table.accountFlags);

--- a/Sunrise/src/state/unlocks/unlocks_runtime.cpp
+++ b/Sunrise/src/state/unlocks/unlocks_runtime.cpp
@@ -46,6 +46,13 @@ bool account_flag_set(std::uint16_t index) noexcept {
     return index < g_table.accountFlags.size() && g_table.accountFlags[index] == kFlagSet;
 }
 
+/** @return True when the selected character's object flag at this row is set. */
+bool character_object_flag_set(std::uint16_t index) noexcept {
+    const std::shared_lock guard(g_lock);
+    return index < g_table.characterObjectFlags.size()
+           && g_table.characterObjectFlags[index] == kFlagSet;
+}
+
 /** Writes one account acquired flag. */
 bool set_account_flag(std::uint16_t index, std::uint8_t value) noexcept {
     const std::lock_guard guard(g_lock);

--- a/Sunrise/src/state/unlocks/unlocks_runtime.h
+++ b/Sunrise/src/state/unlocks/unlocks_runtime.h
@@ -29,6 +29,9 @@ void mutate(void* context, void (*apply)(void*, Table&) noexcept) noexcept;
 /** @param index Account flag bank row. @return True when the flag is set. */
 [[nodiscard]] bool account_flag_set(std::uint16_t index) noexcept;
 
+/** @param index Character object flag bank row. @return True when the flag is set. */
+[[nodiscard]] bool character_object_flag_set(std::uint16_t index) noexcept;
+
 /**
  * Writes one account acquired flag.
  * @param index Account flag bank row.


### PR DESCRIPTION
With the shipped `complete_exotic_catalysts: true`, the default investment snapshot needed 130 Family-5 flag overrides: 43 authored, 25 artifact and 62 catalyst. That exceeded Sunrise's previous 127-row storage, and the client's Family-5 arrays only hold 100 rows each. On `a57dc9a` opcode 503 fell back to a 7-byte echo and the client disconnected during investment sign-in after a message-argument bitstream decode error.

This keeps completion enabled and brings the default snapshot down to 90 flags:

- Artifact ownership stays in its native character acquired-flag bank, which already carries the purchase and reset path. The 25 duplicate Family-5 artifact flags are dropped, and stale authored copies are removed so they cannot mask the character projection.
- Catalyst completion flags that the package's account flag-map table maps to the account bank are set there. Fifteen flags move; acquisition gates and the unmapped completion flags stay in Family 5. An authored override for a mapped completion flag is still raised to set.
- `kUnlockOverrideCapacity` becomes 100, the client's real array size. The family-5 rearm hook previously copied 127 rows into the client object, which ran 108 bytes past the flag list.
- Artifact projection and the investment snapshot fail atomically, and the snapshot logs the reason when it does.
- The derived account mappings persist in cache format 61 (master took 60 for the entity position profiles), so older build-data caches rebuild.

Changes since the first revision: rebased on current master after the tests and docs folders were removed, so the test, fixture and markdown files are gone; the touched lines follow `.clang-format`; the new declarations carry full doc comments; the builder's mapping failure reports the item hash and lane like its neighbours; and the snapshot logs its failure reason. Release x64 build is clean.

Offline verification against the installed package's 11,923-row account mapping table and the 75-row catalyst catalog: 45 released catalysts, 15 mapped completion flags, successful cache re-derivation, and a complete default snapshot of 90 flags / 42 values.

This PR changes native state projection only. It contains no gameplay scripts, Tower Events changes, runtime/account files, or unrelated networking fixes.
