### PR TITLE
Fix empty settings documents during version migration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,23 @@ on:
   workflow_dispatch:
 
 jobs:
+  settings-upgrade:
+    name: Settings upgrade regressions
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure tests
+        run: cmake -S tests/settings_upgrade -B build/settings-upgrade-tests -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build tests
+        run: cmake --build build/settings-upgrade-tests
+
+      - name: Run tests
+        run: ctest --test-dir build/settings-upgrade-tests --output-on-failure
+
   release:
     name: Release x64
     # The image carries Visual Studio 2026, so the project's own v145 toolset and its

--- a/Sunrise/Sunrise.vcxproj
+++ b/Sunrise/Sunrise.vcxproj
@@ -1219,6 +1219,7 @@
     <ClInclude Include="src\core\settings\rule_text.h" />
     <ClInclude Include="src\core\filesystem\temporary_sibling.h" />
     <ClInclude Include="src\core\settings\settings.h" />
+    <ClInclude Include="src\core\settings\version.h" />
     <ClInclude Include="src\core\settings\parser.h" />
     <ClInclude Include="src\core\settings\client\definition.h" />
     <ClInclude Include="src\core\settings\server\definition.h" />

--- a/Sunrise/src/core/settings/settings.h
+++ b/Sunrise/src/core/settings/settings.h
@@ -10,6 +10,7 @@
 #include "client/definition.h"
 #include "server/definition.h"
 #include "steam/definition.h"
