### PR TITLE
Add diagnostics for UMU/Proton startup after SDK generation

### DIFF
--- a/Sunrise/src/core/runtime/core_runtime.cpp
+++ b/Sunrise/src/core/runtime/core_runtime.cpp
@@ -38,6 +38,48 @@ threading::SrwLock g_runtimeLock{};
 /** The installed public package headers live beside the game executable. */
 constexpr std::wstring_view kInstalledPackagesDirectory = L"packages";
 
+/**
+ * Marks a startup boundary before entering code that may never return to the failure handler.
+ * @tparam Initialize Callable that returns the existing step's success result.
+ * @param stage Stable initialization stage name.
+ * @param run Runs exactly one existing initialization step.
+ * @return The step's unmodified success result.
+ */
+template <typename Initialize>
+[[nodiscard]] bool initialize_stage(const char* stage, Initialize run) noexcept {
+    const std::uint64_t startedTick = GetTickCount64();
+    log::writef(log::Channel::core, log::Level::info, "ev=initialize stage=%s phase=begin", stage);
+    const bool complete = run();
+    log::writef(log::Channel::core,
+                log::Level::info,
+                "ev=initialize stage=%s phase=complete result=%s ms=%llu",
+                stage,
+                complete ? "ok" : "fail",
+                static_cast<unsigned long long>(GetTickCount64() - startedTick));
+    return complete;
+}
+
+/** @return Stable names for catalog outcomes, including expected first-boot absence. */
+[[nodiscard]] const char*
+catalog_status_name(state::activity_sdk::generated_world::manifest::LoadStatus status) noexcept {
+    using Status = state::activity_sdk::generated_world::manifest::LoadStatus;
+    switch (status) {
+    case Status::loaded:
+        return "loaded";
+    case Status::missing:
+        return "missing";
+    case Status::sourceMismatch:
+        return "source_mismatch";
+    case Status::sdkMismatch:
+        return "sdk_mismatch";
+    case Status::invalid:
+        return "invalid";
+    case Status::versionMismatch:
+        return "version_mismatch";
+    }
+    return "invalid";
+}
+
 /** Initializes the base State before content-authenticated generated artifacts are considered. */
 [[nodiscard]] bool initialize_state(void* module) noexcept {
     return state::initialize(
@@ -67,12 +109,22 @@ constexpr std::wstring_view kInstalledPackagesDirectory = L"packages";
     if (!state::content_manifest::visit_snapshot(&copy_content_fingerprint, &source)
         || !path::module_directory(module, catalogPath)
         || !path::append(catalogPath, L"Sunrise\\sdk\\catalog.bin")) {
+        log::write(log::Channel::core,
+                   log::Level::info,
+                   "ev=activity_sdk_load stage=identity result=unavailable reason=source_or_path");
         return false;
     }
     manifest::Catalog catalog{};
     manifest::LoadStatus status = manifest::LoadStatus::invalid;
-    return manifest::load(catalogPath.chars.data(), source, catalog, status)
-           && status == manifest::LoadStatus::loaded
+    log::write(log::Channel::core,
+               log::Level::info,
+               "ev=activity_sdk_load stage=catalog_manifest phase=begin");
+    const bool loaded = manifest::load(catalogPath.chars.data(), source, catalog, status);
+    log::writef(log::Channel::core,
+                log::Level::info,
+                "ev=activity_sdk_load stage=catalog_manifest phase=complete result=%s",
+                catalog_status_name(status));
+    return loaded && status == manifest::LoadStatus::loaded
            && state::activity_sdk::identity::derive(source, catalog.sdk.payloadSha256, output)
            && output.sdkBuildSha256 == catalog.sdk.buildSha256;
 }
@@ -80,8 +132,16 @@ constexpr std::wstring_view kInstalledPackagesDirectory = L"packages";
 /** Publishes the optional pack only through the authenticated catalog committed beside it. */
 void initialize_activity_sdk(void* module) noexcept {
     state::activity_sdk::ExpectedIdentity expected{};
-    (void)activity_sdk_identity(module, expected);
+    const bool authenticated = activity_sdk_identity(module, expected);
+    log::writef(log::Channel::core,
+                log::Level::info,
+                "ev=activity_sdk_load stage=pack phase=begin identity=%s",
+                authenticated ? "authenticated" : "unavailable");
     state::activity_sdk::initialize(module, expected);
+    log::writef(log::Channel::core,
+                log::Level::info,
+                "ev=activity_sdk_load stage=pack phase=complete result=%s",
+                state::activity_sdk::status_name(state::activity_sdk::status()));
     // The wire catalog borrows the published catalog's strings, so it follows every publish.
 }
 
@@ -158,24 +218,30 @@ bool initialize(void* module) noexcept {
         // The sinks exist only from here, so this is the earliest a begin marker can reach a
         // channel. The duration it pairs with still counts from function entry.
         log::write(log::Channel::core, log::Level::debug, "ev=initialize phase=begin");
-        if (!ui::runtime::initialize(settings::get().client.userInterface)) {
+        if (!initialize_stage("ui", [] {
+                return ui::runtime::initialize(settings::get().client.userInterface);
+            })) {
             stage = "ui";
-        } else if (!ui::modules::hud::initialize(module)) {
+        } else if (!initialize_stage("ui_hud",
+                                     [module] { return ui::modules::hud::initialize(module); })) {
             // Registered before logs, which is the order the menu lists the Core pages in.
             stage = "ui_hud";
-        } else if (!ui::modules::logs::initialize()) {
+        } else if (!initialize_stage("ui_logs", [] { return ui::modules::logs::initialize(); })) {
             stage = "ui_logs";
-        } else if (!state::entitlements::publish(settings::get().server.entitlements)) {
+        } else if (!initialize_stage("entitlements", [] {
+                       return state::entitlements::publish(settings::get().server.entitlements);
+                   })) {
             stage = "entitlements";
-        } else if (!initialize_state(module)) {
+        } else if (!initialize_stage("state", [module] { return initialize_state(module); })) {
             stage = "state";
-        } else if (!initialize_content_manifest(module)) {
+        } else if (!initialize_stage("content_manifest",
+                                     [module] { return initialize_content_manifest(module); })) {
             stage = "content_manifest";
-        } else if (!middleware::initialize()) {
+        } else if (!initialize_stage("middleware", [] { return middleware::initialize(); })) {
             stage = "middleware";
-        } else if (!server::initialize()) {
+        } else if (!initialize_stage("server", [] { return server::initialize(); })) {
             stage = "server";
-        } else if (!client::initialize(module)) {
+        } else if (!initialize_stage("client", [module] { return client::initialize(module); })) {
             stage = "client";
         }
     }

--- a/Sunrise/src/state/activity_sdk/activity_sdk_loader.cpp
+++ b/Sunrise/src/state/activity_sdk/activity_sdk_loader.cpp
@@ -6,11 +6,50 @@
 #include <string>
 
 #include "../../core/filesystem/path.h"
+#include "../../core/logging/log.h"
 #include "../../middleware/crypto/sha256.h"
 #include "internal.h"
 
 namespace sunrise::state::activity_sdk {
 namespace {
+
+/** @param stage SDK load boundary that must be visible even if the next call does not return. */
+void begin_load_stage(const char* stage) noexcept {
+    core::log::writef(core::log::Channel::state,
+                      core::log::Level::debug,
+                      "ev=activity_sdk_load stage=%s phase=begin",
+                      stage);
+}
+
+/**
+ * Names a refused pack check without logging its contents.
+ * @param stage Failed loader boundary.
+ * @param reason Stable check name or validation refusal.
+ * @return False for the caller's existing failure path.
+ */
+[[nodiscard]] bool refuse_load(const char* stage, const char* reason) noexcept {
+    core::log::writef(core::log::Channel::state,
+                      core::log::Level::warn,
+                      "ev=activity_sdk_load stage=%s result=fail reason=%s",
+                      stage,
+                      reason);
+    return false;
+}
+
+/**
+ * Reports an error captured immediately after a failed Win32 call, before logging or cleanup.
+ * @param stage Failed loader boundary.
+ * @param error The failing call's GetLastError value.
+ * @return False for the caller's existing failure path.
+ */
+[[nodiscard]] bool refuse_windows_load(const char* stage, DWORD error) noexcept {
+    core::log::writef(core::log::Channel::state,
+                      core::log::Level::warn,
+                      "ev=activity_sdk_load stage=%s result=fail win32_error=%lu",
+                      stage,
+                      static_cast<unsigned long>(error));
+    return false;
+}
 
 /** The SDK pack is installed beneath the module directory without creating it at read time. */
 constexpr std::wstring_view kPackSuffix = L"Sunrise\\activity_sdk.pack";
@@ -90,30 +129,37 @@ constexpr std::array<std::uint32_t, format::kSectionCount> kExpectedStrides{
         || header.headerSize != sizeof(format::Header) || header.fileSize != file.size()
         || header.sectionCount != format::kSectionCount || header.reserved != 0
         || !valid_sections(header)) {
-        return false;
+        return refuse_load("header", "layout_or_bounds");
     }
     if (header.sdkBuildSha256 != expected.sdkBuildSha256) {
         result = Status::wrongSdkBuild;
-        return false;
+        return refuse_load("header", "sdk_build_mismatch");
     }
     if (header.payloadSha256 != expected.payloadSha256
         || header.contentKeySha256 != expected.contentKeySha256
         || header.logicalIrSha256 != expected.logicalIrSha256) {
-        return false;
+        return refuse_load("header", "identity_mismatch");
     }
     middleware::crypto::sha256::Digest digest{};
     const auto payload = file.subspan(header.headerSize);
-    return middleware::crypto::sha256::hash(payload, digest) && digest == expected.payloadSha256;
+    begin_load_stage("payload_hash");
+    if (!middleware::crypto::sha256::hash(payload, digest)) {
+        return refuse_load("payload_hash", "hash_failed");
+    }
+    return digest == expected.payloadSha256 || refuse_load("payload_hash", "digest_mismatch");
 }
 
 /** Converts an exact Windows file size to process address space. */
 [[nodiscard]] bool mapped_size(HANDLE file, std::size_t& output) noexcept {
     output = 0;
     LARGE_INTEGER size{};
-    if (GetFileSizeEx(file, &size) == FALSE || size.QuadPart < sizeof(format::Header)
+    if (GetFileSizeEx(file, &size) == FALSE) {
+        return refuse_windows_load("file_size", GetLastError());
+    }
+    if (size.QuadPart < sizeof(format::Header)
         || static_cast<std::uint64_t>(size.QuadPart)
                > static_cast<std::uint64_t>((std::numeric_limits<std::size_t>::max)())) {
-        return false;
+        return refuse_load("file_size", "invalid_size");
     }
     output = static_cast<std::size_t>(size.QuadPart);
     return true;
@@ -126,9 +172,12 @@ constexpr std::array<std::uint32_t, format::kSectionCount> kExpectedStrides{
     wchar_t* filePart = nullptr;
     const DWORD copied = GetFullPathNameW(
         path, static_cast<DWORD>(absolute.chars.size()), absolute.chars.data(), &filePart);
-    if (copied == 0 || copied >= absolute.chars.size() || filePart == nullptr
+    if (copied == 0) {
+        return refuse_windows_load("pack_directory", GetLastError());
+    }
+    if (copied >= absolute.chars.size() || filePart == nullptr
         || filePart <= absolute.chars.data()) {
-        return false;
+        return refuse_load("pack_directory", "invalid_path");
     }
     std::size_t length = static_cast<std::size_t>(filePart - absolute.chars.data());
     while (length != 0
@@ -136,14 +185,14 @@ constexpr std::array<std::uint32_t, format::kSectionCount> kExpectedStrides{
         --length;
     }
     if (length == 0) {
-        return false;
+        return refuse_load("pack_directory", "empty_directory");
     }
     try {
         output.assign(absolute.chars.data(), length);
         return true;
     } catch (...) {
         output.clear();
-        return false;
+        return refuse_load("pack_directory", "allocation_failed");
     }
 }
 
@@ -157,8 +206,9 @@ bool load_path_expected(const wchar_t* path,
     output.reset();
     result = Status::catalogInvalid;
     if (path == nullptr || path[0] == L'\0') {
-        return false;
+        return refuse_load("open", "invalid_path");
     }
+    begin_load_stage("open");
     const HANDLE file = CreateFileW(path,
                                     GENERIC_READ,
                                     FILE_SHARE_READ | FILE_SHARE_DELETE,
@@ -171,7 +221,13 @@ bool load_path_expected(const wchar_t* path,
         result = error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND
                      ? Status::missing
                      : Status::catalogInvalid;
-        return false;
+        if (result == Status::missing) {
+            core::log::write(core::log::Channel::state,
+                             core::log::Level::info,
+                             "ev=activity_sdk_load stage=open result=missing");
+            return false;
+        }
+        return refuse_windows_load("open", error);
     }
 
     std::shared_ptr<Catalog> pending;
@@ -179,34 +235,49 @@ bool load_path_expected(const wchar_t* path,
         pending = std::make_shared<Catalog>();
     } catch (...) {
         CloseHandle(file);
-        return false;
+        return refuse_load("catalog_storage", "allocation_failed");
     }
     pending->file_ = file;
+    begin_load_stage("pack_directory");
     if (!pack_directory(path, pending->artifactDirectory_)) {
         return false;
     }
+    begin_load_stage("file_size");
     if (!mapped_size(file, pending->size_)) {
         return false;
     }
+    begin_load_stage("file_mapping");
     const HANDLE mapping = CreateFileMappingW(file, nullptr, PAGE_READONLY, 0, 0, nullptr);
     if (mapping == nullptr) {
-        return false;
+        return refuse_windows_load("file_mapping", GetLastError());
     }
     pending->mapping_ = mapping;
+    begin_load_stage("map_view");
     const void* const view = MapViewOfFile(mapping, FILE_MAP_READ, 0, 0, 0);
     if (view == nullptr) {
-        return false;
+        return refuse_windows_load("map_view", GetLastError());
     }
     pending->view_ = static_cast<const std::byte*>(view);
     pending->header_ = reinterpret_cast<const format::Header*>(pending->view_);
     const std::span<const std::byte> bytes(pending->view_, pending->size_);
+    begin_load_stage("header");
     if (!identity::valid(expected.sdkBuildSha256) || !identity::valid(expected.payloadSha256)
-        || !identity::valid(expected.contentKeySha256) || !identity::valid(expected.logicalIrSha256)
-        || !valid_header(*pending->header_, bytes, expected, result) || !valid_catalog(*pending)) {
+        || !identity::valid(expected.contentKeySha256)
+        || !identity::valid(expected.logicalIrSha256)) {
+        return refuse_load("header", "expected_identity_unavailable");
+    }
+    if (!valid_header(*pending->header_, bytes, expected, result)) {
         return false;
+    }
+    begin_load_stage("catalog_validation");
+    if (!valid_catalog(*pending)) {
+        return refuse_load("catalog_validation", last_catalog_reason());
     }
     output = std::move(pending);
     result = Status::ready;
+    core::log::write(core::log::Channel::state,
+                     core::log::Level::info,
+                     "ev=activity_sdk_load stage=load phase=complete result=ready");
     return true;
 }
 

--- a/docs/umu-sdk-startup-diagnostics.md
+++ b/docs/umu-sdk-startup-diagnostics.md
@@ -1,0 +1,82 @@
+# Diagnosing startup after SDK generation under UMU/Proton
+
+This change adds diagnostics for [upstream issue #100](https://github.com/stanuwu/Sunrise/issues/100).
+It does not establish or fix the cause of the reported exit code 5. The report provides neither
+the Proton version nor a Wine exception trace, and the failing game environment has not been
+reproduced here.
+
+## What the source establishes
+
+`Sunrise/src/state/runtime/state_runtime.cpp` emits `ev=account stage=identity` during normal
+initialization, before session randomization and publication of State. The message is not an error.
+It does not establish that every subsequent operation failed: each log channel has its own filter.
+
+`Sunrise/src/core/runtime/core_runtime.cpp` then initializes the content manifest, authenticates
+`Sunrise/sdk/catalog.bin`, and asks the SDK loader to read `Sunrise/activity_sdk.pack`. Middleware,
+Server and Client initialization follow. A generated SDK therefore changes the startup work, but
+that timing alone does not identify a corrupt cache or a runner bug.
+
+`Sunrise/src/state/activity_sdk/activity_sdk_loader.cpp` opens and maps the pack read-only, checks
+the expected identity, hashes the payload, and validates catalog relations before returning it.
+Previously, many failures here only became a generic SDK status. The new events identify the
+boundary and preserve the actual Win32 error on failed file/path/mapping calls. Expected first-boot
+absence remains an informational `missing` result.
+
+The patch retains the original startup order, validation checks, failure results and cleanup.
+It neither catches crashes nor skips SDK validation. No game data is embedded or logged by the
+new events. Logging changes timing, so a successful diagnostic run alone cannot prove a fix.
+
+## Capture a failing run
+
+1. Keep a backup of the existing DLL, settings, generated SDK and current logs before testing.
+   Use the diagnostic `steam_api64.dll` built from this branch. Keep its matching PDB available
+   for symbolizing a crash. The DLL is built by the normal Windows Release x64 workflow.
+2. In `Sunrise/settings.json`, merge the following into the existing `core.logging` object.
+   Preserve the other Core settings and the rest of the document; do not add duplicate keys or
+   replace the whole settings file with this fragment.
+
+   ```json
+   {
+     "debugger_sink": true,
+     "file_sink": true,
+     "levels": {
+       "core": "debug",
+       "state": "debug",
+       "client": "debug",
+       "server": "debug",
+       "middleware": "debug"
+     }
+   }
+   ```
+
+3. Add `PROTON_LOG=1` to the environment of the existing failing UMU/Proton launch. Preserve its
+   current executable, prefix, runner and DLL overrides. If launching through Steam, put
+   `PROTON_LOG=1 %command%` in that game's launch options alongside any existing required options.
+   [Proton documents](https://github.com/ValveSoftware/Proton#runtime-config-options) the log as
+   `steam-<APPID>.log` under `PROTON_LOG_DIR`, which defaults to the user's home directory.
+4. Reproduce once and copy `Sunrise/logs/sunrise.log`, the Proton log and the launcher terminal
+   output before another launch rotates or overwrites them. Record the exact Sunrise commit/DLL,
+   UMU and Proton versions, the vanilla Wine version that works, launch arguments, and whether the
+   runners used the same prefix, game files and generated SDK. Review logs before sharing and
+   redact credentials or personal paths if present; do not attach game files or SDK dumps.
+
+## Read the result
+
+- `ev=initialize stage=... phase=begin` followed by the matching `phase=complete` shows that a
+  runtime stage returned. The last unmatched stage is a lead for the exception trace, not proof
+  that its code caused the exception.
+- `stage=catalog_manifest` and `stage=pack` separate catalog authentication from pack loading.
+- State debug events name `open`, `pack_directory`, `file_size`, `file_mapping`, `map_view`,
+  `header`, `payload_hash` and `catalog_validation`.
+- `win32_error=...` is captured from an API that actually failed. A launcher's process exit code
+  must not be interpreted as this field. Establish the exception/error domain from the Proton log.
+- `stage=pack phase=complete result=ready` means pack loading and SDK publication returned; use
+  the following startup stages and the exception trace to investigate a later crash.
+
+If a cache-presence comparison is needed, use a disposable copy of the installation and preserve
+the original generated files. Disable `core.activity_sdk_generation.enabled` in that copy before
+temporarily moving its pack aside, so the comparison does not regenerate the SDK. A changed
+outcome localizes the trigger; it still does not establish the underlying fault.
+
+The next evidence needed for a behavioural fix is a failing Proton exception/backtrace paired
+with these stage events and the exact runner and Sunrise versions.


### PR DESCRIPTION
Related to #100.

Startup after SDK generation can exit with only the normal account-identity event logged. Silent SDK-load failures and per-channel filters leave the failing stage unclear.

This adds:
- Initialization begin/end markers and elapsed times in Sunrise/src/core/runtime/core_runtime.cpp, including catalog authentication and SDK publication status.
- SDK open, path, size, mapping, hash and validation diagnostics in Sunrise/src/state/activity_sdk/activity_sdk_loader.cpp. Failed Win32 calls report their error before logging or cleanup can overwrite it.
- Reproduction and Proton-log collection instructions in docs/umu-sdk-startup-diagnostics.md.

Initialization order, validation, failure results and cleanup are preserved. No dependencies or game data are added. This supplies diagnostics; it does not claim to fix #100 or the separate white-screen/package-handle report. Logging may affect timing.

Validation:
- One commit, 4d2404de6d4cd41283b789c0465b549a0eb5f65c, on upstream a57dc9a9e74eb71e876baea79047c9af679b2347.
- Windows Release x64 build and artifact upload passed: https://github.com/lutralutraq77/Sunrise-work/actions/runs/33990738907
- Earlier local loader fault-injection checks passed for nine failures and success, covering statuses, cleanup and error capture. These used fake OS/hash/validation boundaries, not a real Windows/Wine environment.
- The reported UMU/Proton failure has not been reproduced. A failing Proton backtrace, diagnostic Sunrise log and exact runner versions are still needed.