### PR TITLE
Fix activity loading on Linux and add a Proton launcher.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Destiny 2 Offline Exploration Mod
 > Most gameplay features are not currently supported. (Missions, Enemies, NPCs, Quests, Persistent Saves, ...)
 
 - [Install Instructions](https://github.com/stanuwu/Sunrise/wiki/Installing)
+- [Experimental Linux/Proton Runtime](scripts/linux/README.md)
 - [FAQ](https://github.com/stanuwu/Sunrise/wiki/FAQ)
 - [Common Issues](https://github.com/stanuwu/Sunrise/wiki/Common-Issues)
 - [Discord](https://discord.gg/22JS6et5k9)

--- a/scripts/linux/README.md
+++ b/scripts/linux/README.md
@@ -1,0 +1,103 @@
+# Experimental Linux/Proton runtime
+
+Sunrise can run through Proton, but Linux runtime support is experimental. This guide assumes the
+required Destiny 2 depots and the Sunrise `steam_api64.dll` have already been installed according
+to the [manual installation guide](https://github.com/stanuwu/Sunrise/wiki/Installing).
+
+The launcher has been tested with native Steam, Proton Experimental and a Btrfs home directory.
+It does not download game data, install packages or modify a Steam-managed Destiny 2 installation.
+
+## Requirements
+
+- A 64-bit Linux system with working Vulkan drivers
+- A native Steam installation
+- Proton Experimental, Proton Hotfix or another compatible Proton build
+- Bash, `realpath`, `cksum` and `flock` (normally provided by coreutils and util-linux)
+- A separate directory containing the required historical game depots
+- The Sunrise DLL installed as `<game>/bin/x64/steam_api64.dll`
+
+Do not point the launcher at the current Steam-managed Destiny 2 installation. Sunrise requires the
+historical game build described by the project's installation guide.
+
+## Launching
+
+From the repository root, run:
+
+```bash
+./scripts/linux/sunrise-run --game-dir "$HOME/Games/ProjectSunrise"
+```
+
+The launcher discovers Steam and Proton, creates an isolated prefix under the user data directory,
+maps the game directory to Wine drive `D:`, and launches `D:\destiny2.exe`. Override discovery when
+needed:
+
+```bash
+./scripts/linux/sunrise-run \
+    --game-dir /path/to/ProjectSunrise \
+    --proton "/path/to/Proton - Experimental/proton" \
+    --steam-root /path/to/Steam \
+    --prefix /path/to/compatdata
+```
+
+Run `./scripts/linux/sunrise-run --help` for the corresponding environment variables and all
+options.
+
+### Why the dedicated Wine drive is required
+
+Proton normally translates a directly launched Linux path through Wine's `Z:` drive. A game stored
+at `/home/user/Games/ProjectSunrise` can therefore see its executable and writable Sunrise directory
+under `Z:\home\user\Games\ProjectSunrise`.
+
+Sunrise validates every ancestor of its transactional activity SDK output before publishing it. It
+allows Wine's synthetic drive root, but rejects an unexpected reparse point beneath that root so a
+link or mount cannot redirect the generated pack during publication. Wine can expose Linux mount
+points—including Btrfs subvolume mounts—as those intermediate reparse points. In that layout,
+Sunrise rejects the otherwise valid directory and logs output similar to:
+
+```text
+activity_sdk_generation stage=pack ... result=failed
+sdk_generation result=fail ... detail="invalid_input"
+```
+
+Without `activity_sdk.pack` and its catalog, activity mission seeds cannot be resolved. The game can
+reach orbit normally, but selecting a destination remains on the loading screen indefinitely.
+
+The launcher maps the game directory directly to `D:` before starting `D:\destiny2.exe`. The Linux
+mount is then represented by the permitted Wine drive root rather than an unexpected component
+beneath `Z:`. This preserves Sunrise's existing reparse-point protection; the launcher does not
+disable or bypass the validation. The issue depends on the Wine-visible filesystem ancestry and is
+not specific to Arch Linux.
+
+The launcher also prevents two copies using the same game directory from running simultaneously.
+Sunrise's embedded server uses fixed local ports, so an overlapping process would otherwise fail to
+bind and the game would report that it could not connect to the Destiny 2 servers.
+
+The first launch can spend several minutes generating `activity_sdk.pack`. If Sunrise reports a
+startup timeout, leave the game open until the Sunrise popup closes, exit normally, and launch it
+again.
+
+## Adding the launcher to Steam
+
+The script can be added as a non-Steam game:
+
+1. Select **Games > Add a Non-Steam Game to My Library**.
+2. Browse to `scripts/linux/sunrise-run` and add it.
+3. Set its launch options to `--game-dir "/path/to/ProjectSunrise"`.
+4. Do not force a Steam Play compatibility tool for the shortcut. The script invokes Proton itself.
+
+## Troubleshooting
+
+If Steam or Proton is not discovered, pass their paths explicitly with `--steam-root` and
+`--proton`. Steam installed in an unusual location may not be detected automatically.
+
+Steam Flatpak paths are detected on a best-effort basis but have not been tested. Flatpak Steam may
+also need filesystem permission for a game directory outside its sandbox.
+
+If the selected Wine drive is already in use, choose another letter:
+
+```bash
+./scripts/linux/sunrise-run --game-dir /path/to/ProjectSunrise --drive r
+```
+
+Use a new `--prefix` path to test with a clean compatibility prefix without deleting an existing
+one.

--- a/scripts/linux/sunrise-run
+++ b/scripts/linux/sunrise-run
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly app_id="1085660"
+
+usage() {
+    cat <<'EOF'
+Usage: sunrise-run --game-dir PATH [options]
+
+Launch Sunrise with Proton in an isolated compatibility prefix.
+
+Options:
+  --game-dir PATH   Directory containing destiny2.exe (required)
+  --proton PATH     Proton executable (auto-detected by default)
+  --steam-root PATH Steam installation root (auto-detected by default)
+  --prefix PATH     Compatibility data directory
+  --drive LETTER    Wine drive used for the game directory (default: d)
+  -h, --help        Show this help
+
+The same values can be supplied through SUNRISE_GAME_DIR, SUNRISE_PROTON,
+SUNRISE_STEAM_ROOT, SUNRISE_PREFIX and SUNRISE_DRIVE.
+EOF
+}
+
+fail() {
+    printf 'sunrise-run: %s\n' "$*" >&2
+    exit 1
+}
+
+game_dir="${SUNRISE_GAME_DIR:-}"
+proton="${SUNRISE_PROTON:-}"
+steam_root="${SUNRISE_STEAM_ROOT:-}"
+prefix="${SUNRISE_PREFIX:-${XDG_DATA_HOME:-$HOME/.local/share}/Sunrise/compatdata}"
+drive="${SUNRISE_DRIVE:-d}"
+
+while (($# > 0)); do
+    case "$1" in
+    --game-dir | --proton | --steam-root | --prefix | --drive)
+        (($# >= 2)) || fail "$1 requires a value"
+        case "$1" in
+        --game-dir) game_dir="$2" ;;
+        --proton) proton="$2" ;;
+        --steam-root) steam_root="$2" ;;
+        --prefix) prefix="$2" ;;
+        --drive) drive="$2" ;;
+        esac
+        shift 2
+        ;;
+    -h | --help)
+        usage
+        exit 0
+        ;;
+    *)
+        fail "unknown option: $1"
+        ;;
+    esac
+done
+
+[[ -n "$game_dir" ]] || fail "--game-dir is required"
+[[ "$drive" =~ ^[d-yD-Y]$ ]] || fail "--drive must be one letter from d through y"
+drive="${drive,,}"
+[[ "$drive" != "s" && "$drive" != "t" ]] \
+    || fail "Wine drives s: and t: are reserved by Proton"
+
+game_dir="$(realpath -e "$game_dir")" || fail "game directory does not exist"
+[[ -d "$game_dir" ]] || fail "game directory is not a directory: $game_dir"
+[[ -f "$game_dir/destiny2.exe" ]] || fail "destiny2.exe was not found in $game_dir"
+[[ -f "$game_dir/bin/x64/steam_api64.dll" ]] \
+    || fail "steam_api64.dll was not found; install the Sunrise DLL first"
+command -v flock >/dev/null 2>&1 || fail "flock is required (usually provided by util-linux)"
+
+runtime_directory="${XDG_RUNTIME_DIR:-/tmp}"
+lock_directory="$runtime_directory/sunrise-run-$UID"
+if ! mkdir -p -m 700 "$lock_directory" 2>/dev/null; then
+    lock_directory="/tmp/sunrise-run-$UID"
+    mkdir -p -m 700 "$lock_directory"
+fi
+[[ "$(stat -c %u "$lock_directory")" == "$UID" ]] \
+    || fail "launcher lock directory is owned by another user: $lock_directory"
+chmod 700 "$lock_directory"
+lock_key="$(printf '%s' "$game_dir" | cksum)"
+lock_key="${lock_key%% *}"
+exec 9>"$lock_directory/$lock_key.lock"
+flock -n 9 || fail "another Sunrise instance is already running for $game_dir"
+
+if [[ -z "$steam_root" ]]; then
+    steam_candidates=(
+        "$HOME/.local/share/Steam"
+        "$HOME/.steam/root"
+        "$HOME/.steam/steam"
+        "$HOME/.var/app/com.valvesoftware.Steam/.local/share/Steam"
+    )
+    for candidate in "${steam_candidates[@]}"; do
+        if [[ -d "$candidate/steamapps" ]]; then
+            steam_root="$(realpath -e "$candidate")"
+            break
+        fi
+    done
+else
+    steam_root="$(realpath -e "$steam_root")" || fail "Steam root does not exist"
+fi
+[[ -n "$steam_root" ]] || fail "Steam was not found; specify --steam-root"
+
+if [[ -z "$proton" ]]; then
+    proton_candidates=(
+        "$steam_root/steamapps/common/Proton - Experimental/proton"
+        "$steam_root/steamapps/common/Proton Hotfix/proton"
+        "$steam_root/steamapps/common"/Proton*/proton
+        "$steam_root/compatibilitytools.d"/*/proton
+    )
+    for candidate in "${proton_candidates[@]}"; do
+        if [[ -x "$candidate" ]]; then
+            proton="$candidate"
+            break
+        fi
+    done
+else
+    proton="$(realpath -e "$proton")" || fail "Proton executable does not exist"
+fi
+[[ -x "$proton" ]] || fail "Proton was not found; specify --proton"
+
+mkdir -p "$prefix/pfx/dosdevices"
+prefix="$(realpath -e "$prefix")"
+
+export STEAM_COMPAT_CLIENT_INSTALL_PATH="$steam_root"
+export STEAM_COMPAT_DATA_PATH="$prefix"
+export SteamAppId="$app_id"
+export SteamGameId="$app_id"
+
+drive_link="$prefix/pfx/dosdevices/$drive:"
+if [[ -L "$drive_link" ]]; then
+    mapped_directory="$(realpath -e "$drive_link")" \
+        || fail "Wine drive $drive: has a broken mapping"
+    [[ "$mapped_directory" == "$game_dir" ]] \
+        || fail "Wine drive $drive: is already mapped to $mapped_directory"
+elif [[ -e "$drive_link" ]]; then
+    fail "Wine drive $drive: exists but is not a symbolic link"
+else
+    ln -s "$game_dir" "$drive_link"
+fi
+
+printf 'Launching Sunrise from %s:\\destiny2.exe\n' "${drive^^}"
+cd "$game_dir"
+exec "$proton" run "${drive^^}:\\destiny2.exe"


### PR DESCRIPTION
This fixes infinite activity loading on affected Linux filesystems and adds a one-command Proton launcher, making Sunrise straightforward to run on Linux.