+#include "version.h"
 
 namespace sunrise::core::settings {
 
@@ -20,13 +21,6 @@ struct ActivitySdkGenerationSettings final {
     /** Writes the sdk/lua declaration tree. On by default, and only runs when generation does. */
     bool luaDeclarations{true};
 };
-
-/**
- * Layout version of the settings file this build writes and expects.
- * Raise it when a key is renamed, removed, changes meaning, or must take a new default. Adding a
- * key needs no raise, because a missing key already takes its default.
- */
-inline constexpr std::uint32_t kSettingsVersion = 13;
 
 /** Parsed read-only process settings. */
 struct Settings {

--- a/Sunrise/src/core/settings/settings_upgrade.cpp
+++ b/Sunrise/src/core/settings/settings_upgrade.cpp
@@ -12,7 +12,7 @@
 #include <cstdint>
 #include <cstdio>
 
-#include "settings.h"
+#include "version.h"
 
 namespace sunrise::core::settings::upgrade {
 namespace {
@@ -307,10 +307,17 @@ bool apply(std::string_view document,
         if (root == std::string_view::npos) {
             return false;
         }
+        const std::size_t firstMember = document.find_first_not_of(" \t\r\n", root + 1);
+        if (firstMember == std::string_view::npos) {
+            return false;
+        }
+        // An empty root has no following member; a comma would make valid settings unparsable.
+        const bool emptyRoot = document[firstMember] == '}';
         const int length = std::snprintf(versionText.data(),
                                          versionText.size(),
-                                         "\"version\": %u,",
-                                         static_cast<unsigned>(kSettingsVersion));
+                                         "\"version\": %u%s",
+                                         static_cast<unsigned>(kSettingsVersion),
+                                         emptyRoot ? "" : ",");
         if (length <= 0) {
             return false;
         }

--- a/Sunrise/src/core/settings/version.h
+++ b/Sunrise/src/core/settings/version.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <cstdint>
+
+namespace sunrise::core::settings {
+
+/**
+ * Layout version of the settings file this build writes and expects.
+ * Raise it when a key is renamed, removed, changes meaning, or must take a new default.
+ * Adding a key needs no raise, because a missing key already takes its default.
+ */
+inline constexpr std::uint32_t kSettingsVersion = 13;
+
+} // namespace sunrise::core::settings

--- a/tests/settings_upgrade/CMakeLists.txt
+++ b/tests/settings_upgrade/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.20)
+project(SunriseSettingsUpgradeTests LANGUAGES CXX)
+
+enable_testing()
+add_executable(settings_upgrade_test
+    settings_upgrade_test.cpp
+    ../../Sunrise/src/core/settings/settings_upgrade.cpp
+)
+target_compile_features(settings_upgrade_test PRIVATE cxx_std_20)
+if(MSVC)
+    target_compile_options(settings_upgrade_test PRIVATE /W4 /WX /permissive-)
+else()
+    target_compile_options(settings_upgrade_test PRIVATE -Wall -Wextra -Werror -pedantic)
+endif()
+add_test(NAME settings_upgrade COMMAND settings_upgrade_test)

--- a/tests/settings_upgrade/README.md
+++ b/tests/settings_upgrade/README.md
@@ -1,0 +1,19 @@
+# Settings upgrade regressions
+
+These tests compile the production settings migration code with synthetic JSON. They need a C++20
+compiler and CMake, and run on Linux or Windows without the game, Windows SDK, or third-party
+dependencies.
+
+```sh
+cmake -S tests/settings_upgrade -B build/settings-upgrade-tests
+cmake --build build/settings-upgrade-tests --config Release
+ctest --test-dir build/settings-upgrade-tests -C Release --output-on-failure
+```
+
+The nine cases cover empty roots with JSON whitespace, nonempty roots, a closing brace inside a
+string value, and existing version members. Each case checks the full migrated text, exact-fit
+storage, rejection of a buffer one byte too small, and recognition of the upgraded version.
+Checks remain active in Release builds.
+
+Before the fix, the four empty-root cases produce a trailing comma after the inserted version.
+Startup passes that text to the strict settings parser, which rejects it and stops initialization.

--- a/tests/settings_upgrade/settings_upgrade_test.cpp
+++ b/tests/settings_upgrade/settings_upgrade_test.cpp
@@ -1,0 +1,72 @@
+#include <array>
+#include <cstdio>
+#include <cstdlib>
+#include <span>
+#include <string>
+#include <string_view>
+
+#include "../../Sunrise/src/core/settings/settings_upgrade.h"
+#include "../../Sunrise/src/core/settings/version.h"
+
+namespace {
+
+namespace settings = sunrise::core::settings;
+
+/** Fixed output storage exceeds every synthetic document used here. */
+constexpr std::size_t kOutputCapacity = 256;
+
+/**
+ * Checks migration text, an exact-fit buffer, and rejection of a short buffer.
+ * @param document Synthetic settings input, with no game or account data.
+ * @param expected Complete expected JSON, including preserved whitespace.
+ * @return True when every output and capacity check passes.
+ */
+[[nodiscard]] bool check_upgrade(std::string_view document, std::string_view expected) noexcept {
+    std::array<char, kOutputCapacity> output{};
+    std::size_t written = 0;
+    if (!settings::upgrade::apply(document, "{}", output, written)
+        || std::string_view(output.data(), written) != expected) {
+        std::fprintf(stderr,
+                     "Unexpected migration for: %.*s\n",
+                     static_cast<int>(document.size()),
+                     document.data());
+        return false;
+    }
+    if (!settings::upgrade::apply(document, "{}", std::span(output).first(expected.size()), written)
+        || written != expected.size() || std::string_view(output.data(), written) != expected) {
+        std::fputs("Exact-fit migration failed\n", stderr);
+        return false;
+    }
+    if (settings::upgrade::apply(
+            document, "{}", std::span(output).first(expected.size() - 1), written)) {
+        std::fputs("Short migration buffer was accepted\n", stderr);
+        return false;
+    }
+    if (settings::upgrade::needed(expected)) {
+        std::fputs("Migrated settings still need an upgrade\n", stderr);
+        return false;
+    }
+    return true;
+}
+
+} // namespace
+
+/** @return Success when empty roots and existing members survive version insertion. */
+int main() {
+    const std::string member = "\"version\": " + std::to_string(settings::kSettingsVersion);
+    bool passed = true;
+    passed = check_upgrade("{}", "{" + member + "}") && passed;
+    passed = check_upgrade("{ }", "{" + member + " }") && passed;
+    passed = check_upgrade("{\t\r\n }", "{" + member + "\t\r\n }") && passed;
+    passed = check_upgrade(" \n{\r\n}\t", " \n{" + member + "\r\n}\t") && passed;
+    passed = check_upgrade("{\"core\":{}}", "{" + member + ",\"core\":{}}") && passed;
+    passed = check_upgrade("{ \n\"core\":{} }", "{" + member + ", \n\"core\":{} }") && passed;
+    passed = check_upgrade("{\"note\":\"}\"}", "{" + member + ",\"note\":\"}\"}") && passed;
+    passed = check_upgrade("{\"version\": 0}", "{" + member + "}") && passed;
+    passed = check_upgrade("{" + member + "}", "{" + member + "}") && passed;
+    if (!passed) {
+        return EXIT_FAILURE;
+    }
+    std::puts("All 9 settings upgrade cases passed (including exact-fit and short buffers).");
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This fixes a startup failure when upgrading a valid empty settings file.

For `{}`, the version upgrader currently produces `{"version": 13,}`. The trailing comma makes the generated JSON invalid, so settings parsing fails and startup stops.

In `Sunrise/src/core/settings/settings_upgrade.cpp`, the fix checks the first non-whitespace character after the opening brace. Empty objects receive the version without a comma; nonempty objects retain the separator and their original contents and whitespace.

The unchanged `kSettingsVersion = 13` constant moves into `Sunrise/src/core/settings/version.h`, allowing the production upgrader to compile independently of the Windows UI dependencies for testing. The Visual Studio project includes the new header.

`tests/settings_upgrade/` adds nine synthetic JSON regression cases covering empty objects, whitespace, nonempty objects, braces inside strings, and existing version fields. Each also checks exact-fit buffers, rejection of undersized buffers, and recognition of the upgraded version. A dedicated GitHub Actions job runs the tests.

Validation:

* All four empty-object cases failed before the fix; all nine cases passed afterward.
* The nine cases also passed with the fix applied to upstream `a57dc9a9e74eb71e876baea79047c9af679b2347`.
* CMake/CTest and address/undefined-behaviour sanitizer checks passed on the fork version.
* The equivalent fix on the older fork passed the Windows Release x64 build and regression tests: https://github.com/lutralutraq77/Sunrise-work/actions/runs/33977798758. That run does not validate the full Windows build of this upstream-based branch; this PR’s CI still needs to do that.
* In-game behaviour has not been tested.

This is one focused fix, with no new dependencies or game data and no settings-version increase.
